### PR TITLE
docs: FCaptcha follow-up sweep (layer count, captcha lists, dashboard toggle)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,14 @@ Test-intent shortcut: if the user's phrasing is specifically about *testing* (e.
 
 > 👋 **Welcome to Nimiq Simple Faucet**
 >
-> A self-hosted, stable (2.x) faucet / payout service for Nimiq with 9 pluggable abuse-prevention layers (rate-limiting on by default; captcha, hashcash, geo-IP, fingerprint, on-chain, AI scoring opt-in) and SDKs for 8 frameworks.
+> A self-hosted, stable (2.x) faucet / payout service for Nimiq with 10 pluggable abuse-prevention layers (rate-limiting on by default; captcha, hashcash, geo-IP, fingerprint, on-chain, AI scoring opt-in) and SDKs for 8 frameworks.
 >
 > **Here's the map:**
 > - `apps/server` — Fastify REST + WebSocket + admin + MCP
 > - `apps/dashboard` — admin Vue 3 app (at `/admin`)
 > - `apps/claim-ui` — public Vue 3 claim page (at `/`)
 > - `packages/sdk-*` — 8 SDKs: ts, react, vue, python, go, capacitor, react-native, flutter
-> - `packages/abuse-*` — 9 pluggable abuse layers (`AbuseCheck` contract)
+> - `packages/abuse-*` — 10 pluggable abuse layers (`AbuseCheck` contract)
 > - `packages/driver-nimiq-*` — RPC or WASM signer driver
 > - `examples/*` — Docker-runnable demo per framework
 >

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This faucet stands on the shoulders of the open-source projects below. Huge than
 - [otplib](https://github.com/yeojz/otplib) — TOTP
 
 **Abuse-prevention providers**
-- [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/), [hCaptcha](https://www.hcaptcha.com/)
+- [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/), [hCaptcha](https://www.hcaptcha.com/), [FCaptcha](https://github.com/WebDecoy/FCaptcha) (self-hosted)
 - [MaxMind GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/), [IPinfo](https://ipinfo.io/), [DB-IP](https://db-ip.com/) (via [ip-location-db](https://github.com/sapics/ip-location-db))
 - [ONNX Runtime](https://onnxruntime.ai/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,9 @@ We will keep you updated at least weekly until the issue is closed.
 - Downstream integrator applications that embed the SDKs. Report those to the
   respective maintainers.
 - Third-party services (MaxMind, IPinfo, Cloudflare Turnstile, hCaptcha,
-  upstream Nimiq nodes) — report to the vendor.
+  upstream Nimiq nodes) — report to the vendor. Self-hosted CAPTCHA
+  services like [FCaptcha](https://github.com/WebDecoy/FCaptcha) are
+  operator-run and upstream bugs should be reported to that project.
 - Denial of service by exhausting a paid third-party quota (captcha, GeoIP) —
   this is an integrator-side capacity concern, not a faucet vulnerability.
 - Social engineering of maintainers or integrators.

--- a/START.md
+++ b/START.md
@@ -1,6 +1,6 @@
 ---
 title: "Nimiq Simple Faucet — Choose your adventure"
-tagline: "Welcome to Nimiq Simple Faucet. A self-hosted, stable (2.x) faucet / payout service for Nimiq with 9 pluggable abuse-prevention layers (rate-limiting on by default; others opt-in) and 8 SDKs."
+tagline: "Welcome to Nimiq Simple Faucet. A self-hosted, stable (2.x) faucet / payout service for Nimiq with 10 pluggable abuse-prevention layers (rate-limiting on by default; others opt-in) and 8 SDKs."
 
 adventures:
   - number: 1
@@ -21,7 +21,7 @@ adventures:
     icon: "🧪"
     title: Full platform walkthrough
     time: "~2 hr"
-    details: "Exercise every feature — server, admin dashboard, claim UI, 6 examples, 8 SDKs, CLI tools, MCP server, 9 abuse layers."
+    details: "Exercise every feature — server, admin dashboard, claim UI, 6 examples, 8 SDKs, CLI tools, MCP server, 10 abuse layers."
     docs: "[docs/qa-testing.md](./docs/qa-testing.md)"
     link: /paths/full-walkthrough
   - number: 4
@@ -63,7 +63,7 @@ adventures:
 
 # 🎮 Nimiq Simple Faucet — Choose your adventure
 
-> 👋 **Welcome to Nimiq Simple Faucet.** A self-hosted, stable (2.x) faucet / payout service for Nimiq with 9 pluggable abuse-prevention layers (rate-limiting on by default; others opt-in) and 8 SDKs.
+> 👋 **Welcome to Nimiq Simple Faucet.** A self-hosted, stable (2.x) faucet / payout service for Nimiq with 10 pluggable abuse-prevention layers (rate-limiting on by default; others opt-in) and 8 SDKs.
 
 **Pick a quest — reply with a number:**
 
@@ -74,7 +74,7 @@ adventures:
   Path [1] plus generate a wallet, fund it at https://faucet.pos.nimiq-testnet.com, wire the credentials into `.env`, and claim a real testnet tx. End state: admin dashboard open, confirmed tx in the claims table. Full walkthrough: [deploy/compose/README.md](./deploy/compose/README.md).
 
 **[3] 🧪 Full platform walkthrough** · ~2 hr
-  Exercise every feature — server, admin dashboard, claim UI, 6 examples, 8 SDKs, CLI tools, MCP server, 9 abuse layers. See [docs/qa-testing.md](./docs/qa-testing.md).
+  Exercise every feature — server, admin dashboard, claim UI, 6 examples, 8 SDKs, CLI tools, MCP server, 10 abuse layers. See [docs/qa-testing.md](./docs/qa-testing.md).
 
 **[4] 🧩 Drop into my app** · ~10 min
   Framework recipe (Next.js, Vue, Capacitor, React Native, Flutter, Go, plain TS). See [AGENTS.md](./AGENTS.md#recipes).

--- a/apps/claim-ui/src/components/ClaimStatus.vue
+++ b/apps/claim-ui/src/components/ClaimStatus.vue
@@ -33,7 +33,7 @@ function mapReason(code?: string, message?: string): string {
   if (src.includes('invalid address')) return 'reason.invalidAddress';
   if (src.includes('geo') || src.includes('country')) return 'reason.geoBlocked';
   if (src.includes('vpn') || src.includes('proxy')) return 'reason.vpnBlocked';
-  if (src.includes('captcha') || src.includes('turnstile') || src.includes('hcaptcha')) return 'reason.captchaFailed';
+  if (src.includes('captcha') || src.includes('turnstile') || src.includes('hcaptcha') || src.includes('fcaptcha')) return 'reason.captchaFailed';
   return 'reason.unknown';
 }
 

--- a/apps/dashboard/src/views/ConfigView.vue
+++ b/apps/dashboard/src/views/ConfigView.vue
@@ -5,6 +5,7 @@ import { api, ApiError } from '../lib/api';
 interface LayerFlags {
   turnstile: boolean;
   hcaptcha: boolean;
+  fcaptcha: boolean;
   hashcash: boolean;
   geoip: boolean;
   fingerprint: boolean;
@@ -45,6 +46,7 @@ const form = reactive({
   layers: {
     turnstile: false,
     hcaptcha: false,
+    fcaptcha: false,
     hashcash: false,
     geoip: false,
     fingerprint: false,

--- a/apps/docs/guide/abuse-prevention.md
+++ b/apps/docs/guide/abuse-prevention.md
@@ -9,7 +9,7 @@ score and one of `allow`, `review`, or `deny`.
 1. **Transport & rate limits** — per-minute global cap, per-IP daily cap, CORS.
 2. **Blocklist** — exact matches on `ip`, `address`, `uid`, `asn`, `country`.
 3. **Hashcash** — client puzzle, required when `FAUCET_HASHCASH_SECRET` is set.
-4. **Captcha** — Turnstile or hCaptcha, required when configured.
+4. **Captcha** — Turnstile, hCaptcha, or self-hosted FCaptcha, required when configured.
 5. **GeoIP / ASN / VPN / Tor / hosting** — offline MaxMind or online IPinfo.
 6. **On-chain Nimiq heuristics** — address age, balance, activity.
 7. **Host context** — signed signals from the integrator (see [Host context](./host-context.md)).
@@ -40,6 +40,7 @@ can queue manual approval. The admin dashboard surfaces all `review` rows.
 | Hashcash | `@faucet/abuse-hashcash` | `FAUCET_HASHCASH_SECRET` |
 | Turnstile | `@faucet/abuse-turnstile` | `FAUCET_TURNSTILE_*` |
 | hCaptcha | `@faucet/abuse-hcaptcha` | `FAUCET_HCAPTCHA_*` |
+| FCaptcha | `@faucet/abuse-fcaptcha` | `FAUCET_FCAPTCHA_*` |
 | GeoIP | `@faucet/abuse-geoip` | `FAUCET_GEOIP_BACKEND` |
 | Fingerprint | `@faucet/abuse-fingerprint` | built-in |
 | Nimiq on-chain | `@faucet/abuse-onchain-nimiq` | built-in |

--- a/apps/docs/guide/configuration.md
+++ b/apps/docs/guide/configuration.md
@@ -44,6 +44,7 @@ Set exactly one provider (or none and rely on hashcash).
 | --- | --- |
 | `FAUCET_TURNSTILE_SITE_KEY` / `FAUCET_TURNSTILE_SECRET` | Cloudflare Turnstile. |
 | `FAUCET_HCAPTCHA_SITE_KEY` / `FAUCET_HCAPTCHA_SECRET` | hCaptcha. |
+| `FAUCET_FCAPTCHA_URL` / `FAUCET_FCAPTCHA_SITE_KEY` / `FAUCET_FCAPTCHA_SECRET` | Self-hosted [FCaptcha](https://github.com/WebDecoy/FCaptcha); all three are required. See `deploy/compose/fcaptcha.yml`. |
 
 ## Hashcash (client puzzle)
 

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -16,7 +16,7 @@ features:
   - title: Self-hosted
     details: One container, one binary. Ships as `ghcr.io/panoramicrum/nimiq-simple-faucet:latest` with SQLite defaults; scales to Postgres and Redis when you need it.
   - title: Pluggable abuse stack
-    details: Turnstile, hCaptcha, hashcash, GeoIP/ASN, on-chain Nimiq heuristics, and optional LLM scoring combine into a single decision pipeline.
+    details: Turnstile, hCaptcha, FCaptcha, hashcash, GeoIP/ASN, on-chain Nimiq heuristics, and optional LLM scoring combine into a single decision pipeline.
   - title: AI-agent integration (MCP)
     details: An `/mcp` endpoint exposes public, integrator, and admin tools so Claude Code, Cursor, and custom agents can introspect, claim, and moderate.
   - title: Admin dashboard

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -47,7 +47,7 @@ src/
     stream.ts           WS /v1/stream (live events)
     admin/*.ts          /admin/* routes (auth, claims, blocklist, integrators, config, account, audit)
   abuse/
-    pipeline.ts         Orchestrates all 9 abuse checks into allow/challenge/review/deny
+    pipeline.ts         Orchestrates all 10 abuse checks into allow/challenge/review/deny
   auth/
     session.ts          Cookie sessions + TOTP
     keyring.ts          Faucet key encryption at rest (Argon2id + XChaCha20-Poly1305)

--- a/apps/server/src/abuse/pipeline.ts
+++ b/apps/server/src/abuse/pipeline.ts
@@ -107,7 +107,7 @@ export function buildPipeline(
     console.warn(
       '[security] Hashcash is the only challenge layer. It prevents casual abuse but is ' +
       'solvable by scripts (~0.2s with parallel workers). For public-facing faucets, add ' +
-      'Turnstile or hCaptcha alongside hashcash. See docs/abuse-layers/hashcash.md.',
+      'Turnstile, hCaptcha, or FCaptcha alongside hashcash. See docs/abuse-layers/hashcash.md.',
     );
   }
 

--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -23,7 +23,10 @@ interface CspDirectives {
   'form-action': string[];
 }
 
-/** CSP directives per profile. `relaxed-for-ui` is default to let Turnstile + hCaptcha iframes load. */
+/** CSP directives per profile. `relaxed-for-ui` is default to let Turnstile + hCaptcha iframes load.
+ *  FCaptcha's widget is served from the operator's own FCaptcha host (typically same-origin or
+ *  reverse-proxied), so no third-party allowances are hardcoded for it — operators who run FCaptcha
+ *  on a separate origin can add it to CSP via a reverse-proxy `script-src` allowlist. */
 function cspDirectives(profile: CspProfile): CspDirectives | false {
   if (profile === 'off') return false;
   const base: CspDirectives = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ the [root README](../README.md).
 
 ## Abuse Prevention
 
-- [abuse-layers/](./abuse-layers/) — detailed documentation for all 9 abuse layers, providers, configuration, and how to add your own
+- [abuse-layers/](./abuse-layers/) — detailed documentation for all 10 abuse layers, providers, configuration, and how to add your own
 - [fraud-prevention.md](./fraud-prevention.md) — one-pager on the defense-in-depth strategy + trust connectors (for stakeholders)
 
 ## Security

--- a/docs/abuse-layers/README.md
+++ b/docs/abuse-layers/README.md
@@ -102,7 +102,7 @@ The order is not currently configurable. Each layer's **weight** affects its con
 
 ### Combining captcha with hashcash
 
-You can enable both a captcha provider (Turnstile or hCaptcha) **and** hashcash simultaneously. The ClaimUI will render both widgets — the captcha widget and the hashcash progress bar. The claim button only activates when both challenges are satisfied.
+You can enable a captcha provider (Turnstile, hCaptcha, or FCaptcha) **and** hashcash simultaneously. The ClaimUI will render both widgets — the captcha widget and the hashcash progress bar. The claim button only activates when both challenges are satisfied.
 
 This is the **recommended production setup**: captcha verifies the user is human, hashcash adds CPU cost to prevent rapid automated claiming even if the captcha is bypassed.
 

--- a/docs/abuse-layers/hashcash.md
+++ b/docs/abuse-layers/hashcash.md
@@ -33,7 +33,7 @@ Setting `FAUCET_HASHCASH_SECRET` enables the layer. Use a random string of at le
 | 24 | ~15-30s | ~3s | High-value faucets |
 | 30 | ~minutes | ~minutes | Maximum friction |
 
-> **Important:** Hashcash alone is not sufficient for public-facing faucets. A Python script with 7 CPU workers can solve difficulty 20 in ~0.17 seconds. For real protection against automated scripts, combine hashcash with at least one additional layer — either a CAPTCHA provider (Turnstile/hCaptcha), `FAUCET_REQUIRE_BROWSER=true` (Sec-Fetch header enforcement), or both.
+> **Important:** Hashcash alone is not sufficient for public-facing faucets. A Python script with 7 CPU workers can solve difficulty 20 in ~0.17 seconds. For real protection against automated scripts, combine hashcash with at least one additional layer — either a CAPTCHA provider (Turnstile/hCaptcha/FCaptcha), `FAUCET_REQUIRE_BROWSER=true` (Sec-Fetch header enforcement), or both.
 
 ## Decision logic
 

--- a/docs/admin-first-run.md
+++ b/docs/admin-first-run.md
@@ -147,8 +147,11 @@ Before you expose this instance to real users:
 - [ ] Set `FAUCET_CORS_ORIGINS` to your integrator's actual origins —
       don't leave `*` in production.
 - [ ] Enable a captcha provider: `FAUCET_TURNSTILE_SITE_KEY` +
-      `FAUCET_TURNSTILE_SECRET`, or the hCaptcha equivalents. Without one,
-      your faucet will burn through its balance in minutes under bot load.
+      `FAUCET_TURNSTILE_SECRET`, the hCaptcha equivalents, or self-hosted
+      FCaptcha (`FAUCET_FCAPTCHA_URL` + `FAUCET_FCAPTCHA_SITE_KEY` +
+      `FAUCET_FCAPTCHA_SECRET`; see `deploy/compose/fcaptcha.yml`).
+      Without one, your faucet will burn through its balance in minutes
+      under bot load.
 - [ ] Tune rate limits: `FAUCET_RATE_LIMIT_PER_IP_PER_DAY` (default 5) is
       almost always too generous for mainnet. 1-2 is more typical.
 - [ ] Configure GeoIP to match your legal footprint — see the `geoip*`

--- a/docs/claim-ui.md
+++ b/docs/claim-ui.md
@@ -59,7 +59,7 @@ Spawns a Web Worker that brute-forces SHA-256 hashes to solve the server-issued 
 
 ### Challenge flow
 
-Captcha providers (Turnstile/hCaptcha) are mutually exclusive, but either can be combined with hashcash — both widgets render simultaneously when both are enabled. The claim button (the cat mascot) stays disabled until:
+Captcha providers (Turnstile / hCaptcha / FCaptcha) are mutually exclusive — pick one — but any of them can be combined with hashcash, in which case both widgets render simultaneously. The claim button (the cat mascot) stays disabled until:
 
 1. A valid Nimiq address is entered
 2. The active challenge is satisfied (captcha token obtained or hashcash solved)

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -56,7 +56,7 @@ address from the supplied key.
 - [ ] Ingress controller installed (nginx, traefik, cloud-native, etc.)
 - [ ] DNS A/AAAA record pointing at your cluster's ingress
 - [ ] A funded Nimiq address on the correct network (main or test)
-- [ ] Captcha provider account (Turnstile or hCaptcha) if you're exposing the public claim UI
+- [ ] Captcha provider (Turnstile or hCaptcha account, or a self-hosted FCaptcha instance) if you're exposing the public claim UI
 - [ ] Postgres (managed RDS / Cloud SQL / self-hosted) if you expect >1 replica or >1000 claims/day
 - [ ] Redis (managed ElastiCache / Memorystore) for the same case
 - [ ] Backup strategy: SQLite volume snapshots OR Postgres logical dumps

--- a/docs/fraud-prevention.md
+++ b/docs/fraud-prevention.md
@@ -15,7 +15,7 @@ Every claim runs through a pipeline. Any layer can flag, score, or deny.
 | Per-IP rate limit | Same IP hammering (per minute) | ~0 | Always on |
 | Per-IP daily cap | Over-claiming from a single IP in 24h | ~0 | Always on |
 | Blocklist | Known-bad IP, address, UID, ASN, or country | ~0 | Admin-curated |
-| Captcha (Turnstile / hCaptcha) | Trivial bots | 1 verify call | Env var + site key |
+| Captcha (Turnstile / hCaptcha / FCaptcha) | Trivial bots | 1 verify call | Env var + site key |
 | Hashcash (client puzzle) | Raises attacker CPU cost per claim | ~1 s client CPU | `FAUCET_HASHCASH_SECRET` |
 | GeoIP / ASN / VPN / Tor / datacenter | Regional policy + datacenter IPs | <5 ms (MaxMind), ~150 ms (IPinfo) | `FAUCET_GEOIP_BACKEND` |
 | Fingerprint correlation | Multi-account / multi-browser farming | DB lookup | `FAUCET_FINGERPRINT_ENABLED` |

--- a/docs/qa-testing.md
+++ b/docs/qa-testing.md
@@ -224,7 +224,7 @@ Open http://localhost:8080/ in an incognito/private window (to avoid dashboard s
 2. The 2nd claim returns status `rejected` with a friendly message.
 
 ### Path D — captcha (optional)
-If you configured Turnstile or hCaptcha in `.env`, verify the widget renders, returns a token, and the server accepts it. If you haven't, skip this.
+If you configured Turnstile, hCaptcha, or FCaptcha in `.env`, verify the widget renders, returns a token, and the server accepts it. If you haven't, skip this.
 
 ### Path E — WS vs polling
 Kill the WebSocket in DevTools. The status should still converge via the `GET /v1/claim/:id` polling fallback.
@@ -396,7 +396,7 @@ Work through each layer. After each deliberate rejection, check the admin dashbo
 - `FAUCET_AI_ENABLED=true`. Submit unusual request patterns (velocity bursts, weird entropy in hostContext). Score rises.
 
 ### Ask your AI
-> "Help me trigger each of the 9 abuse layers deliberately so I can see them in action. For each one, tell me what flag to set, what request to send, and what the expected rejection reason should look like in the admin claims drawer."
+> "Help me trigger each of the 10 abuse layers deliberately so I can see them in action. For each one, tell me what flag to set, what request to send, and what the expected rejection reason should look like in the admin claims drawer."
 
 ---
 

--- a/docs/security/owasp-top10.md
+++ b/docs/security/owasp-top10.md
@@ -14,7 +14,7 @@ remaining work is scheduled.
 | A07 Identification and Authentication Failures | TOTP on admin login and sensitive admin mutations; Argon2id with OWASP-recommended parameters; per-endpoint login rate limit (5/min/IP); generic auth error messages | Session-store + lockout policy ships with M3.1 | M3.1, M6.2 |
 | A08 Software and Data Integrity Failures | `pnpm --frozen-lockfile=false` today but lockfile committed; release images will ship with SBOM attached; Docker image built reproducibly via multi-stage Dockerfile | Release signing (cosign) and SLSA provenance not yet wired | M9 |
 | A09 Security Logging and Monitoring Failures | Every claim row persists signals + decision + score; audit log table for admin actions; live `admin.audit` stream via WS; log scrubber forbids secrets | Audit log + WS stream implemented in M3.4; structured error IDs for support flow pending | M3.4, M6.2 |
-| A10 Server-Side Request Forgery | Only outbound traffic is: captcha verify endpoints (fixed hostnames), GeoIP provider (fixed hostname or local MMDB file), configured Nimiq RPC node, Turnstile/hCaptcha; no user-supplied URLs in server code paths | Confirm no future admin feature forwards operator URLs without an allow-list | M6.4 |
+| A10 Server-Side Request Forgery | Only outbound traffic is: captcha verify endpoints (fixed hostnames for Turnstile/hCaptcha; operator-configured URL for self-hosted FCaptcha), GeoIP provider (fixed hostname or local MMDB file), configured Nimiq RPC node; no user-supplied URLs in server code paths | Confirm no future admin feature forwards operator URLs without an allow-list | M6.4 |
 
 ## Per-endpoint cross-reference
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -50,7 +50,7 @@ this repo (shipped unless marked **planned**).
 
 | STRIDE | Threat | Mitigation |
 | --- | --- | --- |
-| Spoofing | Bots pretending to be humans | Cloudflare Turnstile / hCaptcha; hashcash fallback; per-integrator HMAC when `x-faucet-api-key` is present |
+| Spoofing | Bots pretending to be humans | Cloudflare Turnstile / hCaptcha / self-hosted FCaptcha; hashcash fallback; per-integrator HMAC when `x-faucet-api-key` is present |
 | Tampering | Malformed / overlong bodies | Zod schema (`ClaimBody`), `bodyLimit: 64 KiB` at Fastify layer, `parseAddress` strict |
 | Repudiation | Operator cannot prove a claim decision | Every claim row persists `signalsJson`, `decision`, `abuseScore`; audit log (planned M3.4) adds admin overrides |
 | Info disclosure | Leaking why a claim was denied to abusers | Public response returns only the first reason; full signals are admin-only via `/admin/claims/:id/explain` |

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -146,7 +146,7 @@ A successful smoke test confirms:
 
 It does **not** cover:
 - Admin dashboard flows (see Playwright e2e)
-- Captcha providers (Turnstile/hCaptcha) — those need real site keys
+- Captcha providers — Turnstile/hCaptcha need real site keys, FCaptcha needs a running instance ([deploy/compose/fcaptcha.yml](../deploy/compose/fcaptcha.yml))
 - GeoIP accuracy — tested in unit tests against fixtures
 
 Never commit `.env`, `.wallet.local.json`, or any real keys.

--- a/packages/abuse-ai/llms.txt
+++ b/packages/abuse-ai/llms.txt
@@ -15,4 +15,4 @@ The caller provides a `RecentClaimsQuery` with `byIp`, `byAddress`, `byUid` coun
 5. Surfaces model id, score, top-3 contributions, and the full feature bundle in `signals` for the dashboard's explain drawer.
 6. Soft-skips on any error — a bad counter source must not block the pipeline.
 
-Pair with `@faucet/abuse-geoip`, `@faucet/abuse-hashcash`, and the captcha packages for a full anti-abuse pipeline.
+Pair with `@faucet/abuse-geoip`, `@faucet/abuse-hashcash`, and a captcha layer (`@faucet/abuse-turnstile`, `@faucet/abuse-hcaptcha`, or self-hosted `@faucet/abuse-fcaptcha`) for a full anti-abuse pipeline.

--- a/packages/abuse-hashcash/llms.txt
+++ b/packages/abuse-hashcash/llms.txt
@@ -8,4 +8,4 @@ Self-hosted **client-side hashcash** challenge. Purely an anti-bot layer — unr
 
 Difficulty: leading zero bits required in SHA-256(challenge + ":" + nonce). 20 ≈ 1M hashes, a few seconds on consumer hardware.
 
-Use this for a fully self-hosted abuse layer with no third-party captcha. Pairs well with `@faucet/abuse-turnstile` or `@faucet/abuse-hcaptcha`.
+Use this for a fully self-hosted abuse layer with no third-party captcha. Pairs well with any captcha provider — `@faucet/abuse-turnstile`, `@faucet/abuse-hcaptcha`, or the self-hosted `@faucet/abuse-fcaptcha`.

--- a/packages/abuse-hcaptcha/README.md
+++ b/packages/abuse-hcaptcha/README.md
@@ -23,4 +23,5 @@ Implements `AbuseCheck` from [@faucet/core](../core/) — registered in
 ## See also
 
 - Sibling: [@faucet/abuse-turnstile](../abuse-turnstile/) (Cloudflare Turnstile)
+- Sibling: [@faucet/abuse-fcaptcha](../abuse-fcaptcha/) (self-hosted FCaptcha)
 - [@faucet/core](../core/) — `AbuseCheck` interface

--- a/packages/abuse-turnstile/README.md
+++ b/packages/abuse-turnstile/README.md
@@ -20,14 +20,17 @@ Implements `AbuseCheck` from [@faucet/core](../core/) — registered in
 - `allow` when the Turnstile service returns success.
 - One outbound call per claim (fast).
 
-## Turnstile vs hCaptcha
+## Turnstile vs hCaptcha vs FCaptcha
 
-Turnstile is the lighter-weight alternative (no checkbox UI in most
-cases). Pick one — don't run both simultaneously. See
-[`/v1/config`](../../apps/server/src/routes/claim.ts) for how the server
-advertises the active provider to clients.
+Turnstile is the lighter-weight hosted alternative (no checkbox UI in
+most cases); hCaptcha is the hosted privacy-first option; FCaptcha is
+the self-hosted, MIT-licensed option with behavioural + PoW signals.
+Pick one — don't run more than one captcha provider simultaneously.
+See [`/v1/config`](../../apps/server/src/routes/claim.ts) for how the
+server advertises the active provider to clients.
 
 ## See also
 
 - Sibling: [@faucet/abuse-hcaptcha](../abuse-hcaptcha/)
+- Sibling: [@faucet/abuse-fcaptcha](../abuse-fcaptcha/) (self-hosted)
 - [@faucet/core](../core/) — `AbuseCheck` interface


### PR DESCRIPTION
## Summary

Follow-up to #81, which added FCaptcha as the 10th pluggable abuse-prevention layer. PR #81 only updated the canonical surfaces (README.md, docs/abuse-layers/README.md, apps/server + SDK wiring). This PR sweeps the long tail — every active doc surface that still said "9 layers" or listed "Turnstile or hCaptcha" without FCaptcha — and closes the two small code gaps that let main silently drop the new provider.

Four commits, grouped by theme:

1. **Layer count 9 → 10** — START.md, AGENTS.md, docs/README.md, apps/server/README.md, docs/qa-testing.md.
2. **Captcha-provider enumerations** — 14 files; expanded every "Turnstile or hCaptcha" list. Includes README Acknowledgements, both guide pages, security/threat-model, security/owasp-top10, fraud-prevention, claim-ui guide, admin-first-run, deployment-production, smoke-testing, hashcash layer doc, the combine-with-hashcash note in abuse-layers/README, and SECURITY.md.
3. **Dashboard + server code** — [apps/dashboard/src/views/ConfigView.vue](apps/dashboard/src/views/ConfigView.vue) silently dropped the `fcaptcha` key coming back from `/v1/config`; added it to `LayerFlags` + form defaults so the toggle renders. Also updated the CSP-comment in [hardening.ts](apps/server/src/hardening.ts), the "hashcash alone is insufficient" warning in [pipeline.ts](apps/server/src/abuse/pipeline.ts), and the error-classifier heuristic in [ClaimStatus.vue](apps/claim-ui/src/components/ClaimStatus.vue).
4. **Sibling cross-references** — `packages/abuse-{turnstile,hcaptcha}/README.md` and `packages/abuse-{hashcash,ai}/llms.txt` all now mention `@faucet/abuse-fcaptcha`.

Historical docs (CHANGELOG.md, .changeset/*, apps/docs/changelog.md, ROADMAP.md) are intentionally untouched — they record specific past-version shipments.

## Test plan

- [x] `pnpm --filter @faucet/server build && pnpm --filter @faucet/server test` — 78/78 pass
- [x] `pnpm --filter @nimiq-faucet/dashboard build` — clean
- [x] `pnpm --filter @nimiq-faucet/docs build && pnpm --filter @nimiq-faucet/playground build` — both VitePress builds succeed
- [x] `rg -n '9 (pluggable|abuse)'` excluding historical files → 0 hits
- [x] `rg -n 'Turnstile.{0,80}hCaptcha'` excluding historical + places mentioning FCaptcha → only 2 hits, both annotated follow-on lines (SECURITY.md has a follow-up FCaptcha note below; hardening.ts has a block-comment extension explaining FCaptcha is same-origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)