### PR TITLE
fix(server): trustProxy CIDR allow-list (closes #87, closes #83)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,13 @@ FAUCET_DEV=false
 # unless FAUCET_DEV=1. Set FAUCET_TLS_REQUIRED=false explicitly to allow HTTP.
 # FAUCET_TLS_REQUIRED=true
 # FAUCET_HELMET_CSP=relaxed-for-ui      # strict | relaxed-for-ui | off
+#
+# Trusted-proxy allow-list. Comma-separated CIDRs of upstream proxies whose
+# X-Forwarded-For / X-Real-IP headers the server will honour. LEAVE UNSET
+# when the faucet is directly reachable — any value here lets that peer
+# spoof req.ip and bypass the per-IP rate-limit, blocklist, and hashcash
+# IP binding. Typical values:
+#   - behind an internal LB on a VPC:   FAUCET_TRUSTED_PROXY_CIDRS=10.0.0.0/8
+#   - behind Cloudflare specifically:   use Cloudflare's published IP ranges
+#   - bare-metal / directly exposed:    leave unset
+# FAUCET_TRUSTED_PROXY_CIDRS=

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -34,6 +34,16 @@ export async function buildApp(
   config: ServerConfig,
   opts: BuildAppOptions = {},
 ): Promise<{ app: FastifyInstance; ctx: AppContext }> {
+  // Fix #87: never trust `X-Forwarded-For` / `X-Real-IP` from arbitrary peers.
+  // Trust only the CIDRs an operator has explicitly allow-listed
+  // (`FAUCET_TRUSTED_PROXY_CIDRS`). Empty → no upstream proxy is trusted and
+  // `req.ip` is the raw socket address. Loopback is added in dev so local
+  // e2e tests can exercise XFF paths against `127.0.0.1`.
+  const proxyAllowList = [
+    ...config.trustedProxyCidrs,
+    ...(config.dev ? ['127.0.0.1/32', '::1/128'] : []),
+  ];
+  const trustProxy: boolean | string[] = proxyAllowList.length > 0 ? proxyAllowList : false;
   const app = Fastify({
     logger: opts.quietLogs
       ? false
@@ -41,7 +51,7 @@ export async function buildApp(
           level: config.dev ? 'debug' : 'info',
           redact: { paths: buildRedactPaths(), censor: '[REDACTED]', remove: false },
         },
-    trustProxy: true,
+    trustProxy,
     bodyLimit: 64 * 1024,
   });
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -124,6 +124,28 @@ export const ServerConfigSchema = z.object({
   tlsRequired: z.coerce.boolean().default(true),
   helmetCsp: z.enum(['strict', 'relaxed-for-ui', 'off']).default('relaxed-for-ui'),
 
+  /**
+   * CIDR allow-list of upstream proxies whose `X-Forwarded-For` / `X-Real-IP`
+   * the server will honour. Empty (default) means **do not trust any proxy**:
+   * `req.ip` becomes the raw socket address, closing IP-spoofing bypasses of
+   * the per-IP rate-limit, blocklist, and hashcash IP binding (issue #87).
+   *
+   * Set via `FAUCET_TRUSTED_PROXY_CIDRS` as a comma-separated list, e.g.
+   * `10.0.0.0/8,172.16.0.0/12` for an internal LB. Loopback is included
+   * automatically in dev mode for local tests that inject XFF.
+   */
+  trustedProxyCidrs: z
+    .string()
+    .optional()
+    .transform((v) =>
+      v
+        ? v
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [],
+    ),
+
   metricsEnabled: z.coerce.boolean().default(true),
   reconcileEnabled: z.coerce.boolean().default(true),
   reconcileIntervalMs: z.coerce.number().int().min(10_000).default(5 * 60_000),
@@ -196,6 +218,7 @@ const ENV_KEYS: Record<string, string> = {
   corsOrigins: 'FAUCET_CORS_ORIGINS',
   tlsRequired: 'FAUCET_TLS_REQUIRED',
   helmetCsp: 'FAUCET_HELMET_CSP',
+  trustedProxyCidrs: 'FAUCET_TRUSTED_PROXY_CIDRS',
   metricsEnabled: 'FAUCET_METRICS_ENABLED',
   reconcileEnabled: 'FAUCET_RECONCILE_ENABLED',
   reconcileIntervalMs: 'FAUCET_RECONCILE_INTERVAL_MS',

--- a/apps/server/test/trustproxy.e2e.test.ts
+++ b/apps/server/test/trustproxy.e2e.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for #87: the per-IP rate-limit and blocklist must use the
+ * raw socket address when the upstream peer isn't in the trusted-proxy CIDR
+ * allow-list. Before this fix, `trustProxy: true` made any client's
+ * `X-Forwarded-For` authoritative for `req.ip`, which let a single attacker
+ * rotate spoofed IPs per request to bypass per-IP quotas.
+ *
+ * The test drives `/v1/claim` via `app.inject`, which presents the request
+ * to Fastify as if it originated at `127.0.0.1`. With the default config
+ * (`trustedProxyCidrs` empty, `dev=false`), XFF must be ignored: repeat
+ * requests with distinct XFF headers should still hit the same per-IP cap.
+ * With loopback allow-listed (simulated via `dev=true`), XFF is honoured
+ * and distinct XFF values bypass the cap — this is the operator-opt-in path
+ * for legitimate reverse-proxy deployments.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+
+class FakeDriver extends BaseTestDriver {
+  override async send(to: string): Promise<string> {
+    return `tx_${to.slice(-4)}`;
+  }
+  override async waitForConfirmation(): Promise<void> {}
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerMinute: '1000',
+    rateLimitPerIpPerDay: '2',
+    adminPassword: 'test-password-123',
+    tlsRequired: false,
+    corsOrigins: 'https://example.test',
+    ...overrides,
+  });
+}
+
+describe('trustProxy CIDR allow-list (#87)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-trustproxy-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('ignores spoofed X-Forwarded-For when the upstream is not in the trust list', async () => {
+    // Default config: no proxy trusted, non-dev — the only IP the server
+    // ever sees for a request is its socket peer (127.0.0.1 via inject).
+    const config = baseConfig(tmp);
+    const built = await buildApp(config, { driverOverride: new FakeDriver(), quietLogs: true });
+    apps.push(built.app);
+    await built.app.ready();
+
+    const send = (xff: string) =>
+      built.app.inject({
+        method: 'POST',
+        url: '/v1/claim',
+        payload: { address: USER_ADDR },
+        headers: { 'content-type': 'application/json', 'x-forwarded-for': xff },
+      });
+
+    // rateLimitPerIpPerDay=2. Three attempts from "distinct" spoofed IPs —
+    // if the spoof were honoured each would be a separate bucket (all 200).
+    // Because XFF is ignored, the third one hits the per-IP cap and is denied.
+    const a = await send('203.0.113.1');
+    const b = await send('203.0.113.2');
+    const c = await send('203.0.113.3');
+    expect(a.statusCode).toBe(200);
+    expect(b.statusCode).toBe(200);
+    expect(c.statusCode).toBe(403);
+    expect(c.json().reason).toMatch(/daily cap/);
+  });
+
+  it('honours X-Forwarded-For when the upstream peer is in the trust list (dev → loopback auto-trusted)', async () => {
+    // dev=true auto-adds 127.0.0.1/32 + ::1/128 to the trust list so
+    // legitimate reverse-proxy deployments keep working under test. With
+    // loopback trusted, distinct XFF values become distinct req.ip buckets.
+    const config = baseConfig(tmp, { dev: 'true' });
+    const built = await buildApp(config, { driverOverride: new FakeDriver(), quietLogs: true });
+    apps.push(built.app);
+    await built.app.ready();
+
+    const send = (xff: string) =>
+      built.app.inject({
+        method: 'POST',
+        url: '/v1/claim',
+        payload: { address: USER_ADDR },
+        headers: { 'content-type': 'application/json', 'x-forwarded-for': xff },
+      });
+
+    // Same three calls: each XFF is a fresh per-IP bucket so all succeed.
+    const a = await send('203.0.113.11');
+    const b = await send('203.0.113.12');
+    const c = await send('203.0.113.13');
+    expect(a.statusCode).toBe(200);
+    expect(b.statusCode).toBe(200);
+    expect(c.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 1 / Finding #001 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). The audit's executive summary calls this "the most leveraged single fix" — closes the full bypass of the per-IP rate-limit and blocklist.

### Before

[apps/server/src/app.ts](apps/server/src/app.ts) booted Fastify with `trustProxy: true`. That makes any client's `X-Forwarded-For` / `X-Real-IP` header authoritative for `req.ip`. A client sending `X-Forwarded-For: 1.2.3.4` has their request counted against `1.2.3.4` in the `ipCounters` table, not the real socket peer — rotating the header per request trivially bypasses the daily cap and any IP blocklist entries.

### After

New optional config field `trustedProxyCidrs` read from `FAUCET_TRUSTED_PROXY_CIDRS` (comma-separated CIDRs). Empty default = no upstream proxy trusted = `req.ip` is the raw socket address. Loopback (`127.0.0.1/32`, `::1/128`) is auto-trusted when `dev=true` so `inject()`-based e2e tests can still exercise XFF paths.

Example:

```bash
# Behind an internal LB:
FAUCET_TRUSTED_PROXY_CIDRS=10.0.0.0/8

# Bare-metal / directly exposed (default):
# FAUCET_TRUSTED_PROXY_CIDRS unset → no XFF trust
```

Documented in `.env.example`.

### Regression coverage

Two new cases in [apps/server/test/trustproxy.e2e.test.ts](apps/server/test/trustproxy.e2e.test.ts):

1. **Spoof rejected.** Default config, three `/v1/claim` calls with distinct `X-Forwarded-For` values — the third hits the daily per-IP cap (all three share the real socket peer's bucket).
2. **Opt-in honoured.** `dev=true` auto-trusts loopback; the same three calls with distinct XFF succeed — proving legitimate reverse-proxy deployments still work once the operator adds their LB's CIDR.

## Test plan

- [x] `pnpm --filter @faucet/server build` — clean
- [x] `pnpm --filter @faucet/server test` — 80/80 (78 existing + 2 new)
- [ ] Manual curl against a test build confirming a spoofed XFF does not create a new `ipCounters` row when `FAUCET_TRUSTED_PROXY_CIDRS` is unset

## Closes

- Closes #87 (audit finding #001)
- Closes #83 (pre-existing duplicate from the maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)