### PR TITLE
fix(server): session-bound MCP admin auth + deprecate static token (closes #88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,13 @@ FAUCET_ADMIN_PASSWORD=change-me-at-least-8-chars
 # FAUCET_ADMIN_SESSION_TTL_MS=28800000         # 8h default session cookie lifetime
 # FAUCET_ADMIN_TOTP_STEP_UP_TTL_MS=120000      # 2m default sensitive-action TOTP re-auth window
 # FAUCET_KEYRING_PATH=/data/faucet.key         # XChaCha20-Poly1305 encrypted key blob (argon2id/scrypt KDF)
+# Admin MCP auth. The preferred path is an admin session cookie obtained from
+# /admin/auth/login plus a TOTP step-up (X-Faucet-Totp header on the MCP
+# request). The legacy static bearer path is still honoured for one minor;
+# set FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=false once your clients have
+# migrated to sessions.
+# FAUCET_ADMIN_MCP_TOKEN=replace-with-a-strong-random-token
+# FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=true
 
 # --- Integrator keys (server-to-server HMAC) ---
 # Comma-separated "<id>:<apiKey>:<hmacSecret>" triples.

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -80,6 +80,15 @@ export const ServerConfigSchema = z.object({
 
   adminPassword: z.string().min(8).optional(),
   adminTotpSecret: z.string().optional(),
+  /** Static bearer-token fallback for admin MCP tools. DEPRECATED in favour
+   *  of the admin-session path (#88). Kept so existing operator deployments
+   *  don't break when they bump through this version. */
+  adminMcpToken: z.string().optional(),
+  /** When false, the static `adminMcpToken` is ignored and the only way to
+   *  invoke admin MCP tools is a valid admin session cookie + TOTP step-up.
+   *  Default `true` for one minor so current deployments keep working; flip
+   *  to `false` once you've migrated to the session path. */
+  adminMcpAllowStaticToken: z.coerce.boolean().default(true),
   adminSessionTtlMs: z.coerce.number().int().min(60_000).default(8 * 60 * 60_000),
   adminTotpStepUpTtlMs: z.coerce.number().int().min(30_000).default(2 * 60_000),
   adminLoginRatePerMinute: z.coerce.number().int().min(1).default(5),
@@ -204,6 +213,8 @@ const ENV_KEYS: Record<string, string> = {
   aiReviewThreshold: 'FAUCET_AI_REVIEW_THRESHOLD',
   adminPassword: 'FAUCET_ADMIN_PASSWORD',
   adminTotpSecret: 'FAUCET_ADMIN_TOTP_SECRET',
+  adminMcpToken: 'FAUCET_ADMIN_MCP_TOKEN',
+  adminMcpAllowStaticToken: 'FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN',
   adminSessionTtlMs: 'FAUCET_ADMIN_SESSION_TTL_MS',
   adminTotpStepUpTtlMs: 'FAUCET_ADMIN_TOTP_STEP_UP_TTL_MS',
   adminLoginRatePerMinute: 'FAUCET_ADMIN_LOGIN_RATE_PER_MINUTE',

--- a/apps/server/src/mcp/index.ts
+++ b/apps/server/src/mcp/index.ts
@@ -5,21 +5,101 @@
  *   - `POST /mcp` — streamable HTTP transport (JSON-RPC over HTTP/SSE).
  *   - `GET  /mcp` — lightweight discovery: name, version, tool catalogue.
  *
- * Admin authentication is a stub: reads `x-faucet-admin-token` and compares
- * timing-safely to `FAUCET_ADMIN_MCP_TOKEN`. The real admin-session flow is
- * M3; see `apps/server/src/mcp/server.ts`.
+ * Admin authentication (two paths, tried in order):
+ *
+ *   1. **Admin session + TOTP step-up** (preferred, #88). Client sends the
+ *      `faucet_session` cookie obtained from `/admin/auth/login`. Session
+ *      must have a TOTP step-up within `adminTotpStepUpTtlMs`.
+ *   2. **Static `FAUCET_ADMIN_MCP_TOKEN`** (deprecated fallback). Sent via
+ *      the `x-faucet-admin-token` header. Only honoured when
+ *      `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=true`. Kept so existing
+ *      deployments don't break when bumping to this version; operators
+ *      should migrate to the session path and flip the flag to `false`.
+ *
+ * Per-request rate-limit: `adminLoginRatePerMinute` / minute / IP (same
+ * bucket as `/admin/auth/login`). Every admin tool call is written to the
+ * audit log naming the resolved principal (`session:<userId>` or
+ * `static-token`). Public tools are unauthenticated and unaudited.
  */
+import { timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { eq } from 'drizzle-orm';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { AppContext } from '../context.js';
-import { ALL_TOOLS, ADMIN_TOOLS, buildMcpServer } from './server.js';
+import { adminUsers } from '../db/schema.js';
+import {
+  ADMIN_SESSION_COOKIE,
+  ADMIN_TOTP_HEADER,
+} from '../auth/middleware.js';
+import { validateSession, verifyTotp, markSessionTotpStepUp } from '../auth/session.js';
+import { ALL_TOOLS, ADMIN_TOOLS, buildMcpServer, type AdminPrincipal } from './server.js';
 
-/** Header used to pass the stub admin token. */
+/** Header used to pass the deprecated static admin token. */
 export const ADMIN_TOKEN_HEADER = 'x-faucet-admin-token';
 
-export async function mcpRoute(app: FastifyInstance, ctx: AppContext): Promise<void> {
-  const configuredAdminToken = process.env.FAUCET_ADMIN_MCP_TOKEN;
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
 
+/**
+ * Resolve the admin principal for an MCP request, if any. Tries session
+ * first, falls back to the deprecated static token. Returns `null` when no
+ * admin auth was presented / verified — admin tool calls then fail at the
+ * per-tool guard in {@link buildMcpServer}.
+ *
+ * Exported for unit testing. The transport plumbing around it is thin.
+ */
+export async function resolveAdminPrincipal(
+  ctx: AppContext,
+  req: FastifyRequest,
+): Promise<AdminPrincipal | null> {
+  const cookies = (req as FastifyRequest & { cookies?: Record<string, string | undefined> })
+    .cookies;
+  const sessionToken = cookies?.[ADMIN_SESSION_COOKIE];
+  if (sessionToken) {
+    const session = await validateSession(ctx.db, sessionToken);
+    if (session) {
+      // Require a fresh TOTP step-up either on the session row or supplied
+      // as `x-faucet-totp` in this request, matching the /admin/* policy.
+      const stepUpTtlMs = ctx.config.adminTotpStepUpTtlMs;
+      const now = Date.now();
+      const recent =
+        session.totpStepUpAt && now - session.totpStepUpAt.getTime() <= stepUpTtlMs;
+      if (recent) {
+        return { kind: 'session', userId: session.userId };
+      }
+      const header = req.headers[ADMIN_TOTP_HEADER];
+      const code = Array.isArray(header) ? header[0] : header;
+      if (code && typeof code === 'string') {
+        const [user] = await ctx.db
+          .select()
+          .from(adminUsers)
+          .where(eq(adminUsers.id, session.userId))
+          .limit(1);
+        if (user?.totpSecret && verifyTotp(user.totpSecret, code)) {
+          await markSessionTotpStepUp(ctx.db, sessionToken);
+          return { kind: 'session', userId: session.userId };
+        }
+      }
+      // Session present but no valid step-up → intentionally falls through
+      // to the static-token path (or denial) rather than auto-accepting.
+    }
+  }
+
+  if (ctx.config.adminMcpAllowStaticToken && ctx.config.adminMcpToken) {
+    const headerValue = req.headers[ADMIN_TOKEN_HEADER];
+    const provided = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    if (provided && constantTimeEqual(provided, ctx.config.adminMcpToken)) {
+      return { kind: 'static-token' };
+    }
+  }
+  return null;
+}
+
+export async function mcpRoute(app: FastifyInstance, ctx: AppContext): Promise<void> {
   app.get('/mcp', async () => ({
     name: 'nimiq-faucet',
     version: '0.0.1',
@@ -30,36 +110,39 @@ export async function mcpRoute(app: FastifyInstance, ctx: AppContext): Promise<v
     })),
   }));
 
-  app.post('/mcp', async (req: FastifyRequest, reply: FastifyReply) => {
-    const headerValue = req.headers[ADMIN_TOKEN_HEADER];
-    const providedAdminToken = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  app.post(
+    '/mcp',
+    {
+      config: {
+        rateLimit: { max: ctx.config.adminLoginRatePerMinute, timeWindow: '1 minute' },
+      },
+    },
+    async (req: FastifyRequest, reply: FastifyReply) => {
+      const principal = await resolveAdminPrincipal(ctx, req);
 
-    const server = buildMcpServer(ctx, {
-      getAdminToken: () => providedAdminToken,
-      ...(configuredAdminToken !== undefined ? { configuredAdminToken } : {}),
-    });
+      const server = buildMcpServer(ctx, {
+        getAdminPrincipal: () => principal,
+      });
 
-    // Stateless: one transport per request, no session IDs. The SDK's type
-    // signature marks `sessionIdGenerator` as `() => string`, but the runtime
-    // treats `undefined` as the stateless sentinel — see the SDK JSDoc.
-    const transport = new StreamableHTTPServerTransport(
-      { sessionIdGenerator: undefined } as unknown as ConstructorParameters<
-        typeof StreamableHTTPServerTransport
-      >[0],
-    );
+      // Stateless: one transport per request, no session IDs. The SDK's type
+      // signature marks `sessionIdGenerator` as `() => string`, but the runtime
+      // treats `undefined` as the stateless sentinel — see the SDK JSDoc.
+      const transport = new StreamableHTTPServerTransport(
+        { sessionIdGenerator: undefined } as unknown as ConstructorParameters<
+          typeof StreamableHTTPServerTransport
+        >[0],
+      );
 
-    reply.raw.on('close', () => {
-      void transport.close();
-      void server.close();
-    });
+      reply.raw.on('close', () => {
+        void transport.close();
+        void server.close();
+      });
 
-    // Hand the raw socket to the MCP transport. Fastify must not try to
-    // serialize a response on top of it.
-    reply.hijack();
-    // The transport's optional-property variance conflicts with
-    // `exactOptionalPropertyTypes` on the SDK's `Transport` interface; the
-    // cast is safe because the same SDK package produces both sides.
-    await server.connect(transport as unknown as Parameters<typeof server.connect>[0]);
-    await transport.handleRequest(req.raw, reply.raw, req.body);
-  });
+      // Hand the raw socket to the MCP transport. Fastify must not try to
+      // serialize a response on top of it.
+      reply.hijack();
+      await server.connect(transport as unknown as Parameters<typeof server.connect>[0]);
+      await transport.handleRequest(req.raw, reply.raw, req.body);
+    },
+  );
 }

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -1,21 +1,24 @@
 /**
  * MCP server surface for the Nimiq Simple Faucet.
  *
- * Milestone M7.3. Public tools are unauthenticated; admin-scoped tools go
- * through {@link requireAdminToken}. The real admin-session integration lands
- * in M3 (see plan `/home/richy/.claude/plans/starry-roaming-bunny.md`).
- *
- * The admin guard currently accepts a single shared secret via
- * `FAUCET_ADMIN_MCP_TOKEN`. A future release will replace this with full
- * admin-session machinery (short-lived tokens, revocation, audit log).
+ * Public tools are unauthenticated; admin-scoped tools require an
+ * {@link AdminPrincipal} resolved upstream by `apps/server/src/mcp/index.ts`
+ * — either an admin-session + TOTP step-up (preferred) or the deprecated
+ * static `FAUCET_ADMIN_MCP_TOKEN`. Every admin tool call is written to the
+ * audit log naming the principal (#88).
  */
-import { timingSafeEqual } from 'node:crypto';
 import { desc, eq, and } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { blocklist, claims } from '../db/schema.js';
 import type { AppContext } from '../context.js';
+import { writeAudit } from '../auth/audit.js';
+
+/** Identifies who invoked an admin-scoped MCP tool. */
+export type AdminPrincipal =
+  | { kind: 'session'; userId: string }
+  | { kind: 'static-token' };
 
 /** Names of tools that require the admin token. */
 export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
@@ -50,34 +53,26 @@ export const ALL_TOOLS: readonly string[] = [
 const BLOCK_KINDS = ['ip', 'address', 'uid', 'asn', 'country'] as const;
 
 /**
- * Enforces the admin-token policy. Throws a plain `Error` so the SDK surfaces
- * it as a tool-call error to the client. Uses timing-safe comparison.
- *
- * NOTE: Uses a shared secret for now; will migrate to session-based auth.
+ * Enforces the admin-principal policy for a tool call. Throws a plain `Error`
+ * so the SDK surfaces it as a tool-call error to the client. The principal is
+ * resolved upstream by the transport; this is a pure guard.
  */
-export function requireAdminToken(
+export function requireAdminPrincipal(
   tools: ReadonlySet<string>,
   toolName: string,
-  providedToken: string | undefined,
-  configuredToken: string | undefined,
+  principal: AdminPrincipal | null,
 ): void {
   if (!tools.has(toolName)) return;
-  if (!configuredToken) {
-    throw new Error('Admin MCP not configured: set FAUCET_ADMIN_MCP_TOKEN');
-  }
-  if (!providedToken) throw new Error('Admin MCP token missing');
-  const a = Buffer.from(providedToken);
-  const b = Buffer.from(configuredToken);
-  if (a.length !== b.length || !timingSafeEqual(a, b)) {
-    throw new Error('Admin MCP token invalid');
-  }
+  if (!principal) throw new Error('Admin MCP auth required');
 }
 
 export interface BuildMcpServerOptions {
-  /** Resolves the per-request admin token from the incoming HTTP headers. */
-  getAdminToken?: () => string | undefined;
-  /** The configured admin token (typically `process.env.FAUCET_ADMIN_MCP_TOKEN`). */
-  configuredAdminToken?: string | undefined;
+  /** Resolves the authenticated admin principal (if any) for this request. */
+  getAdminPrincipal?: () => AdminPrincipal | null;
+}
+
+function principalLabel(p: AdminPrincipal): string {
+  return p.kind === 'session' ? `session:${p.userId}` : 'static-token';
 }
 
 /**
@@ -92,13 +87,17 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
     { capabilities: { tools: {}, resources: {} } },
   );
 
-  const guard = (toolName: string): void => {
-    requireAdminToken(
-      ADMIN_TOOLS,
-      toolName,
-      opts.getAdminToken?.(),
-      opts.configuredAdminToken,
-    );
+  const guard = async (toolName: string): Promise<void> => {
+    const principal = opts.getAdminPrincipal?.() ?? null;
+    requireAdminPrincipal(ADMIN_TOOLS, toolName, principal);
+    if (principal) {
+      await writeAudit(ctx.db, {
+        actor: principalLabel(principal),
+        action: `mcp.${toolName}`,
+        target: toolName,
+        signals: {},
+      });
+    }
   };
 
   const ok = (payload: unknown) => ({
@@ -202,7 +201,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       inputSchema: {},
     },
     async () => {
-      guard('faucet.balance');
+      await guard('faucet.balance');
       const balance = await ctx.driver.getBalance();
       return ok({ balanceLuna: balance.toString() });
     },
@@ -218,7 +217,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       },
     },
     async ({ to, amountLuna }) => {
-      guard('faucet.send');
+      await guard('faucet.send');
       const parsed = ctx.driver.parseAddress(to);
       const txId = await ctx.driver.send(parsed, BigInt(amountLuna));
       return ok({ txId, to: parsed, amountLuna });
@@ -237,7 +236,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       },
     },
     async ({ kind, value, reason, expiresAt }) => {
-      guard('faucet.block_address');
+      await guard('faucet.block_address');
       const id = nanoid();
       await ctx.db.insert(blocklist).values({
         id,
@@ -260,7 +259,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       },
     },
     async ({ kind, value }) => {
-      guard('faucet.unblock_address');
+      await guard('faucet.unblock_address');
       await ctx.db
         .delete(blocklist)
         .where(and(eq(blocklist.kind, kind), eq(blocklist.value, value)));
@@ -275,7 +274,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       inputSchema: { limit: z.number().int().min(1).max(1000).optional() },
     },
     async ({ limit }) => {
-      guard('faucet.list_blocks');
+      await guard('faucet.list_blocks');
       const rows = await ctx.db
         .select()
         .from(blocklist)
@@ -292,7 +291,7 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
       inputSchema: { claimId: z.string().min(1) },
     },
     async ({ claimId }) => {
-      guard('faucet.explain_decision');
+      await guard('faucet.explain_decision');
       const [row] = await ctx.db.select().from(claims).where(eq(claims.id, claimId)).limit(1);
       if (!row) return ok({ error: 'not found', claimId });
       return ok({

--- a/apps/server/test/mcp-auth.e2e.test.ts
+++ b/apps/server/test/mcp-auth.e2e.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression tests for #88: admin-scoped MCP tools must require either an
+ * admin session with a TOTP step-up, OR (deprecated fallback) a valid static
+ * FAUCET_ADMIN_MCP_TOKEN. With the static path disabled via
+ * FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=false, only the session path works.
+ *
+ * We test the auth resolver `resolveAdminPrincipal` directly rather than
+ * driving JSON-RPC tool calls through the HTTP transport. The resolver IS
+ * the security boundary; the MCP SDK's transport plumbing is out of scope
+ * for these tests. The existing mcp.e2e.test.ts already covers the per-tool
+ * guard (`requireAdminPrincipal`) and tool registration.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyRequest } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authenticator } from '@otplib/preset-default';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { resolveAdminPrincipal } from '../src/mcp/index.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const PASSWORD = 'test-password-123';
+
+class FakeDriver extends BaseTestDriver {
+  override async getBalance(): Promise<bigint> { return 42n; }
+  override async send(): Promise<string> { return 'tx_x'; }
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    adminPassword: PASSWORD,
+    dev: 'true',
+    ...overrides,
+  });
+}
+
+/**
+ * Build a minimal FastifyRequest-ish object carrying the cookies and headers
+ * the resolver actually consults. The resolver only reads `req.cookies` and
+ * `req.headers`, so a typed cast from this shape is safe.
+ */
+function mockReq(opts: {
+  sessionCookie?: string;
+  staticToken?: string;
+  totpCode?: string;
+}): FastifyRequest {
+  const cookies: Record<string, string> = {};
+  if (opts.sessionCookie) cookies.faucet_session = opts.sessionCookie;
+  const headers: Record<string, string> = {};
+  if (opts.staticToken) headers['x-faucet-admin-token'] = opts.staticToken;
+  if (opts.totpCode) headers['x-faucet-totp'] = opts.totpCode;
+  return { cookies, headers } as unknown as FastifyRequest;
+}
+
+/** Seed + step-up a session; return the session cookie + TOTP secret. */
+async function seedAndStepUp(app: Awaited<ReturnType<typeof buildApp>>['app']) {
+  const first = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: PASSWORD },
+    headers: { 'content-type': 'application/json' },
+  });
+  expect(first.statusCode).toBe(200);
+  const totpSecret = first.json().totpSecret as string;
+  const totp = authenticator.generate(totpSecret);
+  const second = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: PASSWORD, totp },
+    headers: { 'content-type': 'application/json' },
+  });
+  expect(second.statusCode).toBe(200);
+  const session = parseCookie(second.headers['set-cookie'], 'faucet_session');
+  return { session: session!, totpSecret };
+}
+
+describe('resolveAdminPrincipal (#88)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+  let ctxs: Array<Awaited<ReturnType<typeof buildApp>>['ctx']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-mcp-auth-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    ctxs = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns null when no auth is presented', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const principal = await resolveAdminPrincipal(built.ctx, mockReq({}));
+    expect(principal).toBeNull();
+  });
+
+  it('resolves a session principal when the session has a recent TOTP step-up', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const { session } = await seedAndStepUp(built.app);
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ sessionCookie: session }),
+    );
+    expect(principal).toEqual({ kind: 'session', userId: 'admin' });
+  });
+
+  it('returns null when a session exists but has no step-up and no TOTP header', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    // Seed-login only — leaves totpStepUpAt null on the session row.
+    const seed = await built.app.inject({
+      method: 'POST',
+      url: '/admin/auth/login',
+      payload: { password: PASSWORD },
+      headers: { 'content-type': 'application/json' },
+    });
+    const session = parseCookie(seed.headers['set-cookie'], 'faucet_session');
+    expect(session).toBeTruthy();
+
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ sessionCookie: session! }),
+    );
+    expect(principal).toBeNull();
+  });
+
+  it('accepts a live TOTP header as step-up when the session has none recorded yet', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    // Seed-login only — no second login, so totpStepUpAt is null. We pass a
+    // live TOTP code via header so the resolver records step-up on the fly.
+    const seed = await built.app.inject({
+      method: 'POST',
+      url: '/admin/auth/login',
+      payload: { password: PASSWORD },
+      headers: { 'content-type': 'application/json' },
+    });
+    const session = parseCookie(seed.headers['set-cookie'], 'faucet_session');
+    const totpSecret = seed.json().totpSecret as string;
+    const totp = authenticator.generate(totpSecret);
+
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ sessionCookie: session!, totpCode: totp }),
+    );
+    expect(principal).toEqual({ kind: 'session', userId: 'admin' });
+  });
+
+  it('accepts the static token when the allow-static flag is on', async () => {
+    const built = await buildApp(
+      baseConfig(tmp, { adminMcpToken: 'static-abc', adminMcpAllowStaticToken: true }),
+      { driverOverride: new FakeDriver(), quietLogs: true },
+    );
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ staticToken: 'static-abc' }),
+    );
+    expect(principal).toEqual({ kind: 'static-token' });
+  });
+
+  it('ignores the static token when the allow-static flag is off', async () => {
+    const built = await buildApp(
+      baseConfig(tmp, { adminMcpToken: 'static-abc', adminMcpAllowStaticToken: false }),
+      { driverOverride: new FakeDriver(), quietLogs: true },
+    );
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ staticToken: 'static-abc' }),
+    );
+    expect(principal).toBeNull();
+  });
+
+  it('rejects a wrong static token even with the flag on', async () => {
+    const built = await buildApp(
+      baseConfig(tmp, { adminMcpToken: 'right-abc', adminMcpAllowStaticToken: true }),
+      { driverOverride: new FakeDriver(), quietLogs: true },
+    );
+    apps.push(built.app);
+    ctxs.push(built.ctx);
+    await built.app.ready();
+
+    const principal = await resolveAdminPrincipal(
+      built.ctx,
+      mockReq({ staticToken: 'wrong-abc' }),
+    );
+    expect(principal).toBeNull();
+  });
+});

