### PR TITLE
fix(server): constant-time compare on admin first-login seed (closes #89)

### DIFF
--- a/apps/server/src/routes/admin/auth.ts
+++ b/apps/server/src/routes/admin/auth.ts
@@ -14,7 +14,7 @@
  * Rate limit: 5 requests/min/IP on /admin/auth/login (applied at registration
  * time via @fastify/rate-limit's per-route config).
  */
-import { randomBytes } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { eq } from 'drizzle-orm';
 import type { AppContext } from '../../context.js';
@@ -43,6 +43,20 @@ import {
 import { writeAudit } from '../../auth/audit.js';
 
 const ADMIN_USER_ID = 'admin';
+
+/**
+ * Constant-time UTF-8 string compare. Used on the first-login seed branch
+ * where the submitted password is matched against the env-configured
+ * `FAUCET_ADMIN_PASSWORD`. `===` / `!==` on V8 short-circuit on length and
+ * on the first differing character, which leaks a prefix-timing oracle
+ * over the network (audit finding #003, issue #89).
+ */
+function safeEqualUtf8(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
 
 // Shared schema — single source of truth with OpenAPI spec.
 import { LoginRequest as LoginBody } from '../../openapi/schemas.js';
@@ -74,7 +88,7 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
         if (!ctx.config.adminPassword) {
           return reply.code(403).send({ error: 'admin not configured' });
         }
-        if (password !== ctx.config.adminPassword) {
+        if (!safeEqualUtf8(password, ctx.config.adminPassword)) {
           return reply.code(401).send({ error: 'invalid credentials' });
         }
         const { hash, salt } = await hashPassword(password);

--- a/apps/server/test/admin-first-login.e2e.test.ts
+++ b/apps/server/test/admin-first-login.e2e.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression tests for #89: first-login seed branch in
+ * apps/server/src/routes/admin/auth.ts.
+ *
+ * 1. Wrong-password behaviour is preserved after switching the `!==` compare
+ *    to `timingSafeEqual`. We send a same-length but wrong password and
+ *    assert 401 + no seeded admin row. (We don't attempt to measure timing;
+ *    timingSafeEqual's constant-time property is Node's contract.)
+ * 2. The per-route `@fastify/rate-limit` bucket throttles brute-force during
+ *    the seed window. Fire `adminLoginRatePerMinute + 2` wrong attempts from
+ *    one peer and assert the overflow is 429 — this pins the rate-limit
+ *    contract so a future refactor can't silently drop the `config.rateLimit`
+ *    block from the login route.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+import { adminUsers } from '../src/db/schema.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const CORRECT_PASSWORD = 'test-password-123';
+
+class FakeDriver extends BaseTestDriver {
+  override async send(): Promise<string> { return 'tx_x'; }
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    adminPassword: CORRECT_PASSWORD,
+    dev: 'true',
+    ...overrides,
+  });
+}
+
+describe('admin first-login seed branch (#89)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+  let ctxs: Array<Awaited<ReturnType<typeof buildApp>>['ctx']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-admin-first-login-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    ctxs = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns 401 and does not seed when a same-length wrong password is submitted', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const wrong = 'x'.repeat(CORRECT_PASSWORD.length);
+    expect(wrong.length).toBe(CORRECT_PASSWORD.length);
+
+    const res = await built.app.inject({
+      method: 'POST',
+      url: '/admin/auth/login',
+      payload: { password: wrong },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toMatch(/invalid credentials/i);
+
+    // Confirm the seed branch did not fire — no adminUsers row.
+    const rows = await built.ctx.db.select().from(adminUsers);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('rate-limits brute-force attempts against the seed branch (429 after the cap)', async () => {
+    // Lower the per-route cap for a fast deterministic test.
+    const built = await buildApp(
+      baseConfig(tmp, { adminLoginRatePerMinute: '3' }),
+      { driverOverride: new FakeDriver(), quietLogs: true },
+    );
+    apps.push(built.app);
+    await built.app.ready();
+
+    const tryWrong = () =>
+      built.app.inject({
+        method: 'POST',
+        url: '/admin/auth/login',
+        payload: { password: 'definitely-not-the-password' },
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const r = await tryWrong();
+      statuses.push(r.statusCode);
+    }
+
+    // The first N (≤ cap) all return 401 (credentials invalid, not throttled).
+    // Once the cap is exceeded, @fastify/rate-limit returns 429.
+    expect(statuses.slice(0, 3)).toEqual([401, 401, 401]);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 1 / 2 of 4 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #003 / issue #89.

### Before

The seed branch in [apps/server/src/routes/admin/auth.ts:77](apps/server/src/routes/admin/auth.ts#L77) compared the submitted password against `FAUCET_ADMIN_PASSWORD` with `!==`. V8's string equality short-circuits on length mismatch and on the first differing character, which on a network-facing endpoint is a prefix-timing oracle for the admin password. Every other credential compare in this repo already uses `timingSafeEqual` — the seed branch was the one remaining exception.

### After

- New `safeEqualUtf8` helper at module scope: length check → `timingSafeEqual` on UTF-8 buffers. Same idiom the rest of the repo uses.
- Wrong-password behaviour is unchanged: still 401, still no seed, still routed through the per-route `@fastify/rate-limit` at 5/min/IP by default.
- Combined with PR #108 (#87: trustProxy CIDR allow-list, already merged) the per-IP bucket binds to the real socket peer, so the rate limit is now an actual throttle rather than a spoofable fiction.

Out of scope (and intentionally so): the audit's optional \"bootstrap virtual account\" lockout table and the \"eliminate the seed branch entirely\" alternative. Both are larger design shifts and aren't needed for this hotfix — the constant-time compare plus the now-trustworthy per-IP rate-limit is enough.

### Regression coverage

Two new cases in [apps/server/test/admin-first-login.e2e.test.ts](apps/server/test/admin-first-login.e2e.test.ts):

1. **Same-length wrong password → 401 + no seed.** Guards correctness of the new compare. The test specifically chooses a wrong password of identical length to confirm the code doesn't fall back to length-only rejection.
2. **Brute-force throttle.** With `adminLoginRatePerMinute=3`, six wrong logins from one peer return `401, 401, 401, 429, 429, ...` — pins the per-route rate-limit contract so a future refactor can't silently drop the `config.rateLimit` block.

Timing measurements themselves are deliberately **not** asserted — they're notoriously flaky in CI. `timingSafeEqual`'s constant-time property is Node's contract; repeating its internal test here would be redundant.

## Test plan

- [x] `pnpm --filter @faucet/server build` — clean
- [x] `pnpm --filter @faucet/server test` — 82/82 (80 existing + 2 new)

## Closes

- Closes #89 (audit finding #003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)