### PR TITLE
chore: runtime core quality audit simplification tranche

### DIFF
--- a/apps/claim-ui/package.json
+++ b/apps/claim-ui/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@faucet/core": "workspace:*",
     "@nimiq-faucet/sdk": "workspace:*",
     "vue": "^3.5.10"
   },

--- a/apps/claim-ui/src/lib/validate.ts
+++ b/apps/claim-ui/src/lib/validate.ts
@@ -1,12 +1,12 @@
-// Mirrors the regex in packages/driver-nimiq-rpc/src/index.ts (parseAddress).
-const NIMIQ_ADDRESS_RE = /^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/;
+import {
+  isValidNimiqAddress as isValidNimiqAddressCore,
+  normalizeNimiqAddress as normalizeNimiqAddressCore,
+} from '@faucet/core';
 
 export function isValidNimiqAddress(input: string): boolean {
-  if (!input) return false;
-  const normalized = input.trim().toUpperCase().replace(/\s+/g, ' ');
-  return NIMIQ_ADDRESS_RE.test(normalized);
+  return isValidNimiqAddressCore(input);
 }
 
 export function normalizeNimiqAddress(input: string): string {
-  return input.trim().toUpperCase().replace(/\s+/g, ' ');
+  return normalizeNimiqAddressCore(input);
 }

--- a/apps/server/src/openapi/document.ts
+++ b/apps/server/src/openapi/document.ts
@@ -257,6 +257,20 @@ function registerRoutes(): void {
   });
 
   registry.registerPath({
+    method: 'post',
+    path: '/admin/account/rotate-key',
+    tags: ['Admin'],
+    summary: 'Rotate encrypted at-rest key material (requires TOTP step-up)',
+    security: [{ adminSession: [] }],
+    responses: {
+      200: {
+        description: 'Rotation timestamp',
+        content: jsonContent(z.object({ rotatedAt: z.string() })),
+      },
+    },
+  });
+
+  registry.registerPath({
     method: 'get',
     path: '/admin/audit-log',
     tags: ['Admin'],
@@ -276,6 +290,41 @@ function registerRoutes(): void {
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: 'Claim with expanded signals' },
+      404: { description: 'Claim not found', content: jsonContent(ErrorResponse) },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/admin/claims/{id}/allow',
+    tags: ['Admin'],
+    summary: 'Override a claim to allow (manual admin action)',
+    security: [{ adminSession: [] }],
+    request: { params: z.object({ id: z.string() }) },
+    responses: {
+      200: { description: 'Updated', content: jsonContent(OkResponse) },
+      404: { description: 'Claim not found', content: jsonContent(ErrorResponse) },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/admin/claims/{id}/deny',
+    tags: ['Admin'],
+    summary: 'Override a claim to deny (manual admin action)',
+    security: [{ adminSession: [] }],
+    request: {
+      params: z.object({ id: z.string() }),
+      body: {
+        content: jsonContent(
+          z.object({
+            reason: z.string().max(256).optional(),
+          }),
+        ),
+      },
+    },
+    responses: {
+      200: { description: 'Updated', content: jsonContent(OkResponse) },
       404: { description: 'Claim not found', content: jsonContent(ErrorResponse) },
     },
   });

--- a/apps/server/test/admin-auth.e2e.test.ts
+++ b/apps/server/test/admin-auth.e2e.test.ts
@@ -3,35 +3,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { authenticator } from '@otplib/preset-default';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 
-class FakeDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) throw new Error(`bad address: ${s}`);
-    return n;
-  }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 10_000_000n; }
-  async send() { return 'tx_x'; }
-  async waitForConfirmation() {}
-}
-
-function parseCookie(setCookie: string | string[] | undefined, name: string): string | null {
-  if (!setCookie) return null;
-  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
-  for (const line of arr) {
-    const m = line.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
-    if (m) return decodeURIComponent(m[1]!);
-  }
-  return null;
+class FakeDriver extends BaseTestDriver {
+  override async getBalance() { return 10_000_000n; }
+  override async send() { return 'tx_x'; }
 }
 
 describe('admin auth', () => {

--- a/apps/server/test/admin-claims.e2e.test.ts
+++ b/apps/server/test/admin-claims.e2e.test.ts
@@ -2,40 +2,20 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class FakeDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class FakeDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) throw new Error(`bad address: ${s}`);
-    return n;
-  }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 10_000_000n; }
-  async send(to: string, amount: bigint) {
+  override async getBalance() { return 10_000_000n; }
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
-}
-
-function parseCookie(setCookie: string | string[] | undefined, name: string): string | null {
-  if (!setCookie) return null;
-  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
-  for (const line of arr) {
-    const m = line.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
-    if (m) return decodeURIComponent(m[1]!);
-  }
-  return null;
 }
 
 let sharedAuth: { session: string; csrf: string } | undefined;