--- a/apps/server/test/mcp.e2e.test.ts
+++ b/apps/server/test/mcp.e2e.test.ts
@@ -9,7 +9,7 @@ import {
   ALL_TOOLS,
   PUBLIC_TOOLS,
   buildMcpServer,
-  requireAdminToken,
+  requireAdminPrincipal,
 } from '../src/mcp/server.js';
 import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
 
@@ -97,8 +97,7 @@ describe('MCP (/mcp)', () => {
    */
   it('buildMcpServer registers all 9 tools on a real McpServer instance', () => {
     const server = buildMcpServer(ctx, {
-      getAdminToken: () => undefined,
-      configuredAdminToken: ADMIN_TOKEN,
+      getAdminPrincipal: () => null,
     });
     // Read-only peek at the private tool registry to verify registration.
     const registered = (server as unknown as { _registeredTools: Record<string, unknown> })
@@ -108,30 +107,27 @@ describe('MCP (/mcp)', () => {
     }
   });
 
-  it('admin guard rejects calls when the token is missing or wrong', () => {
+  it('admin guard rejects calls when no principal is presented', () => {
     expect(() =>
-      requireAdminToken(ADMIN_TOOLS, 'faucet.balance', undefined, ADMIN_TOKEN),
-    ).toThrow(/missing/i);
-    expect(() =>
-      requireAdminToken(ADMIN_TOOLS, 'faucet.balance', 'nope', ADMIN_TOKEN),
-    ).toThrow(/invalid/i);
+      requireAdminPrincipal(ADMIN_TOOLS, 'faucet.balance', null),
+    ).toThrow(/admin mcp auth required/i);
   });
 
-  it('admin guard refuses all admin tools when FAUCET_ADMIN_MCP_TOKEN is unset', () => {
-    expect(() =>
-      requireAdminToken(ADMIN_TOOLS, 'faucet.balance', ADMIN_TOKEN, undefined),
-    ).toThrow(/not configured/i);
-  });
-
-  it('admin guard ignores public tools', () => {
+  it('admin guard ignores public tools regardless of principal presence', () => {
     for (const name of PUBLIC_TOOLS) {
-      expect(() => requireAdminToken(ADMIN_TOOLS, name, undefined, undefined)).not.toThrow();
+      expect(() => requireAdminPrincipal(ADMIN_TOOLS, name, null)).not.toThrow();
     }
   });
 
-  it('admin guard accepts the correct token (timing-safe)', () => {
+  it('admin guard accepts a session principal', () => {
     expect(() =>
-      requireAdminToken(ADMIN_TOOLS, 'faucet.balance', ADMIN_TOKEN, ADMIN_TOKEN),
+      requireAdminPrincipal(ADMIN_TOOLS, 'faucet.balance', { kind: 'session', userId: 'admin' }),
+    ).not.toThrow();
+  });
+
+  it('admin guard accepts the static-token principal', () => {
+    expect(() =>
+      requireAdminPrincipal(ADMIN_TOOLS, 'faucet.balance', { kind: 'static-token' }),
     ).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

Tranche 1 / 3 of 4 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #002 / issue #88.

### Before

`POST /mcp` authenticated admin-scoped tools (`faucet.send`, `faucet.balance`, `faucet.block_address`, `faucet.unblock_address`, `faucet.list_blocks`, `faucet.explain_decision`) only via the static env-var bearer `FAUCET_ADMIN_MCP_TOKEN` — no expiry, no rotation, no per-caller identity, no audit binding. The in-file comments at [apps/server/src/mcp/server.ts:5–10](apps/server/src/mcp/server.ts#L5) already acknowledged this as a deferred design.

### After

New auth resolver [`resolveAdminPrincipal`](apps/server/src/mcp/index.ts) tries two paths in order:

1. **Admin session + TOTP step-up (preferred).** The existing `faucet_session` cookie is validated against `adminSessions`; either a recorded `totpStepUpAt` within `adminTotpStepUpTtlMs` is accepted, or an `X-Faucet-Totp` header is verified live (and the step-up recorded on the session row).
2. **Static `FAUCET_ADMIN_MCP_TOKEN` (deprecated).** Honoured only when the new `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN` flag is `true` (default `true` for one minor so operators aren't surprised; flip to `false` once you've migrated). Compared via `timingSafeEqual`.

The resolved principal is plumbed into `buildMcpServer` via `getAdminPrincipal`. The per-tool guard `requireAdminPrincipal` (renamed from `requireAdminToken`) rejects when null. Every admin tool invocation now writes an audit-log row naming the principal (`session:<userId>` or `static-token`).

Other hardening:

- `POST /mcp` gets per-route `@fastify/rate-limit` config (`adminLoginRatePerMinute` / minute / IP) matching `/admin/auth/login`. Combined with PR #108 (#87 — CIDR-scoped `trustProxy`) the bucket now binds to the real socket peer.
- `.env.example` documents `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN` and the migration path.

### Out of scope

Changing the session cookie's `Path` from `/admin` to `/` so browsers auto-send it to `/mcp` — that's a dashboard UX change (would require an in-dashboard MCP client), not security. Operators using MCP today use the static token; operators using the SDK / scripts pass the cookie explicitly.

### Regression coverage

- **Rewritten** [apps/server/test/mcp.e2e.test.ts](apps/server/test/mcp.e2e.test.ts) — the four `requireAdminToken` unit cases now exercise the new `requireAdminPrincipal` shape (null → throw, session principal → ok, static-token principal → ok, public tools always ok).
- **New** [apps/server/test/mcp-auth.e2e.test.ts](apps/server/test/mcp-auth.e2e.test.ts) — 7 cases on the resolver directly: no auth, session + recorded step-up, session without step-up + no header, session + live TOTP header, static token allow=on, static token allow=off, wrong static token. The resolver is the security boundary; transport plumbing is out of scope.

## Test plan

- [x] `pnpm --filter @faucet/server build` — clean
- [x] `pnpm --filter @faucet/server test` — 89/89

## Closes

- Closes #88 (audit finding #002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)