### PR TITLE
feat(geoip): add DB-IP Lite as zero-config default GeoIP backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,11 @@ FAUCET_RATE_LIMIT_PER_IP_PER_DAY=5
 # FAUCET_HASHCASH_DIFFICULTY=20
 # FAUCET_HASHCASH_TTL_MS=300000
 
-# --- Geo-IP / ASN / VPN / datacenter filtering (optional) ---
-# Backend: "none" (default, off), "maxmind" (offline .mmdb), or "ipinfo" (API).
-# FAUCET_GEOIP_BACKEND=maxmind
+# --- Geo-IP / ASN / VPN / datacenter filtering ---
+# Backend: "dbip" (default, built-in DB-IP Lite — no config needed),
+#          "maxmind" (offline .mmdb — needs license key),
+#          "ipinfo" (API — needs token), or "none" (off).
+# FAUCET_GEOIP_BACKEND=dbip
 # FAUCET_GEOIP_MAXMIND_COUNTRY_DB=/data/geoip/GeoLite2-Country.mmdb
 # FAUCET_GEOIP_MAXMIND_ASN_DB=/data/geoip/GeoLite2-ASN.mmdb
 # FAUCET_GEOIP_IPINFO_TOKEN=...

--- a/apps/server/src/abuse/pipeline.ts
+++ b/apps/server/src/abuse/pipeline.ts
@@ -2,6 +2,7 @@ import { AbusePipeline, type AbuseCheck, type CurrencyDriver } from '@faucet/cor
 import { hashcashCheck } from '@faucet/abuse-hashcash';
 import { hcaptchaCheck } from '@faucet/abuse-hcaptcha';
 import {
+  DbipResolver,
   IpinfoResolver,
   MaxMindResolver,
   geoipCheck,
@@ -99,6 +100,9 @@ export function buildPipeline(
 }
 
 function buildGeoipResolver(config: ServerConfig): GeoIpResolver | undefined {
+  if (config.geoipBackend === 'dbip') {
+    return new DbipResolver();
+  }
   if (config.geoipBackend === 'maxmind') {
     if (!config.geoipMaxmindCountryDb) {
       throw new Error('FAUCET_GEOIP_BACKEND=maxmind requires FAUCET_GEOIP_MAXMIND_COUNTRY_DB');

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -32,7 +32,7 @@ export const ServerConfigSchema = z.object({
   hashcashDifficulty: z.coerce.number().int().min(8).max(30).default(20),
   hashcashTtlMs: z.coerce.number().int().min(10_000).default(5 * 60_000),
 
-  geoipBackend: z.enum(['none', 'maxmind', 'ipinfo']).default('none'),
+  geoipBackend: z.enum(['none', 'dbip', 'maxmind', 'ipinfo']).default('dbip'),
   geoipMaxmindCountryDb: z.string().optional(),
   geoipMaxmindAsnDb: z.string().optional(),
   geoipIpinfoToken: z.string().optional(),

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -53,6 +53,9 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     hashcash: ctx.config.hashcashSecret
       ? { difficulty: ctx.config.hashcashDifficulty, ttlMs: ctx.config.hashcashTtlMs }
       : null,
+    geoipAttribution: ctx.config.geoipBackend === 'dbip'
+      ? 'IP geolocation by DB-IP (https://db-ip.com)'
+      : undefined,
   }));
 
   app.post('/v1/challenge', {

--- a/packages/abuse-geoip/package.json
+++ b/packages/abuse-geoip/package.json
@@ -13,7 +13,10 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "llms.txt"],
+  "files": [
+    "dist",
+    "llms.txt"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -21,6 +24,8 @@
   },
   "dependencies": {
     "@faucet/core": "workspace:*",
+    "@ip-location-db/dbip-asn-mmdb": "^2.3.2026040119",
+    "@ip-location-db/dbip-country-mmdb": "^2.3.2026040119",
     "maxmind": "^4.3.22",
     "undici": "^6.19.8"
   },

--- a/packages/abuse-geoip/src/dbip.ts
+++ b/packages/abuse-geoip/src/dbip.ts
@@ -1,0 +1,69 @@
+import { open as openMmdb } from 'maxmind';
+import { createRequire } from 'node:module';
+import type { GeoIpResolver, GeoIpResult } from './types.js';
+
+/** DB-IP Lite country MMDB record shape. */
+interface DbipCountryRecord {
+  country_code?: string;
+}
+
+/** DB-IP Lite ASN MMDB record shape. */
+interface DbipAsnRecord {
+  autonomous_system_number?: number;
+  autonomous_system_organization?: string;
+}
+
+// The maxmind package constrains Reader<T> to its own Response union.
+// DB-IP Lite uses a different record schema, so we use `any` for the
+// type parameter and cast to our known interfaces at read time.
+// The actual record shapes are verified against real DB-IP MMDB files.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyReader = Awaited<ReturnType<typeof openMmdb<any>>>;
+
+/**
+ * GeoIP resolver backed by DB-IP Lite MMDB databases bundled via
+ * `@ip-location-db/dbip-country-mmdb` and `@ip-location-db/dbip-asn-mmdb`.
+ *
+ * Works out of the box — no license key, no download step, no configuration.
+ * Data is CC BY 4.0 (https://db-ip.com/db/lite.php).
+ */
+export class DbipResolver implements GeoIpResolver {
+  readonly id = 'dbip';
+  #countryReader: AnyReader | null = null;
+  #asnReader: AnyReader | null = null;
+  #ready: Promise<void>;
+
+  constructor() {
+    this.#ready = this.#load();
+  }
+
+  async #load(): Promise<void> {
+    const require = createRequire(import.meta.url);
+    const countryDbPath = require.resolve(
+      '@ip-location-db/dbip-country-mmdb/dbip-country.mmdb',
+    );
+    const asnDbPath = require.resolve(
+      '@ip-location-db/dbip-asn-mmdb/dbip-asn.mmdb',
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.#countryReader = await openMmdb<any>(countryDbPath, {
+      cache: { max: 6000 },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.#asnReader = await openMmdb<any>(asnDbPath, {
+      cache: { max: 6000 },
+    });
+  }
+
+  async lookup(ip: string): Promise<GeoIpResult> {
+    await this.#ready;
+    const country = this.#countryReader?.get(ip) as DbipCountryRecord | null;
+    const asn = this.#asnReader?.get(ip) as DbipAsnRecord | null;
+    const iso = country?.country_code ?? null;
+    return {
+      country: iso ? iso.toUpperCase() : null,
+      asn: asn?.autonomous_system_number ?? null,
+      asnOrg: asn?.autonomous_system_organization ?? null,
+    };
+  }
+}

--- a/packages/abuse-geoip/src/index.ts
+++ b/packages/abuse-geoip/src/index.ts
@@ -3,3 +3,4 @@ export * from './hosting.js';
 export * from './check.js';
 export { MaxMindResolver, type MaxMindResolverOptions } from './maxmind.js';
 export { IpinfoResolver, type IpinfoResolverOptions } from './ipinfo.js';
+export { DbipResolver } from './dbip.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,12 @@ importers:
       '@faucet/core':
         specifier: workspace:*
         version: link:../core
+      '@ip-location-db/dbip-asn-mmdb':
+        specifier: ^2.3.2026040119
+        version: 2.3.2026040119
+      '@ip-location-db/dbip-country-mmdb':
+        specifier: ^2.3.2026040119
+        version: 2.3.2026040119
       maxmind:
         specifier: ^4.3.22
         version: 4.3.29
@@ -1460,6 +1466,12 @@ packages:
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
+  '@ip-location-db/dbip-asn-mmdb@2.3.2026040119':
+    resolution: {integrity: sha512-9tN2pPfu19S3TrYB5Wkxy3BwTR2Kw7xkhEJC5NL0hEPo2qJ93DKzDXmbW/MyN4lUyrAZUsd60DsLH3YZlCnyuQ==}
+
+  '@ip-location-db/dbip-country-mmdb@2.3.2026040119':
+    resolution: {integrity: sha512-PdE2l2ZNbPQbFzlWScHfmk8jQ/sDFDIxwOyeLzykyAktHJwBI6jfy+IuMolIcL0puNE1FyLCJaP0B8Y9+DWJLQ==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -5356,6 +5368,10 @@ snapshots:
       '@types/node': 22.19.17
 
   '@ioredis/commands@1.5.1': {}
+
+  '@ip-location-db/dbip-asn-mmdb@2.3.2026040119': {}
+
+  '@ip-location-db/dbip-country-mmdb@2.3.2026040119': {}
 
   '@isaacs/cliui@9.0.0': {}
 


### PR DESCRIPTION
## Summary

Adds DB-IP Lite as a third GeoIP backend and makes it the **default**, so country + ASN lookup works out of the box with zero configuration. MaxMind and IPinfo remain as opt-in alternatives.

- New `DbipResolver` class at `packages/abuse-geoip/src/dbip.ts`
- Bundled via `@ip-location-db/dbip-country-mmdb` + `@ip-location-db/dbip-asn-mmdb` (CC BY 4.0)
- Uses the existing `maxmind` npm reader (same MMDB format, no new deps for reading)
- Default `FAUCET_GEOIP_BACKEND` changed from `none` to `dbip`
- `/v1/config` includes `geoipAttribution` field when DB-IP is active (CC BY 4.0 requirement)
- ~12MB added to Docker image (two MMDB files)

## Why

GeoIP was advertised as a built-in abuse layer but was off by default because every backend (MaxMind, IPinfo) required external credentials. With DB-IP Lite, operators get country + ASN lookup on first boot without any signup, download, or env configuration.

## Verified

- `pnpm build` — passes (22/22 tasks)
- `pnpm test` — 139/139 tests pass (geoip: 9/9, server: 57/57)
- DB-IP lookups: `8.8.8.8 → US/AS15169 Google LLC`, `1.1.1.1 → AU/AS13335 Cloudflare`
- Private IPs (`172.19.0.1`) correctly skipped with `"skipped": "private-ip"`
- Stack tested end-to-end: `/v1/config` shows `geoip: true` + attribution with zero env vars

## Test plan

- [ ] `pnpm build && pnpm test` passes
- [ ] Start faucet without `FAUCET_GEOIP_BACKEND` → `GET /v1/config` shows `"geoip": true`
- [ ] Submit claim → explain signals contain `geoip` layer with country + ASN
- [ ] Set `FAUCET_GEOIP_BACKEND=none` → `GET /v1/config` shows `"geoip": false`
- [ ] Set `FAUCET_GEOIP_BACKEND=maxmind` + MMDB paths → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)