### PR TITLE
fix(abuse): captcha timeout + per-check pipeline error boundary (closes #91)

### DIFF
--- a/apps/server/src/abuse/turnstile.ts
+++ b/apps/server/src/abuse/turnstile.ts
@@ -4,7 +4,12 @@ import type { AbuseCheck, CheckResult } from '@faucet/core';
 export interface TurnstileCheckConfig {
   secret: string;
   verifyUrl?: string;
+  /** Per-call timeout in ms (default 3000). Bounds the worker hold during a
+   *  Cloudflare-side outage so a slow upstream can't pin Fastify workers. */
+  timeoutMs?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 3000;
 
 export function turnstileCheck(config: TurnstileCheckConfig): AbuseCheck {
   const verifyUrl = config.verifyUrl ?? 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
@@ -26,17 +31,37 @@ export function turnstileCheck(config: TurnstileCheckConfig): AbuseCheck {
         response: req.captchaToken,
         remoteip: req.ip,
       });
-      const res = await request(verifyUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/x-www-form-urlencoded' },
-        body: form.toString(),
-      });
-      const body = (await res.body.json()) as {
+      const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      let body: {
         success: boolean;
         'error-codes'?: string[];
         action?: string;
         cdata?: string;
       };
+      try {
+        const res = await request(verifyUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: form.toString(),
+          headersTimeout: timeoutMs,
+          bodyTimeout: timeoutMs,
+        });
+        body = (await res.body.json()) as {
+          success: boolean;
+          'error-codes'?: string[];
+          action?: string;
+          cdata?: string;
+        };
+      } catch (err) {
+        // Fail closed on provider timeout / network / parse errors (#91).
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          score: 1,
+          decision: 'deny',
+          reason: 'captcha provider error',
+          signals: { provided: true, error: message },
+        };
+      }
       if (!body.success) {
         return {
           score: 1,

--- a/packages/abuse-fcaptcha/src/index.ts
+++ b/packages/abuse-fcaptcha/src/index.ts
@@ -6,7 +6,11 @@ export interface FCaptchaCheckConfig {
   secret: string;
   /** Base URL of the FCaptcha service (e.g. http://fcaptcha:3000). */
   serverUrl: string;
+  /** Per-call timeout in ms (default 3000). */
+  timeoutMs?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 3000;
 
 interface FCaptchaVerifyResponse {
   valid: boolean;
@@ -31,12 +35,27 @@ export function fcaptchaCheck(config: FCaptchaCheckConfig): AbuseCheck {
           signals: { provided: false },
         };
       }
-      const res = await request(verifyUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ token: req.captchaToken, secret: config.secret }),
-      });
-      const body = (await res.body.json()) as FCaptchaVerifyResponse;
+      const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      let body: FCaptchaVerifyResponse;
+      try {
+        const res = await request(verifyUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ token: req.captchaToken, secret: config.secret }),
+          headersTimeout: timeoutMs,
+          bodyTimeout: timeoutMs,
+        });
+        body = (await res.body.json()) as FCaptchaVerifyResponse;
+      } catch (err) {
+        // Fail closed on provider timeout/network/parse errors (#91).
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          score: 1,
+          decision: 'deny',
+          reason: 'captcha provider error',
+          signals: { provided: true, error: message },
+        };
+      }
       if (!body.valid) {
         return {
           score: 1,

--- a/packages/abuse-fcaptcha/test/check.test.ts
+++ b/packages/abuse-fcaptcha/test/check.test.ts
@@ -101,6 +101,21 @@ describe('fcaptchaCheck', () => {
     expect(r.score).toBe(0);
   });
 
+  it('fails closed on upstream network errors with reason "captcha provider error" (#91)', async () => {
+    mockAgent
+      .get(SERVER_URL)
+      .intercept({ path: '/api/token/verify', method: 'POST' })
+      .replyWithError(new Error('socket hang up'));
+
+    const check = fcaptchaCheck({ secret: 's', serverUrl: SERVER_URL });
+    const r = await check.check(req('any-token'));
+    expect(r.decision).toBe('deny');
+    expect(r.score).toBe(1);
+    expect(r.reason).toBe('captcha provider error');
+    expect(r.signals.provided).toBe(true);
+    expect(typeof r.signals.error).toBe('string');
+  });
+
   it('POSTs the expected JSON body', async () => {
     let captured: string | undefined;
     mockAgent

--- a/packages/abuse-hcaptcha/src/index.ts
+++ b/packages/abuse-hcaptcha/src/index.ts
@@ -4,7 +4,13 @@ import type { AbuseCheck, CheckResult } from '@faucet/core';
 export interface HCaptchaCheckConfig {
   secret: string;
   verifyUrl?: string;
+  /** Per-call timeout in ms (default 3000). Bounds the worker hold during a
+   *  provider outage so a single slow upstream can't pin Fastify workers. */
+  timeoutMs?: number;
 }
+
+/** Default timeout for the upstream verify call. */
+const DEFAULT_TIMEOUT_MS = 3000;
 
 interface HCaptchaResponse {
   success: boolean;
@@ -34,12 +40,32 @@ export function hcaptchaCheck(config: HCaptchaCheckConfig): AbuseCheck {
         response: req.captchaToken,
         remoteip: req.ip,
       });
-      const res = await request(verifyUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/x-www-form-urlencoded' },
-        body: form.toString(),
-      });
-      const body = (await res.body.json()) as HCaptchaResponse;
+      const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      let body: HCaptchaResponse;
+      try {
+        const res = await request(verifyUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: form.toString(),
+          headersTimeout: timeoutMs,
+          bodyTimeout: timeoutMs,
+        });
+        body = (await res.body.json()) as HCaptchaResponse;
+      } catch (err) {
+        // Provider timeout, network error, or unparseable JSON. Fail closed
+        // (deny) so the claim doesn't leak funds, but surface the error in
+        // signals so operators can see degradation in the audit drawer.
+        // Critically, deny runs the normal cleanup path (IP counter
+        // decrement, rejection row) instead of throwing through to a 500
+        // that would burn the caller's daily quota (#91).
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          score: 1,
+          decision: 'deny',
+          reason: 'captcha provider error',
+          signals: { provided: true, error: message },
+        };
+      }
       if (!body.success) {
         return {
           score: 1,

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -34,7 +34,29 @@ export class AbusePipeline {
     let hardDecision: Decision | undefined;
 
     for (const c of this.checks) {
-      const result = await c.check(req);
+      let result;
+      try {
+        result = await c.check(req);
+      } catch (err) {
+        // Per-check error boundary (#91). A check that throws (e.g. captcha
+        // provider timeout, network error, JSON parse failure) must not
+        // 500 the whole pipeline. Treat it as a hard `deny` keyed off the
+        // check id so the calling route runs its normal deny cleanup
+        // (decrement IP counter, write rejection row) instead of leaking
+        // an exception out and burning IP quota.
+        const message = err instanceof Error ? err.message : String(err);
+        const entry: PipelineResult['perCheck'][number] = {
+          id: c.id,
+          score: 1,
+          signals: { error: message },
+          decision: 'deny',
+        };
+        perCheck.push(entry);
+        signals[c.id] = entry.signals;
+        reasons.push(`${c.id}: error`);
+        hardDecision = 'deny';
+        break;
+      }
       const entry: PipelineResult['perCheck'][number] = {
         id: c.id,
         score: result.score,

--- a/packages/core/test/pipeline.test.ts
+++ b/packages/core/test/pipeline.test.ts
@@ -64,4 +64,28 @@ describe('AbusePipeline', () => {
     const rLight = await pLight.evaluate(makeRequest());
     expect(rHeavy.score).toBeGreaterThan(rLight.score);
   });
+
+  it('treats a thrown check as a hard deny (#91 error boundary)', async () => {
+    // A check that throws (e.g. captcha provider timeout) must not 500 the
+    // pipeline. The boundary records it as deny so the calling route runs
+    // its normal cleanup (decrement counter, write rejection row) instead
+    // of leaking the exception out.
+    const exploder: AbuseCheck = {
+      id: 'flaky-provider',
+      async check() {
+        throw new Error('upstream timeout');
+      },
+    };
+    const p = new AbusePipeline([alwaysClean, exploder, alwaysClean]);
+    const r = await p.evaluate(makeRequest());
+    expect(r.decision).toBe('deny');
+    expect(r.perCheck.find((c) => c.id === 'flaky-provider')).toMatchObject({
+      score: 1,
+      decision: 'deny',
+      signals: { error: 'upstream timeout' },
+    });
+    expect(r.reasons.some((s) => s.startsWith('flaky-provider'))).toBe(true);
+    // Short-circuits — the trailing clean check should not have run.
+    expect(r.perCheck.map((c) => c.id)).toEqual(['clean', 'flaky-provider']);
+  });
 });


### PR DESCRIPTION
## Summary

Tranche 2 / 1 of 8 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #005 / issue #91.

### Before

The three captcha drivers (hCaptcha, Turnstile, FCaptcha) wrapped no try/catch around the upstream `request()` call and configured no timeout. `AbusePipeline.evaluate()` likewise had no per-check error boundary.

A captcha provider outage (or a malformed response crashing `.body.json()`) propagated as a 500 — and because the claim route increments `ipCounters` BEFORE the pipeline runs (TOCTOU fix #52), the cleanup that decrements on deny/review was skipped on the exception path. Net effect: a legitimate caller's daily quota was permanently burned by every 500.

### After

Three coordinated changes:

1. **Per-driver timeout.** All three captcha drivers pass undici `headersTimeout`/`bodyTimeout` = `3000 ms` (configurable via `timeoutMs` on each driver's config). A slow upstream can no longer pin a Fastify worker for the ~2 min socket default.
2. **Per-driver try/catch.** On timeout, network error, or unparseable JSON, the driver returns:
   ```ts
   { score: 1, decision: 'deny', reason: 'captcha provider error',
     signals: { provided: true, error } }
   ```
   Same fail-closed posture, but routed through the existing deny path so the route's normal cleanup runs.
3. **Pipeline-level boundary.** [packages/core/src/pipeline.ts](packages/core/src/pipeline.ts)'s `evaluate()` now wraps each `await c.check(req)` in try/catch. Any thrown error is converted to a synthetic deny entry keyed off the check id, with the error message captured in `signals.error`, and short-circuits the pipeline the same way a regular deny does.

### Regression coverage

- [packages/core/test/pipeline.test.ts](packages/core/test/pipeline.test.ts) — new "thrown check → hard deny" case asserting the synthetic-deny shape, that `reasons[]` carries the check id, and that the trailing clean check did NOT run.
- [packages/abuse-fcaptcha/test/check.test.ts](packages/abuse-fcaptcha/test/check.test.ts) — new "fails closed on upstream network errors" case using `undici` `MockAgent`'s `replyWithError`; asserts `decision='deny'`, `reason='captcha provider error'`, `signals.provided=true`, `signals.error` is a string.

The same try/catch shape is applied to hCaptcha and Turnstile drivers; their existing tests still pass.

## Test plan

- [x] `pnpm --filter @faucet/core test` — 8/8 (was 7, +1)
- [x] `pnpm --filter @faucet/abuse-fcaptcha test` — 8/8 (was 7, +1)
- [x] `pnpm --filter @faucet/server test` — 89/89 (unchanged)
- [x] `pnpm -r build` — clean

## Closes

- Closes #91 (audit finding #005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)