--- a/apps/server/test/admin-integrators.e2e.test.ts
+++ b/apps/server/test/admin-integrators.e2e.test.ts
@@ -3,40 +3,20 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class FakeDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class FakeDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) throw new Error(`bad address: ${s}`);
-    return n;
-  }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 10_000_000n; }
-  async send(to: string, amount: bigint) {
+  override async getBalance() { return 10_000_000n; }
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
-}
-
-function parseCookie(setCookie: string | string[] | undefined, name: string): string | null {
-  if (!setCookie) return null;
-  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
-  for (const line of arr) {
-    const m = line.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
-    if (m) return decodeURIComponent(m[1]!);
-  }
-  return null;
 }
 
 function signHmac(secret: string, parts: string[]): string {

--- a/apps/server/test/claim.e2e.test.ts
+++ b/apps/server/test/claim.e2e.test.ts
@@ -2,39 +2,26 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class FakeNimiqDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class FakeNimiqDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
   public balance = 10_000_000n;
 
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) {
-      throw new Error(`bad address: ${s}`);
-    }
-    return n;
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return this.balance;
   }
-  async send(to: string, amount: bigint): Promise<string> {
+  override async send(to: string, amount: bigint): Promise<string> {
     this.sends.push({ to, amount });
     this.balance -= amount;
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation(): Promise<void> {
+  override async waitForConfirmation(): Promise<void> {
     // confirmed instantly
   }
 }

--- a/apps/server/test/fingerprint.e2e.test.ts
+++ b/apps/server/test/fingerprint.e2e.test.ts
@@ -2,32 +2,22 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class StubDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
-  async init() {}
-  parseAddress(s: string) {
-    return s.trim().toUpperCase().replace(/\s+/g, ' ');
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return 0n;
   }
-  async send(to: string, amount: bigint) {
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
 }
 
 describe('fingerprint abuse layer', () => {

--- a/apps/server/test/geoip.e2e.test.ts
+++ b/apps/server/test/geoip.e2e.test.ts
@@ -3,32 +3,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { GeoIpResolver, GeoIpResult } from '@faucet/abuse-geoip';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 4444 4444 4444 4444 4444 4444 4444 4444';
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class StubDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
-  async init() {}
-  parseAddress(s: string) {
-    return s.trim().toUpperCase().replace(/\s+/g, ' ');
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return 0n;
   }
-  async send(to: string, amount: bigint) {
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
 }
 
 class ScriptedResolver implements GeoIpResolver {

--- a/apps/server/test/hardening.e2e.test.ts
+++ b/apps/server/test/hardening.e2e.test.ts
@@ -2,27 +2,14 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
-  async init() {}
-  parseAddress(s: string) {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) throw new Error(`bad: ${s}`);
-    return n;
-  }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 0n; }
-  async send() { return 'tx_1'; }
-  async waitForConfirmation() {}
-}
+class StubDriver extends BaseTestDriver {}
 
 function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
   return ServerConfigSchema.parse({

--- a/apps/server/test/hashcash.e2e.test.ts
+++ b/apps/server/test/hashcash.e2e.test.ts
@@ -3,32 +3,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { solveChallenge } from '@faucet/abuse-hashcash';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class StubDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
-  async init() {}
-  parseAddress(s: string) {
-    return s.trim().toUpperCase().replace(/\s+/g, ' ');
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return 0n;
   }
-  async send(to: string, amount: bigint) {
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
 }
 
 describe('hashcash challenge flow', () => {

--- a/apps/server/test/helpers/testDriver.ts
+++ b/apps/server/test/helpers/testDriver.ts
@@ -1,0 +1,52 @@
+import {
+  isValidNimiqAddress,
+  normalizeNimiqAddress,
+  type Address,
+  type CurrencyDriver,
+  type TxId,
+} from '@faucet/core';
+
+export const TEST_FAUCET_ADDRESS = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+
+export function parseNimiqAddressForTest(input: string, errorPrefix = 'bad address'): Address {
+  const normalized = normalizeNimiqAddress(input);
+  if (!isValidNimiqAddress(normalized)) {
+    throw new Error(`${errorPrefix}: ${input}`);
+  }
+  return normalized as Address;
+}
+
+export class BaseTestDriver implements CurrencyDriver {
+  readonly id = 'nimiq';
+  readonly networks = ['test'] as const;
+
+  async init(): Promise<void> {}
+
+  parseAddress(input: string): Address {
+    return parseNimiqAddressForTest(input);
+  }
+
+  async getFaucetAddress(): Promise<Address> {
+    return TEST_FAUCET_ADDRESS as Address;
+  }
+
+  async getBalance(): Promise<bigint> {
+    return 0n;
+  }
+
+  async send(_to: Address, _amount: bigint): Promise<TxId> {
+    return 'tx_1' as TxId;
+  }
+
+  async waitForConfirmation(): Promise<void> {}
+}
+
+export function parseCookie(setCookie: string | string[] | undefined, name: string): string | null {
+  if (!setCookie) return null;
+  const arr = Array.isArray(setCookie) ? setCookie : [setCookie];
+  for (const line of arr) {
+    const m = line.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+    if (m) return decodeURIComponent(m[1]!);
+  }
+  return null;
+}

--- a/apps/server/test/mcp.e2e.test.ts
+++ b/apps/server/test/mcp.e2e.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
 import {
@@ -12,36 +11,24 @@ import {
   buildMcpServer,
   requireAdminToken,
 } from '../src/mcp/server.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const ADMIN_TOKEN = 'test-token-hex';
 
-class FakeNimiqDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class FakeNimiqDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
   public balance = 10_000_000n;
 
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) {
-      throw new Error(`bad address: ${s}`);
-    }
-    return n;
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return this.balance;
   }
-  async send(to: string, amount: bigint): Promise<string> {
+  override async send(to: string, amount: bigint): Promise<string> {
     this.sends.push({ to, amount });
     this.balance -= amount;
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation(): Promise<void> {}
+  override async waitForConfirmation(): Promise<void> {}
 }
 
 describe('MCP (/mcp)', () => {

--- a/apps/server/test/metrics.e2e.test.ts
+++ b/apps/server/test/metrics.e2e.test.ts
@@ -2,23 +2,14 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
-  async init() {}
-  parseAddress(s: string) {
-    return s.trim().toUpperCase().replace(/\s+/g, ' ');
-  }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 42_000n; }
-  async send() { return 'tx_1'; }
-  async waitForConfirmation() {}
+class StubDriver extends BaseTestDriver {
+  override async getBalance() { return 42_000n; }
 }
 
 function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {

--- a/apps/server/test/onchain.e2e.test.ts
+++ b/apps/server/test/onchain.e2e.test.ts
@@ -2,35 +2,26 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver, HistorySummary } from '@faucet/core';
+import type { HistorySummary } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 const SWEEPER_ADDR = 'NQ00 5555 5555 5555 5555 5555 5555 5555 5555';
 const FRESH_ADDR = 'NQ00 6666 6666 6666 6666 6666 6666 6666 6666';
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class StubDriver extends BaseTestDriver {
   public sends: Array<{ to: string; amount: bigint }> = [];
   public historyFor = new Map<string, HistorySummary>();
-  async init() {}
-  parseAddress(s: string) {
-    return s.trim().toUpperCase().replace(/\s+/g, ' ');
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return 0n;
   }
-  async send(to: string, amount: bigint) {
+  override async send(to: string, amount: bigint) {
     this.sends.push({ to, amount });
     return `tx_${this.sends.length}`;
   }
-  async waitForConfirmation() {}
-  async addressHistory(address: string): Promise<HistorySummary> {
+  override async addressHistory(address: string): Promise<HistorySummary> {
     const hit = this.historyFor.get(address);
     if (hit) return hit;
     return {

--- a/apps/server/test/openapi-parity.test.ts
+++ b/apps/server/test/openapi-parity.test.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROUTES_DIR = join(HERE, '../src/routes');
+const MCP_ROUTE_FILE = join(HERE, '../src/mcp/index.ts');
+const OPENAPI_DOCUMENT_FILE = join(HERE, '../src/openapi/document.ts');
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectTsFiles(full));
+      continue;
+    }
+    if (full.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, '{$1}');
+}
+
+function collectRuntimePaths(): Set<string> {
+  const paths = new Set<string>();
+  const files = [...collectTsFiles(ROUTES_DIR), MCP_ROUTE_FILE];
+  const routeRegex = /app\.(?:get|post|patch|delete)\(\s*['"]([^'"]+)['"]/g;
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    let match: RegExpExecArray | null;
+    while (true) {
+      match = routeRegex.exec(source);
+      if (!match) break;
+      paths.add(normalizePath(match[1] ?? ''));
+    }
+  }
+  return paths;
+}
+
+function collectOpenapiPaths(): Set<string> {
+  const source = readFileSync(OPENAPI_DOCUMENT_FILE, 'utf8');
+  const paths = new Set<string>();
+  const pathRegex = /path:\s*['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while (true) {
+    match = pathRegex.exec(source);
+    if (!match) break;
+    paths.add(match[1] ?? '');
+  }
+  return paths;
+}
+
+describe('OpenAPI path parity', () => {
+  it('keeps documented paths in sync with runtime route registrations', () => {
+    const runtime = collectRuntimePaths();
+    const openapi = collectOpenapiPaths();
+
+    const missingInOpenapi = [...runtime].filter((p) => !openapi.has(p)).sort();
+    const extraInOpenapi = [...openapi].filter((p) => !runtime.has(p)).sort();
+
+    expect(missingInOpenapi).toEqual([]);
+    expect(extraInOpenapi).toEqual([]);
+  });
+});

--- a/apps/server/test/openapi.e2e.test.ts
+++ b/apps/server/test/openapi.e2e.test.ts
@@ -2,30 +2,13 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 
-class StubDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
-  async init(): Promise<void> {}
-  parseAddress(s: string): string {
-    return s;
-  }
-  async getFaucetAddress(): Promise<string> {
-    return FAUCET_ADDR;
-  }
-  async getBalance(): Promise<bigint> {
-    return 0n;
-  }
-  async send(): Promise<string> {
-    return 'tx_0';
-  }
-  async waitForConfirmation(): Promise<void> {}
-}
+class StubDriver extends BaseTestDriver {}
 
 function makeConfig(tmp: string, overrides: Record<string, unknown> = {}) {
   return ServerConfigSchema.parse({

--- a/apps/server/test/readiness.e2e.test.ts
+++ b/apps/server/test/readiness.e2e.test.ts
@@ -2,20 +2,19 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { CurrencyDriver } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 
-class NeverReadyDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class NeverReadyDriver extends BaseTestDriver {
   readonly readyPromise: Promise<void>;
   #ready = false;
   #release!: () => void;
 
   constructor() {
+    super();
     this.readyPromise = new Promise<void>((resolve) => {
       this.#release = () => {
         this.#ready = true;
@@ -32,21 +31,12 @@ class NeverReadyDriver implements CurrencyDriver {
   isReady() {
     return this.#ready;
   }
-  parseAddress(s: string) {
-    const n = s.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(n)) throw new Error(`bad: ${s}`);
-    return n;
-  }
-  async getFaucetAddress() {
-    return FAUCET_ADDR;
-  }
-  async getBalance() {
+  override async getBalance() {
     return 0n;
   }
-  async send() {
-    return 'tx_ready' as never;
+  override async send() {
+    return 'tx_ready';
   }
-  async waitForConfirmation() {}
 }
 
 function baseConfig(dir: string) {

--- a/apps/server/test/reconcile.test.ts
+++ b/apps/server/test/reconcile.test.ts
@@ -3,24 +3,20 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { DriverError, type CurrencyDriver } from '@faucet/core';
+import { DriverError } from '@faucet/core';
 import { buildApp } from '../src/app.js';
 import { ServerConfigSchema } from '../src/config.js';
 import { claims } from '../src/db/schema.js';
 import { sweep } from '../src/reconcile.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
-const FAUCET_ADDR = 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
 
-class MockDriver implements CurrencyDriver {
-  readonly id = 'nimiq';
-  readonly networks = ['test'] as const;
+class MockDriver extends BaseTestDriver {
   confirmBehaviour: 'ok' | 'timeout' | 'rejected' = 'ok';
-  async init() {}
-  parseAddress(s: string) { return s.trim().toUpperCase().replace(/\s+/g, ' '); }
-  async getFaucetAddress() { return FAUCET_ADDR; }
-  async getBalance() { return 0n; }
-  async send() { return 'tx_1'; }
-  async waitForConfirmation() {
+  override async getBalance() { return 0n; }
+  override async send() { return 'tx_1'; }
+  override async waitForConfirmation() {
     if (this.confirmBehaviour === 'ok') return;
     if (this.confirmBehaviour === 'rejected') {
       throw new DriverError('tx invalidated', 'TX_REJECTED');

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ the [root README](../README.md).
 - [qa-testing.md](./qa-testing.md) — 12-phase hands-on walkthrough of every feature (AI-assisted)
 - [release-playbook.md](./release-playbook.md) — tag → publish flow, NPM_TOKEN provisioning, rc dry-runs
 - [release-polish-plan.md](./release-polish-plan.md) — historical pre-1.0 polish plan (reference)
+- [quality/runtime-core-quality-audit-2026-04.md](./quality/runtime-core-quality-audit-2026-04.md) — runtime core quality audit ledger (PRs, issues, recommendations)
 - [../CONTRIBUTING.md](../CONTRIBUTING.md) — dev setup, repository layout, code style
 - [../ROADMAP.md](../ROADMAP.md) — post-1.0 plans + ongoing quality programs
 

--- a/docs/quality/payloads/issue-config-mapping-dedupe.md
+++ b/docs/quality/payloads/issue-config-mapping-dedupe.md
@@ -1,0 +1,31 @@
+## Summary
+Runtime config shape and key mappings are duplicated across server config loading, admin APIs, OpenAPI schema declarations, and dashboard form models.
+
+## Evidence
+- `apps/server/src/config.ts` contains core config schema + `ENV_KEYS` mapping.
+- `apps/server/src/routes/admin/config.ts` re-declares patch payload shape and builds a separate `base` response mapping.
+- `apps/server/src/openapi/schemas.ts` re-declares `AdminConfigPatch` and `AdminConfigResponse`.
+- `apps/dashboard/src/views/ConfigView.vue` duplicates config response and patch types.
+
+## Why this matters
+- Key-name and constraint drift is likely as settings evolve.
+- Operator UX and API docs can silently diverge from runtime behavior.
+- Adding/changing config keys currently requires touching many files.
+
+## Proposed direction
+Create a central config catalog that defines:
+- logical key name
+- type/validation constraints
+- env var name
+- serialization/parsing strategy for persisted overrides
+- admin API exposure metadata (read-only, restart-required, hot-reload)
+
+Then derive admin route schemas, OpenAPI DTOs, and dashboard TS types from that catalog.
+
+## Acceptance criteria
+- Config key metadata is centralized and reused.
+- Admin patch/get and OpenAPI config schema are generated from shared metadata.
+- Dashboard config types are imported/generated from shared API schema, not handwritten duplicates.
+
+## Duplicate check
+No overlap with open security issues `#52`, `#53`, `#54`, `#55`.

--- a/docs/quality/payloads/issue-db-schema-dedup.md
+++ b/docs/quality/payloads/issue-db-schema-dedup.md
@@ -1,0 +1,28 @@
+## Summary
+SQLite and Postgres Drizzle schemas are maintained as two mostly duplicated files.
+
+## Evidence
+- `apps/server/src/db/schema.sqlite.ts` and `apps/server/src/db/schema.pg.ts` define the same tables/columns by hand.
+- New columns or constraints require two synchronized edits and two review surfaces.
+- Changelog/documentation already calls out mirrored schema maintenance burden.
+
+## Why this matters
+- High drift risk when evolving data model.
+- Review overhead and test surface increase for every schema change.
+- Duplicate schema definitions obscure intent and make future backend additions harder.
+
+## Proposed direction
+Introduce a shared table/column descriptor layer and dialect adapters to emit SQLite/PG Drizzle definitions from one model.
+
+Possible incremental path:
+1. Define canonical entity descriptors (`claims`, `blocklist`, etc.).
+2. Provide adapter helpers to materialize sqliteTable/pgTable definitions.
+3. Migrate one or two tables first as a proof of pattern, then roll out.
+
+## Acceptance criteria
+- Reduced duplicated schema declarations between sqlite and pg files.
+- New column additions can be made once with dialect-specific details isolated.
+- Existing migrations and runtime behavior remain unchanged.
+
+## Duplicate check
+No overlap with open security issues `#52`, `#53`, `#54`, `#55`.

--- a/docs/quality/payloads/issue-schema-single-source.md
+++ b/docs/quality/payloads/issue-schema-single-source.md
@@ -1,0 +1,29 @@
+## Summary
+OpenAPI request/response schemas and runtime route validators currently drift because we maintain parallel Zod shapes in multiple places.
+
+## Evidence
+- `apps/server/src/openapi/schemas.ts` defines route-facing DTOs (for OpenAPI generation).
+- Route handlers still define their own schemas in place (example: `apps/server/src/routes/admin/config.ts` defines `PatchBody` independently).
+- The new parity guard (`apps/server/test/openapi-parity.test.ts`) checks path coverage only; it does not protect request/response schema parity.
+
+## Why this matters
+- Same contract is implemented twice, so behavior can diverge without compile-time protection.
+- Documentation can be technically "present" but semantically wrong.
+- Every route update costs extra maintenance and review time.
+
+## Proposed direction
+Create one server-side contract source of truth and consume it from both runtime routes and OpenAPI generation.
+
+Suggested approach:
+1. Introduce shared contract modules (e.g. `apps/server/src/contracts/*`).
+2. Route handlers import those schemas for request validation.
+3. `openapi/schemas.ts` and `openapi/document.ts` import the same contract objects.
+4. Extend parity tests to assert critical schema parity (not only paths).
+
+## Acceptance criteria
+- No duplicated route-level payload schemas between route files and OpenAPI registry modules for targeted admin/public routes.
+- Contract updates require editing one schema definition.
+- Test coverage prevents route/schema drift regressions.
+
+## Duplicate check
+No overlap with open issues `#52`, `#53`, `#54`, `#55` (those are security findings in runtime behavior, not schema-source architecture).

--- a/docs/quality/payloads/issue-sdk-hook-engine-unify.md
+++ b/docs/quality/payloads/issue-sdk-hook-engine-unify.md
@@ -1,0 +1,30 @@
+## Summary
+React and Vue SDK packages implement near-identical faucet hook logic independently.
+
+## Evidence
+- `packages/sdk-react/src/index.ts` and `packages/sdk-vue/src/index.ts` both implement:
+  - `useFaucetClaim` lifecycle orchestration
+  - `useFaucetStatus` polling behavior
+  - `useFaucetStream` subscription wiring
+- Logic duplication includes request orchestration, confirmation polling, error/status transitions, and timer behavior.
+
+## Why this matters
+- Bug fixes and behavior improvements must be duplicated across frameworks.
+- Subtle divergence risk grows over time (especially in pending/retry/error semantics).
+- Harder to guarantee equivalent SDK behavior across ecosystems.
+
+## Proposed direction
+Extract a framework-agnostic hook engine (state machine + effects) and keep framework wrappers thin.
+
+Suggested shape:
+1. Add shared controller primitives in `@nimiq-faucet/sdk` (or dedicated shared package).
+2. React/Vue wrappers bind framework-specific reactivity around that shared engine.
+3. Add contract tests shared across wrappers to verify lifecycle equivalence.
+
+## Acceptance criteria
+- Claim/status/stream core logic exists in one reusable implementation.
+- React/Vue wrappers primarily adapt to framework APIs.
+- Cross-wrapper tests prove equivalent lifecycle behavior.
+
+## Duplicate check
+No overlap with open security issues `#52`, `#53`, `#54`, `#55`.

--- a/docs/quality/payloads/pr-runtime-core-quality-audit-2026-04.md
+++ b/docs/quality/payloads/pr-runtime-core-quality-audit-2026-04.md
@@ -1,0 +1,53 @@
+## Summary
+Implements the low-risk runtime-core quality tranche from the April 2026 audit:
+- adds shared Nimiq address normalization/validation in `@faucet/core`
+- rewires runtime + UI paths to use shared address helpers
+- deduplicates server fake-driver test scaffolding
+- adds OpenAPI/runtime route parity guard test
+- documents missing admin routes in OpenAPI
+- adds the canonical audit report under `docs/quality/`
+
+## Why
+Reduce duplicated logic and contract drift without breaking runtime APIs.
+
+## Changes
+1. Shared address helper
+- Added `packages/core/src/nimiqAddress.ts`
+- Exported via `packages/core/src/index.ts`
+- Replaced duplicated regex parsing in:
+  - `packages/driver-nimiq-rpc/src/index.ts`
+  - `packages/driver-nimiq-wasm/src/index.ts`
+  - `apps/claim-ui/src/lib/validate.ts`
+
+2. Server test dedupe
+- Added `apps/server/test/helpers/testDriver.ts`
+- Refactored e2e/unit tests to extend `BaseTestDriver` and shared helpers
+
+3. OpenAPI parity/drift reduction
+- Added missing OpenAPI docs for:
+  - `POST /admin/account/rotate-key`
+  - `POST /admin/claims/{id}/allow`
+  - `POST /admin/claims/{id}/deny`
+- Added `apps/server/test/openapi-parity.test.ts` to assert runtime path parity with OpenAPI registrations
+
+4. Audit report
+- Added `docs/quality/runtime-core-quality-audit-2026-04.md`
+- Linked report from `docs/README.md`
+
+## Risk
+Low. Behavior-preserving refactors plus docs/test parity guards.
+
+## Validation (Docker)
+- `pnpm build`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:e2e`
+
+## Deferred refactors (filed as follow-up issues)
+- #57 Refactor OpenAPI/runtime route schemas to a single source of truth
+- #58 Deduplicate runtime config mapping across server/admin/openapi/dashboard
+- #59 Reduce duplicated SQLite/Postgres DB schema declarations
+- #60 Unify React/Vue SDK hook engines to prevent lifecycle drift
+
+## Overlap check
+Reviewed open issues `#52`–`#55`; no duplicates were filed from this audit tranche.

--- a/docs/quality/runtime-core-quality-audit-2026-04.md
+++ b/docs/quality/runtime-core-quality-audit-2026-04.md
@@ -24,7 +24,7 @@
 ## PR Ledger
 | PR | Title | Purpose | Risk | Test evidence | Merge status |
 | --- | --- | --- | --- | --- | --- |
-| PENDING_PR_URL | Runtime core quality audit (low-risk simplification tranche) | Implement F1-F4 plus report deliverables | Low | Docker: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` | Open |
+| [#61](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/61) | Runtime core quality audit (low-risk simplification tranche) | Implement F1-F4 plus report deliverables | Low | Docker: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` | Open |
 
 ## Issue Ledger
 | Issue | Problem statement | Why deferred from PR | Priority | Recommended owner |

--- a/docs/quality/runtime-core-quality-audit-2026-04.md
+++ b/docs/quality/runtime-core-quality-audit-2026-04.md
@@ -1,0 +1,79 @@
+# Runtime Core Quality Audit (2026-04)
+
+## Audit Metadata
+- Date: 2026-04-17
+- Scope: `apps/server`, `packages/core`, `packages/driver-*`, `packages/sdk-*`, and root quality scripts/checks.
+- Baseline branch/commit: `origin/main` @ `1a58c48`.
+- Audit branch: `chore/runtime-core-quality-audit-2026-04`.
+- Tooling used: `rg`, `git`, `gh`, Docker (`node:22-bookworm`), `corepack`/`pnpm@10.17.0`, `turbo`, `vitest`, `playwright`.
+- Execution mode: runtime quality gates (`build`, `typecheck`, `test`, `test:e2e`) executed inside Docker containers.
+
+## Findings Register
+| ID | Finding | Classification | Rationale | Disposition |
+| --- | --- | --- | --- | --- |
+| F1 | Nimiq address regex/normalization duplicated across drivers and UI validator | `fix-now` | Low-risk simplification with immediate drift reduction | Implemented in audit PR candidate |
+| F2 | Server fake drivers duplicated across many tests | `fix-now` | Repeated boilerplate raised maintenance cost and inconsistency risk | Implemented in audit PR candidate |
+| F3 | No automated guard for OpenAPI path parity vs runtime route registration | `fix-now` | Drift risk can silently ship broken/undocumented contracts | Implemented in audit PR candidate |
+| F4 | Missing OpenAPI docs for admin routes (`/admin/account/rotate-key`, `/admin/claims/{id}/allow`, `/admin/claims/{id}/deny`) | `fix-now` | Public contract incomplete despite implemented runtime endpoints | Implemented in audit PR candidate |
+| F5 | OpenAPI DTO schemas and route validators are maintained in parallel | `issue` | Requires broader refactor to shared contract source; not low-risk | Filed as #57 |
+| F6 | Runtime config mappings duplicated across server/admin/openapi/dashboard | `issue` | Multi-surface refactor with cross-package impact; too large for low-risk tranche | Filed as #58 |
+| F7 | SQLite/Postgres schema declarations are duplicated | `issue` | Requires schema abstraction and migration-safety design work | Filed as #59 |
+| F8 | React/Vue SDK hook engines duplicate lifecycle logic | `issue` | Framework-wide architecture work; exceeds low-risk tranche scope | Filed as #60 |
+| F9 | Security findings already tracked as open issues (`#52`-`#55`) | `no-action` | Avoid duplicate filing; security backlog already active | Mapped to existing issues only |
+
+## PR Ledger
+| PR | Title | Purpose | Risk | Test evidence | Merge status |
+| --- | --- | --- | --- | --- | --- |
+| PENDING_PR_URL | Runtime core quality audit (low-risk simplification tranche) | Implement F1-F4 plus report deliverables | Low | Docker: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm test:e2e` | Open |
+
+## Issue Ledger
+| Issue | Problem statement | Why deferred from PR | Priority | Recommended owner |
+| --- | --- | --- | --- | --- |
+| [#57](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/57) | OpenAPI/runtime schemas not single-source | Cross-cutting contract refactor across routing + docs | P1 | Server platform maintainer |
+| [#58](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/58) | Runtime config mapping duplicated across layers | Requires shared config catalog + derived DTO/types | P1 | Server + dashboard maintainers |
+| [#59](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/59) | SQLite/Postgres schema duplication | Requires dialect abstraction and careful rollout | P2 | Persistence/DB maintainer |
+| [#60](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/60) | React/Vue hook engine duplication | Requires shared lifecycle engine and wrapper adaptation | P2 | SDK maintainer |
+
+## Recommendation Ledger
+| Recommendation | Impact | Effort | Dependency | Disposition |
+| --- | --- | --- | --- | --- |
+| Introduce shared Nimiq address normalize/validate helper in `@faucet/core` | High drift reduction | Low | None | `implemented` |
+| Reuse shared address helper from RPC/wasm drivers and claim UI | High consistency gain | Low | Shared helper | `implemented` |
+| Deduplicate server test fake driver scaffolding | Medium maintainability gain | Low | Shared test helper | `implemented` |
+| Add OpenAPI/runtime path parity guard test | Medium contract-safety gain | Low | Route/document parser test | `implemented` |
+| Add missing admin route docs to OpenAPI | Medium API correctness gain | Low | OpenAPI document update | `implemented` |
+| Refactor schemas to single source of truth | High long-term safety | Medium/High | Contract module design | `filed` (#57) |
+| Deduplicate runtime config mapping definitions | High operator/API consistency | High | Shared config catalog | `filed` (#58) |
+| Reduce SQLite/Postgres schema duplication | Medium maintainability gain | High | Schema descriptor abstraction | `filed` (#59) |
+| Unify React/Vue SDK hook engines | Medium cross-SDK consistency | Medium | Shared lifecycle engine | `filed` (#60) |
+| Keep existing security backlog tracked without duplicate filing | High signal/noise improvement | Low | Existing issues #52-#55 | `deferred` |
+
+## Duplicate Check
+### Existing open issues reviewed
+- [#52](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/52) Per-IP rate limit bypassable via concurrent requests (TOCTOU).
+- [#53](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/53) Concurrent integrator key rotation overwrite race.
+- [#54](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/54) Source maps served in production.
+- [#55](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/55) Login endpoint password correctness enumeration.
+
+### Existing open PRs reviewed for overlap
+- Dependabot update PRs currently open (`#24`-`#31`) were reviewed; no overlap with this runtime-core audit tranche.
+
+### Finding-to-existing-ID mapping
+- F9 maps to existing security backlog `#52`-`#55`.
+- No duplicate issue was created for any finding already covered by those open issues.
+
+## Validation Evidence
+All commands below were executed in Docker (`node:22-bookworm`) with workspace mounted at `/workspace/repo`:
+- `pnpm install --frozen-lockfile=false`
+- `pnpm build` ✅
+- `pnpm typecheck` ✅
+- `pnpm test` ✅
+- `pnpm test:e2e:install` ✅
+- `pnpm test:e2e` ✅ (42 passed)
+
+## Next-Step Execution Order (Top 5)
+1. Execute #57 (schema single-source refactor) before adding new admin/public endpoints.
+2. Execute #58 (config catalog unification) to reduce operator/API/dashboard drift.
+3. Prioritize security fixes from #55 and #52 (highest exploitability) on the hardening track.
+4. Execute #59 (schema duplication reduction) once #57/#58 contract work stabilizes.
+5. Execute #60 (SDK hook engine unification) with shared lifecycle conformance tests.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './driver.js';
 export * from './abuse.js';
 export * from './pipeline.js';
 export * from './hostContext.js';
+export * from './nimiqAddress.js';

--- a/packages/core/src/nimiqAddress.ts
+++ b/packages/core/src/nimiqAddress.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical Nimiq address format:
+ * `NQxx XXXX XXXX XXXX XXXX XXXX XXXX XXXX XXXX`
+ *
+ * We accept optional spaces between 4-char groups, but always normalize
+ * to uppercase and single spaces before validation.
+ */
+export const NIMIQ_ADDRESS_RE = /^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/;
+
+export function normalizeNimiqAddress(input: string): string {
+  return input.trim().toUpperCase().replace(/\s+/g, ' ');
+}
+
+export function isValidNimiqAddress(input: string): boolean {
+  if (!input) return false;
+  return NIMIQ_ADDRESS_RE.test(normalizeNimiqAddress(input));
+}

--- a/packages/core/test/nimiqAddress.test.ts
+++ b/packages/core/test/nimiqAddress.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isValidNimiqAddress,
+  normalizeNimiqAddress,
+} from '../src/nimiqAddress.js';
+
+describe('nimiqAddress helpers', () => {
+  it('normalizes lowercase and extra spacing', () => {
+    expect(normalizeNimiqAddress('  nq31   qaka 1u1h c1bj pqck bl16 sl5v ql4g ktev  ')).toBe(
+      'NQ31 QAKA 1U1H C1BJ PQCK BL16 SL5V QL4G KTEV',
+    );
+  });
+
+  it('accepts valid grouped and compact forms', () => {
+    expect(isValidNimiqAddress('NQ31 QAKA 1U1H C1BJ PQCK BL16 SL5V QL4G KTEV')).toBe(true);
+    expect(isValidNimiqAddress('NQ31QAKA1U1HC1BJPQCKBL16SL5VQL4GKTEV')).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    expect(isValidNimiqAddress('')).toBe(false);
+    expect(isValidNimiqAddress('NQ31 QAKA')).toBe(false);
+    expect(isValidNimiqAddress('NO31 QAKA 1U1H C1BJ PQCK BL16 SL5V QL4G KTEV')).toBe(false);
+    expect(isValidNimiqAddress('NQ31 QAKA 1U1H C1BJ PQCK BL16 SL5V QL4G KTE!')).toBe(false);
+  });
+});

--- a/packages/driver-nimiq-rpc/src/index.ts
+++ b/packages/driver-nimiq-rpc/src/index.ts
@@ -1,6 +1,8 @@
 import { request } from 'undici';
 import {
   DriverError,
+  isValidNimiqAddress,
+  normalizeNimiqAddress,
   type Address,
   type CurrencyDriver,
   type CurrencyDriverFactory,
@@ -160,8 +162,8 @@ export class NimiqRpcDriver implements CurrencyDriver {
   }
 
   parseAddress(input: string): Address {
-    const normalized = input.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(normalized)) {
+    const normalized = normalizeNimiqAddress(input);
+    if (!isValidNimiqAddress(normalized)) {
       throw new DriverError(`Invalid Nimiq address: ${input}`, 'INVALID_ADDRESS');
     }
     return normalized as Address;

--- a/packages/driver-nimiq-wasm/src/index.ts
+++ b/packages/driver-nimiq-wasm/src/index.ts
@@ -1,5 +1,7 @@
 import {
   DriverError,
+  isValidNimiqAddress,
+  normalizeNimiqAddress,
   type Address,
   type CurrencyDriver,
   type CurrencyDriverFactory,
@@ -118,8 +120,8 @@ export class NimiqWasmDriver implements CurrencyDriver {
   }
 
   parseAddress(input: string): Address {
-    const normalized = input.trim().toUpperCase().replace(/\s+/g, ' ');
-    if (!/^NQ[0-9]{2}(?: ?[0-9A-Z]{4}){8}$/.test(normalized)) {
+    const normalized = normalizeNimiqAddress(input);
+    if (!isValidNimiqAddress(normalized)) {
       throw new DriverError(`Invalid Nimiq address: ${input}`, 'INVALID_ADDRESS');
     }
     if (this.#nimiq) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   apps/claim-ui:
     dependencies:
+      '@faucet/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@nimiq-faucet/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk-ts


### PR DESCRIPTION
## Summary
Implements the low-risk runtime-core quality tranche from the April 2026 audit:
- adds shared Nimiq address normalization/validation in `@faucet/core`
- rewires runtime + UI paths to use shared address helpers
- deduplicates server fake-driver test scaffolding
- adds OpenAPI/runtime route parity guard test
- documents missing admin routes in OpenAPI
- adds the canonical audit report under `docs/quality/`

## Why
Reduce duplicated logic and contract drift without breaking runtime APIs.

## Changes
1. Shared address helper
- Added `packages/core/src/nimiqAddress.ts`
- Exported via `packages/core/src/index.ts`
- Replaced duplicated regex parsing in:
  - `packages/driver-nimiq-rpc/src/index.ts`
  - `packages/driver-nimiq-wasm/src/index.ts`
  - `apps/claim-ui/src/lib/validate.ts`

2. Server test dedupe
- Added `apps/server/test/helpers/testDriver.ts`
- Refactored e2e/unit tests to extend `BaseTestDriver` and shared helpers

3. OpenAPI parity/drift reduction
- Added missing OpenAPI docs for:
  - `POST /admin/account/rotate-key`
  - `POST /admin/claims/{id}/allow`
  - `POST /admin/claims/{id}/deny`
- Added `apps/server/test/openapi-parity.test.ts` to assert runtime path parity with OpenAPI registrations

4. Audit report
- Added `docs/quality/runtime-core-quality-audit-2026-04.md`
- Linked report from `docs/README.md`

## Risk
Low. Behavior-preserving refactors plus docs/test parity guards.

## Validation (Docker)
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`

## Deferred refactors (filed as follow-up issues)
- #57 Refactor OpenAPI/runtime route schemas to a single source of truth
- #58 Deduplicate runtime config mapping across server/admin/openapi/dashboard
- #59 Reduce duplicated SQLite/Postgres DB schema declarations
- #60 Unify React/Vue SDK hook engines to prevent lifecycle drift

## Overlap check
Reviewed open issues `#52`–`#55`; no duplicates were filed from this audit tranche.
