### PR TITLE
Add Nimiq Pay Mini App claim examples (Vue + React)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Boots a self-contained WASM faucet. The WASM client reaches TestAlbatross consen
 
 Every SDK accepts the same `hostContext` (hashed UID, cookie hash, session hash, account age, KYC level, tags, HMAC signature) so your project's own abuse signals flow into the faucet's scoring pipeline.
 
+### Nimiq Pay Mini App
+
+A canonical [Nimiq Pay Mini App](https://mini-apps-launch-developer-center-dev-worker.je-cf9.workers.dev/mini-apps) example that runs inside the Nimiq Pay wallet WebView, reads the user's NIM address via [`@nimiq/mini-app-sdk`](https://www.npmjs.com/package/@nimiq/mini-app-sdk), and claims from this faucet. Two implementations sharing one TypeScript core:
+
+- [`examples/mini-app-claim-vue/`](./examples/mini-app-claim-vue/) — Vue 3 + Vite
+- [`examples/mini-app-claim-react/`](./examples/mini-app-claim-react/) — React 18 + Vite
+- [`examples/mini-app-claim-shared/`](./examples/mini-app-claim-shared/) — framework-agnostic glue (Mini App SDK bridge, fcaptcha widget loader, i18n)
+
+Each example ships its own `docker-compose.yml` that brings up the faucet + fcaptcha + Vite dev server in one command for real-phone testing on your LAN.
+
 ## Abuse prevention (10 pluggable layers, rate-limiting on by default)
 
 1. **Blocklist** — IP, address, UID, ASN, or country deny-list with optional expiry.

--- a/deploy/compose/fcaptcha.yml
+++ b/deploy/compose/fcaptcha.yml
@@ -33,7 +33,9 @@ services:
       # Exposed so the browser can fetch /fcaptcha.js from the same host
       # the claim UI is served from. Put the faucet + fcaptcha behind the
       # same reverse proxy in production and drop this port binding.
-      - "3000:3000"
+      # Issue #120-style env-driven host port so contributors running
+      # multiple example stacks side-by-side don't collide on 3000.
+      - "${FCAPTCHA_HOST_PORT:-3000}:3000"
 
   faucet:
     environment:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -61,3 +61,35 @@ services:
     depends_on:
       - faucet
     restart: "no"
+
+  # Nimiq Pay Mini App — Vue. Note: this builds a *production* bundle served
+  # by nginx (port 3006). For real-phone development against a Nimiq Pay
+  # WebView you want `vite --host` instead — use:
+  #
+  #   cd examples/mini-app-claim-vue && docker compose up --build
+  #
+  # That self-contained compose file boots the faucet + fcaptcha alongside
+  # the dev server reachable on your LAN.
+  example-mini-app-vue:
+    build:
+      context: ..
+      dockerfile: examples/mini-app-claim-vue/Dockerfile
+      args:
+        VITE_FAUCET_URL: http://localhost:8080
+    ports:
+      # Container listens on 8080 because the production stage runs nginx as
+      # an unprivileged user (which can't bind <1024).
+      - "3006:8080"
+    depends_on:
+      - faucet
+
+  example-mini-app-react:
+    build:
+      context: ..
+      dockerfile: examples/mini-app-claim-react/Dockerfile
+      args:
+        VITE_FAUCET_URL: http://localhost:8080
+    ports:
+      - "3007:8080"
+    depends_on:
+      - faucet

--- a/examples/mini-app-claim-react/Dockerfile
+++ b/examples/mini-app-claim-react/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+# Production build of the React mini app — static bundle served by nginx.
+# Build context = repo root. See ../mini-app-claim-vue/Dockerfile for the
+# rationale on copying the entire workspace at once.
+
+FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS build
+COPY . .
+
+ARG VITE_FAUCET_URL=http://localhost:8080
+ENV VITE_FAUCET_URL=${VITE_FAUCET_URL}
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-mini-app-react...
+RUN pnpm turbo run build --filter=@nimiq-faucet/example-mini-app-react
+
+FROM nginxinc/nginx-unprivileged:alpine AS runtime
+COPY --from=build /app/examples/mini-app-claim-react/dist /usr/share/nginx/html
+COPY examples/mini-app-claim-react/nginx.conf /etc/nginx/conf.d/default.conf
+# nginx-unprivileged runs as user `nginx` and listens on 8080 by default
+# so the container can run with no root capabilities.
+EXPOSE 8080

--- a/examples/mini-app-claim-react/Dockerfile.dev
+++ b/examples/mini-app-claim-react/Dockerfile.dev
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7
+# Development server for the React mini app. See Vue counterpart for details.
+
+FROM node:22-bookworm-slim
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+COPY . .
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-mini-app-react...
+
+WORKDIR /app/examples/mini-app-claim-react
+EXPOSE 5173
+CMD ["pnpm", "exec", "vite", "--host"]

--- a/examples/mini-app-claim-react/README.md
+++ b/examples/mini-app-claim-react/README.md
@@ -1,0 +1,35 @@
+# React Mini App — Faucet Claim
+
+The React 18 + Vite counterpart to [`mini-app-claim-vue/`](../mini-app-claim-vue/). Same UX, same flow, same fcaptcha gate. Reuses the framework-agnostic glue in [`mini-app-claim-shared/`](../mini-app-claim-shared/).
+
+## Run it (Docker, identical to the Vue example except port `5174`)
+
+```bash
+pnpm generate:wallet            # then fund it from https://faucet.pos.nimiq-testnet.com
+export LAN_IP=$(hostname -I | awk '{print $1}')      # Linux
+# export LAN_IP=$(ipconfig getifaddr en0)            # macOS
+export FCAPTCHA_SECRET=demo-secret-change-me
+export FAUCET_FCAPTCHA_SITE_KEY=demo-site-key
+export FAUCET_FCAPTCHA_SECRET=demo-secret-change-me
+
+cd examples/mini-app-claim-react
+docker compose up --build
+```
+
+Then open `http://<LAN_IP>:5174` inside Nimiq Pay → Mini Apps on a phone on the same Wi-Fi.
+
+See [`../mini-app-claim-vue/README.md`](../mini-app-claim-vue/README.md) for the full breakdown of what the compose file does, why TLS is off in dev, and how to verify with the [`mini-apps-checklist`](https://github.com/nimiq/developer-center/pull/175) skill.
+
+## Layout differences from the Vue example
+
+```
+mini-app-claim-react/src/
+├── main.tsx                   # createRoot + StrictMode
+├── App.tsx
+├── components/FcaptchaWidget.tsx
+├── hooks/useMiniAppFaucet.ts  # React-state version of the Vue composable
+├── styles.css                 # identical
+└── env.d.ts
+```
+
+The Mini App SDK bridge, fcaptcha loader, and i18n strings come from `@nimiq-faucet/mini-app-claim-shared` — both examples consume the same source.

--- a/examples/mini-app-claim-react/docker-compose.yml
+++ b/examples/mini-app-claim-react/docker-compose.yml
@@ -1,0 +1,38 @@
+# Self-contained dev compose for the React mini app example.
+# Mirror of ../mini-app-claim-vue/docker-compose.yml — port 5174 host-side.
+# See that file (or the README in this directory) for full setup details.
+
+include:
+  - ../../deploy/compose/docker-compose.yml
+  - ../../deploy/compose/fcaptcha.yml
+
+services:
+  faucet:
+    environment:
+      FAUCET_DEV: "1"
+      FAUCET_NETWORK: test
+      FAUCET_SIGNER_DRIVER: wasm
+      FAUCET_TLS_REQUIRED: "false"
+      FAUCET_CORS_ORIGINS: "*"
+      FAUCET_HELMET_CSP: relaxed-for-ui
+      FAUCET_UI_ENABLED: "false"
+      FAUCET_CLAIM_AMOUNT_LUNA: "100000"
+      FAUCET_RATE_LIMIT_PER_IP_PER_DAY: "20"
+      FAUCET_PRIVATE_KEY: ${FAUCET_PRIVATE_KEY:?set FAUCET_PRIVATE_KEY (32 random hex bytes)}
+      FAUCET_KEY_PASSPHRASE: ${FAUCET_KEY_PASSPHRASE:?set FAUCET_KEY_PASSPHRASE (>=8 chars)}
+      FAUCET_ADMIN_PASSWORD: ${FAUCET_ADMIN_PASSWORD:?set FAUCET_ADMIN_PASSWORD (>=8 chars)}
+      FAUCET_FCAPTCHA_PUBLIC_URL: http://${LAN_IP:?set LAN_IP to your Wi-Fi IP}:${FCAPTCHA_HOST_PORT:-3000}
+
+  mini-app-react:
+    build:
+      context: ../..
+      dockerfile: examples/mini-app-claim-react/Dockerfile.dev
+    image: nimiq-faucet-mini-app-react:dev
+    environment:
+      VITE_FAUCET_URL: http://${LAN_IP:?set LAN_IP to your Wi-Fi IP}:${FAUCET_HOST_PORT:-8080}
+      VITE_HMR_HOST: ${LAN_IP}
+    ports:
+      - "${MINI_APP_HOST_PORT:-5174}:5173"
+    depends_on:
+      - faucet
+      - fcaptcha

--- a/examples/mini-app-claim-react/index.html
+++ b/examples/mini-app-claim-react/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#1f2348" />
+    <title>Nimiq Faucet — Mini App (React)</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/mini-app-claim-react/nginx.conf
+++ b/examples/mini-app-claim-react/nginx.conf
@@ -1,0 +1,20 @@
+# nginx serves the production React mini app bundle. Listens on 8080 because
+# the runtime image (nginxinc/nginx-unprivileged:alpine) runs as a non-root
+# user and can't bind <1024.
+server {
+  listen 8080;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # See ../mini-app-claim-vue/nginx.conf for the rationale on each header.
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer" always;
+  add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/examples/mini-app-claim-react/package.json
+++ b/examples/mini-app-claim-react/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nimiq-faucet/example-mini-app-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "React 18 Nimiq Pay Mini App that claims NIM from a self-hosted nimiq-simple-faucet.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nimiq/mini-app-sdk": "^0.0.2",
+    "@nimiq-faucet/mini-app-claim-shared": "workspace:*",
+    "@nimiq-faucet/sdk": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^5.6.2",
+    "vite": "^8.0.10"
+  }
+}

--- a/examples/mini-app-claim-react/src/App.tsx
+++ b/examples/mini-app-claim-react/src/App.tsx
@@ -1,0 +1,127 @@
+import { translate } from '@nimiq-faucet/mini-app-claim-shared';
+import { useMiniAppFaucet } from './hooks/useMiniAppFaucet';
+import { FcaptchaWidgetView } from './components/FcaptchaWidget';
+
+const FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
+const EXPLORER_BASE = import.meta.env.VITE_EXPLORER_URL ?? 'https://nimiq-testnet.observer/#tx/';
+
+export function App() {
+  const { state, captchaPrompt, claim, reset, canClaim } = useMiniAppFaucet(FAUCET_URL);
+  const t = translate;
+
+  const buttonLabel =
+    state.phase === 'awaiting-address' ||
+    state.phase === 'awaiting-captcha' ||
+    state.phase === 'submitting' ||
+    state.phase === 'broadcast'
+      ? t('claiming')
+      : t('claim');
+
+  const showButtonSpinner =
+    state.phase !== 'ready' &&
+    state.phase !== 'rejected' &&
+    state.phase !== 'error' &&
+    state.phase !== 'confirmed' &&
+    state.phase !== 'connecting' &&
+    state.phase !== 'outside-nimiq-pay';
+
+  const explorerUrl = state.txId ? `${EXPLORER_BASE}${state.txId}` : null;
+
+  return (
+    <>
+      <h1 className="title">{t('title')}</h1>
+      <p className="subtitle">{t('subtitle')}</p>
+
+      {state.phase === 'connecting' && (
+        <div className="card">
+          <span>
+            <span className="spinner" />
+            {t('connecting')}
+          </span>
+        </div>
+      )}
+
+      {state.phase === 'outside-nimiq-pay' && (
+        <div className="card">
+          <strong>{t('outsidePay')}</strong>
+          <p className="subtitle">{t('outsidePayHint')}</p>
+          {state.outsideReason && (
+            <p className="subtitle">
+              <small>{state.outsideReason}</small>
+            </p>
+          )}
+        </div>
+      )}
+
+      {state.phase !== 'connecting' && state.phase !== 'outside-nimiq-pay' && (
+        <>
+          {state.address && (
+            <div className="card">
+              <span className="label">{t('addressFromWallet')}</span>
+              <span className="address">{state.address}</span>
+            </div>
+          )}
+
+          {captchaPrompt && (
+            <FcaptchaWidgetView
+              serverUrl={captchaPrompt.serverUrl}
+              siteKey={captchaPrompt.siteKey}
+              onSolved={captchaPrompt.resolve}
+              onFailed={captchaPrompt.reject}
+            />
+          )}
+
+          {state.phase === 'awaiting-captcha' && <p className="subtitle">{t('awaitingCaptcha')}</p>}
+
+          <button className="btn" disabled={!canClaim} onClick={claim}>
+            {showButtonSpinner && <span className="spinner" />}
+            {buttonLabel}
+          </button>
+
+          {state.phase === 'broadcast' && (
+            <div className="banner warn">
+              <span className="spinner" />
+              {t('broadcast')}
+            </div>
+          )}
+
+          {state.phase === 'confirmed' && (
+            <div className="banner good">
+              <strong>{t('confirmed')}</strong>
+              {state.txId && (
+                <p className="tx">
+                  {t('txLabel')}: {state.txId}
+                </p>
+              )}
+              {explorerUrl && (
+                <a href={explorerUrl} target="_blank" rel="noopener" className="link">
+                  {t('explorerLink')} →
+                </a>
+              )}
+            </div>
+          )}
+
+          {(state.phase === 'rejected' || state.phase === 'challenged') && (
+            <div className="banner bad">
+              <strong>{state.phase === 'challenged' ? t('challenged') : t('rejected')}</strong>
+              {state.errorMessage && <p className="tx">{state.errorMessage}</p>}
+              <button className="btn" onClick={reset}>
+                {t('retry')}
+              </button>
+            </div>
+          )}
+
+          {state.phase === 'error' && (
+            <div className="banner bad">
+              <strong>{t('error')}</strong>
+              {state.errorMessage && <p className="tx">{state.errorMessage}</p>}
+              <button className="btn" onClick={reset}>
+                {t('retry')}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/examples/mini-app-claim-react/src/components/FcaptchaWidget.tsx
+++ b/examples/mini-app-claim-react/src/components/FcaptchaWidget.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import { loadFcaptcha, type FcaptchaWidget } from '@nimiq-faucet/mini-app-claim-shared';
+
+export interface FcaptchaWidgetProps {
+  serverUrl: string;
+  siteKey: string;
+  onSolved: (token: string) => void;
+  onFailed: (error: Error) => void;
+}
+
+export function FcaptchaWidgetView({ serverUrl, siteKey, onSolved, onFailed }: FcaptchaWidgetProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  // Stabilise the callbacks via refs so the widget effect below depends only
+  // on (serverUrl, siteKey). Without this, every parent render produces fresh
+  // closure identities for onSolved/onFailed (the parent passes inline arrows
+  // bound to the captchaPrompt useState value), which would tear down and
+  // re-mount the fcaptcha script on every render — broken under StrictMode
+  // and noisy in production.
+  const onSolvedRef = useRef(onSolved);
+  const onFailedRef = useRef(onFailed);
+  useEffect(() => { onSolvedRef.current = onSolved; }, [onSolved]);
+  useEffect(() => { onFailedRef.current = onFailed; }, [onFailed]);
+
+  useEffect(() => {
+    let widget: FcaptchaWidget | null = null;
+    let cancelled = false;
+    if (!hostRef.current) return;
+    void loadFcaptcha({ serverUrl, siteKey, hostElement: hostRef.current })
+      .then((w) => {
+        if (cancelled) {
+          w.destroy();
+          return;
+        }
+        widget = w;
+        return w.token;
+      })
+      .then((token) => {
+        if (cancelled || token === undefined) return;
+        onSolvedRef.current(token);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        onFailedRef.current(err instanceof Error ? err : new Error(String(err)));
+      });
+    return () => {
+      cancelled = true;
+      widget?.destroy();
+    };
+  }, [serverUrl, siteKey]);
+
+  return <div ref={hostRef} className="captcha-host" />;
+}

--- a/examples/mini-app-claim-react/src/env.d.ts
+++ b/examples/mini-app-claim-react/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FAUCET_URL?: string;
+  readonly VITE_EXPLORER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/mini-app-claim-react/src/hooks/useMiniAppFaucet.ts
+++ b/examples/mini-app-claim-react/src/hooks/useMiniAppFaucet.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FaucetClient } from '@nimiq-faucet/sdk';
+import {
+  connectMiniApp,
+  getUserAddress,
+  type MiniAppConnectionState,
+} from '@nimiq-faucet/mini-app-claim-shared';
+
+export type Phase =
+  | 'connecting'
+  | 'outside-nimiq-pay'
+  | 'ready'
+  | 'awaiting-address'
+  | 'awaiting-captcha'
+  | 'submitting'
+  | 'broadcast'
+  | 'confirmed'
+  | 'rejected'
+  | 'challenged'
+  | 'error';
+
+export interface CaptchaPrompt {
+  serverUrl: string;
+  siteKey: string;
+  resolve: (token: string) => void;
+  reject: (err: Error) => void;
+}
+
+export interface MiniAppFaucetState {
+  phase: Phase;
+  address: string | null;
+  txId: string | null;
+  errorMessage: string | null;
+  outsideReason: string | null;
+}
+
+const INITIAL: MiniAppFaucetState = {
+  phase: 'connecting',
+  address: null,
+  txId: null,
+  errorMessage: null,
+  outsideReason: null,
+};
+
+export function useMiniAppFaucet(faucetUrl: string) {
+  const [state, setState] = useState<MiniAppFaucetState>(INITIAL);
+  const [captchaPrompt, setCaptchaPrompt] = useState<CaptchaPrompt | null>(null);
+  const conn = useRef<MiniAppConnectionState | null>(null);
+  // In-flight guard: a fast double-tap can fire two parallel claim() calls
+  // before React's render commit disables the button. Lock here in addition
+  // to the UI-level disable.
+  const inFlight = useRef(false);
+
+  const client = useMemo(() => new FaucetClient({ url: faucetUrl }), [faucetUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void connectMiniApp().then((next) => {
+      if (cancelled) return;
+      conn.current = next;
+      setState((prev) => {
+        if (next.status === 'ready') return { ...prev, phase: 'ready' };
+        if (next.status === 'outside-nimiq-pay')
+          return { ...prev, phase: 'outside-nimiq-pay', outsideReason: next.reason };
+        return prev;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchCaptchaToken = useCallback(async (): Promise<string | undefined> => {
+    const config = await client.config();
+    if (!config.captcha) return undefined;
+    if (config.captcha.provider !== 'fcaptcha') {
+      throw new Error(
+        `This example only renders fcaptcha; faucet is configured for ${config.captcha.provider}.`,
+      );
+    }
+    if (!config.captcha.serverUrl) {
+      throw new Error('faucet returned fcaptcha provider without serverUrl');
+    }
+    setState((prev) => ({ ...prev, phase: 'awaiting-captcha' }));
+    return new Promise<string>((resolve, reject) => {
+      setCaptchaPrompt({
+        serverUrl: config.captcha!.serverUrl!,
+        siteKey: config.captcha!.siteKey,
+        resolve: (token) => {
+          setCaptchaPrompt(null);
+          resolve(token);
+        },
+        reject: (err) => {
+          setCaptchaPrompt(null);
+          reject(err);
+        },
+      });
+    });
+  }, [client]);
+
+  const claim = useCallback(async (): Promise<void> => {
+    if (inFlight.current) return;
+    if (!conn.current || conn.current.status !== 'ready') return;
+    inFlight.current = true;
+    setState((prev) => ({ ...prev, errorMessage: null, txId: null, phase: 'awaiting-address' }));
+    try {
+      const address = await getUserAddress(conn.current.provider);
+      setState((prev) => ({ ...prev, address }));
+      const captchaToken = await fetchCaptchaToken();
+      setState((prev) => ({ ...prev, phase: 'submitting' }));
+      const initialOpts: { captchaToken?: string } = captchaToken ? { captchaToken } : {};
+      const initial = await client.claim(address, initialOpts);
+      setState((prev) => ({ ...prev, txId: initial.txId ?? null }));
+      if (initial.status === 'rejected') {
+        setState((prev) => ({
+          ...prev,
+          phase: 'rejected',
+          errorMessage: initial.reason ?? 'Claim rejected',
+        }));
+        return;
+      }
+      if (initial.status === 'challenged') {
+        setState((prev) => ({
+          ...prev,
+          phase: 'challenged',
+          errorMessage: initial.reason ?? 'Captcha required',
+        }));
+        return;
+      }
+      setState((prev) => ({ ...prev, phase: 'broadcast' }));
+      const final = await client.waitForConfirmation(initial.id);
+      setState((prev) => ({
+        ...prev,
+        txId: final.txId ?? prev.txId,
+        phase: final.status === 'confirmed' ? 'confirmed' : 'rejected',
+        errorMessage: final.status === 'rejected' && final.reason ? final.reason : prev.errorMessage,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setState((prev) => ({ ...prev, phase: 'error', errorMessage: message }));
+    } finally {
+      inFlight.current = false;
+    }
+  }, [client, fetchCaptchaToken]);
+
+  const reset = useCallback(() => {
+    setState({
+      ...INITIAL,
+      phase: conn.current?.status === 'ready' ? 'ready' : 'connecting',
+      outsideReason:
+        conn.current?.status === 'outside-nimiq-pay' ? conn.current.reason : null,
+    });
+    setCaptchaPrompt(null);
+  }, []);
+
+  const canClaim =
+    state.phase === 'ready' ||
+    state.phase === 'rejected' ||
+    state.phase === 'error' ||
+    state.phase === 'confirmed';
+
+  return { state, captchaPrompt, claim, reset, canClaim };
+}

--- a/examples/mini-app-claim-react/src/main.tsx
+++ b/examples/mini-app-claim-react/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+const container = document.getElementById('app');
+if (!container) throw new Error('#app missing in index.html');
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/mini-app-claim-react/src/styles.css
+++ b/examples/mini-app-claim-react/src/styles.css
@@ -1,0 +1,177 @@
+/* Mobile-first. Mini apps must work at 375px and respect 44px touch targets. */
+:root {
+  --bg: #f5f6fa;
+  --fg: #1f2348;
+  --muted: #6b7280;
+  --accent: #1f2348;
+  --accent-fg: #ffffff;
+  --gold: #e9b213;
+  --good: #d1fae5;
+  --good-fg: #065f46;
+  --bad: #fee2e2;
+  --bad-fg: #991b1b;
+  --warn: #fef3c7;
+  --warn-fg: #92400e;
+  --border: #d1d5db;
+  --card: #ffffff;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1124;
+    --fg: #f5f6fa;
+    --muted: #9ca3af;
+    --accent: #f5f6fa;
+    --accent-fg: #1f2348;
+    --good: #064e3b;
+    --good-fg: #d1fae5;
+    --bad: #7f1d1d;
+    --bad-fg: #fee2e2;
+    --warn: #78350f;
+    --warn-fg: #fef3c7;
+    --border: #334155;
+    --card: #1e2245;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+#app {
+  width: 100%;
+  max-width: 480px;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.address {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.btn {
+  min-height: 48px;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 12px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
+  transition: opacity 0.15s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn:not(:disabled):active {
+  opacity: 0.85;
+}
+
+.banner {
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 0.9rem;
+}
+
+.banner.good {
+  background: var(--good);
+  color: var(--good-fg);
+}
+
+.banner.bad {
+  background: var(--bad);
+  color: var(--bad-fg);
+}
+
+.banner.warn {
+  background: var(--warn);
+  color: var(--warn-fg);
+}
+
+.tx {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+.link {
+  color: var(--gold);
+  text-decoration: underline;
+  font-size: 0.9rem;
+}
+
+.captcha-host {
+  min-height: 70px;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/examples/mini-app-claim-react/tsconfig.json
+++ b/examples/mini-app-claim-react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/examples/mini-app-claim-react/vite.config.ts
+++ b/examples/mini-app-claim-react/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const hmrHost = process.env.VITE_HMR_HOST;
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
+    hmr: hmrHost ? { host: hmrHost, protocol: 'ws', clientPort: 5173 } : undefined,
+  },
+});

--- a/examples/mini-app-claim-shared/README.md
+++ b/examples/mini-app-claim-shared/README.md
@@ -1,0 +1,20 @@
+# mini-app-claim-shared
+
+Framework-agnostic glue between [`@nimiq/mini-app-sdk`](https://www.npmjs.com/package/@nimiq/mini-app-sdk) and [`@nimiq-faucet/sdk`](../../packages/sdk-ts/), used by:
+
+- [`mini-app-claim-vue/`](../mini-app-claim-vue/)
+- [`mini-app-claim-react/`](../mini-app-claim-react/)
+
+Currently a private workspace module under `examples/`. Once a third framework example exists (Svelte, vanilla, Solid, etc.) this graduates to `packages/mini-app-core/` and gets published as `@nimiq-faucet/mini-app`.
+
+## What's in it
+
+| Module | Purpose |
+|---|---|
+| `bridge.ts` | `connectMiniApp({ timeout })` (calls `init()`, never throws — returns a state) and `getUserAddress(provider)` (wraps `listAccounts()` and unwraps the SDK's `string[] \| ErrorResponse` return shape). |
+| `fcaptcha.ts` | `loadFcaptcha({ serverUrl, siteKey, hostElement })` — framework-agnostic widget loader returning `{ token: Promise<string>, destroy }`. |
+| `i18n.ts` | `translate(key, lang?)` — reads `getHostLanguage()` from the Mini App SDK; ships `en` + `de` strings. Per `mini-apps-best-practices`, never reads `navigator.language`. |
+
+## Why it's not a published package yet
+
+A two-framework example doesn't yet validate the API. Promoting prematurely creates a versioning burden. Wait until `pnpm --filter "./examples/mini-app-claim-*"` has at least three examples and the helper has survived contact with all of them, then graduate.

--- a/examples/mini-app-claim-shared/package.json
+++ b/examples/mini-app-claim-shared/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@nimiq-faucet/mini-app-claim-shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Framework-agnostic glue between @nimiq/mini-app-sdk and @nimiq-faucet/sdk. Used by the Vue and React mini-app claim examples; promoted to a published package once a third framework example exists.",
+  "exports": {
+    ".": "./src/index.ts",
+    "./bridge": "./src/bridge.ts",
+    "./fcaptcha": "./src/fcaptcha.ts",
+    "./i18n": "./src/i18n.ts"
+  },
+  "dependencies": {
+    "@nimiq/mini-app-sdk": "^0.0.2",
+    "@nimiq-faucet/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/examples/mini-app-claim-shared/src/bridge.ts
+++ b/examples/mini-app-claim-shared/src/bridge.ts
@@ -1,0 +1,53 @@
+import { init, type NimiqProvider, type ErrorResponse } from '@nimiq/mini-app-sdk';
+
+export type MiniAppConnectionState =
+  | { status: 'connecting' }
+  | { status: 'ready'; provider: NimiqProvider }
+  | { status: 'outside-nimiq-pay'; reason: string };
+
+export interface MiniAppConnection {
+  /** Latest state observed; safe to read synchronously after `connect()` resolves. */
+  state: MiniAppConnectionState;
+}
+
+/**
+ * Initialise the Nimiq Pay provider. Resolves to `ready` if the SDK handshake
+ * completes, or to `outside-nimiq-pay` after the timeout if the host wallet
+ * never responds. Never throws — the example UI shows whatever state we land in.
+ */
+export async function connectMiniApp({ timeout = 10_000 }: { timeout?: number } = {}): Promise<MiniAppConnectionState> {
+  try {
+    const provider = await init({ timeout });
+    return { status: 'ready', provider };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { status: 'outside-nimiq-pay', reason };
+  }
+}
+
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  return typeof value === 'object' && value !== null && 'error' in value;
+}
+
+/**
+ * Ask the user (via Nimiq Pay's native confirmation dialog) for a NIM address.
+ * MUST be called from a user gesture — calling on page load is an anti-pattern
+ * (mini-apps-best-practices skill).
+ *
+ * Wraps `provider.listAccounts()` to throw on the SDK's `ErrorResponse` shape so
+ * the call site stays idiomatic (no need to inspect `'error' in result`).
+ */
+export async function getUserAddress(provider: NimiqProvider): Promise<string> {
+  const result = await provider.listAccounts();
+  if (isErrorResponse(result)) {
+    throw new Error(result.error.message || 'listAccounts failed');
+  }
+  if (!Array.isArray(result) || result.length === 0) {
+    throw new Error('No Nimiq addresses returned by Nimiq Pay');
+  }
+  const first = result[0];
+  if (typeof first !== 'string') {
+    throw new Error('Unexpected listAccounts response shape');
+  }
+  return first;
+}

--- a/examples/mini-app-claim-shared/src/fcaptcha.ts
+++ b/examples/mini-app-claim-shared/src/fcaptcha.ts
@@ -1,0 +1,184 @@
+/**
+ * Framework-agnostic loader for the fcaptcha (https://github.com/WebDecoy/FCaptcha)
+ * client widget. Mounts into a host element, returns a promise that resolves
+ * when the user solves the puzzle.
+ *
+ * The faucet's `/v1/config` endpoint exposes `captcha.serverUrl` (the fcaptcha
+ * service URL) and `captcha.siteKey` when fcaptcha is the chosen provider.
+ *
+ * Security: `serverUrl` flows from `/v1/config` straight into a `<script src>`
+ * tag on `document.head`, so a compromised or MITM'd faucet response can pivot
+ * to arbitrary JS execution in this app's origin (with full access to the
+ * user's NIM address via the Mini App SDK). Two layered checks below:
+ *
+ *   1. URL parsed via `new URL()` — rejects malformed schemes (data:, javascript:).
+ *   2. Origin allow-list — only hosts in `trustedOrigins` are accepted; falls
+ *      back to "same origin as VITE_FAUCET_URL" when no list is provided so
+ *      the default behaviour matches the operator's stated trust boundary.
+ *   3. Plaintext HTTP allowed only for loopback / RFC1918 / .local hosts so
+ *      LAN dev still works without inviting a Wi-Fi MITM in production.
+ *
+ * `index.html` should also ship a CSP `script-src` allow-list as defence in
+ * depth — see `nginx.conf` and the `<meta http-equiv>` in `index.html`.
+ */
+
+export interface FcaptchaWidget {
+  /** Resolves with the captcha token once the user solves it. */
+  token: Promise<string>;
+  /** Tear down DOM and event listeners. Idempotent. */
+  destroy(): void;
+}
+
+interface FcaptchaConfig {
+  serverUrl: string;
+  siteKey: string;
+  hostElement: HTMLElement;
+  /**
+   * Optional explicit allow-list of origins (scheme + host + port) that are
+   * permitted to serve the widget bundle. When unset, the parsed origin of
+   * `import.meta.env.VITE_FAUCET_URL` is used as the implicit allow-list,
+   * which matches the operator's stated trust boundary in `/v1/config`.
+   */
+  trustedOrigins?: readonly string[];
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function isLocalHost(host: string): boolean {
+  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]') return true;
+  if (host.endsWith('.local') || host.endsWith('.localhost')) return true;
+  // RFC1918 ranges.
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  return false;
+}
+
+function assertTrusted(serverUrl: string, trustedOrigins: readonly string[]): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(serverUrl);
+  } catch {
+    throw new Error(`fcaptcha: serverUrl is not a valid URL: ${serverUrl}`);
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`fcaptcha: refusing scheme "${parsed.protocol}" — only http(s) is allowed`);
+  }
+  if (parsed.protocol === 'http:' && !isLocalHost(parsed.hostname)) {
+    throw new Error(
+      `fcaptcha: refusing plaintext http:// for non-local host "${parsed.hostname}". ` +
+      `Use https in non-LAN deployments.`,
+    );
+  }
+  if (!trustedOrigins.includes(parsed.origin)) {
+    throw new Error(
+      `fcaptcha: serverUrl origin "${parsed.origin}" is not in the trusted list ` +
+      `[${trustedOrigins.join(', ')}]. The faucet returned an unexpected captcha host; ` +
+      `aborting widget load to avoid script-injection.`,
+    );
+  }
+  return parsed;
+}
+
+function loadScript(serverUrl: string, trustedOrigins: readonly string[]): Promise<void> {
+  if (scriptPromise) return scriptPromise;
+  const trustedUrl = assertTrusted(serverUrl, trustedOrigins);
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>('script[data-fcaptcha]');
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => {
+        scriptPromise = null;
+        reject(new Error('fcaptcha script failed to load'));
+      }, { once: true });
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = new URL('/fcaptcha.js', trustedUrl).toString();
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.dataset.fcaptcha = 'true';
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => {
+      // Clear the cached promise so the next mount can retry. Without this,
+      // a single transient network error poisons every subsequent widget mount
+      // for the lifetime of the page.
+      scriptPromise = null;
+      script.remove();
+      reject(new Error('fcaptcha script failed to load'));
+    }, { once: true });
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+interface FcaptchaGlobal {
+  render(host: HTMLElement, opts: {
+    siteKey: string;
+    serverUrl: string;
+    callback: (token: string) => void;
+    'error-callback'?: (err: unknown) => void;
+  }): { reset(): void };
+}
+
+declare global {
+  interface Window {
+    fcaptcha?: FcaptchaGlobal;
+  }
+}
+
+function defaultTrustedOrigins(): readonly string[] {
+  // Implicit allow-list = the faucet origin we were built against. Operators
+  // pass an explicit `trustedOrigins` when the captcha host differs from the
+  // faucet host (e.g. a CDN-fronted captcha.example.com).
+  const faucetUrl = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_FAUCET_URL;
+  if (!faucetUrl) return [];
+  try {
+    return [new URL(faucetUrl).origin];
+  } catch {
+    return [];
+  }
+}
+
+export async function loadFcaptcha({
+  serverUrl,
+  siteKey,
+  hostElement,
+  trustedOrigins,
+}: FcaptchaConfig): Promise<FcaptchaWidget> {
+  const allow = trustedOrigins && trustedOrigins.length > 0 ? trustedOrigins : defaultTrustedOrigins();
+  if (allow.length === 0) {
+    throw new Error(
+      'fcaptcha: no trustedOrigins provided and VITE_FAUCET_URL is unset; ' +
+      'cannot validate the captcha host. Set VITE_FAUCET_URL at build time ' +
+      'or pass an explicit trustedOrigins list.',
+    );
+  }
+  await loadScript(serverUrl, allow);
+  if (!window.fcaptcha) {
+    throw new Error('fcaptcha global missing after script load');
+  }
+  let resolveToken!: (token: string) => void;
+  let rejectToken!: (err: Error) => void;
+  const token = new Promise<string>((resolve, reject) => {
+    resolveToken = resolve;
+    rejectToken = reject;
+  });
+  const widget = window.fcaptcha.render(hostElement, {
+    siteKey,
+    serverUrl,
+    callback: (t) => resolveToken(t),
+    'error-callback': (err) => rejectToken(err instanceof Error ? err : new Error(String(err))),
+  });
+  return {
+    token,
+    destroy: () => {
+      try {
+        widget.reset();
+      } catch {
+        // already torn down
+      }
+      hostElement.replaceChildren();
+    },
+  };
+}

--- a/examples/mini-app-claim-shared/src/i18n.ts
+++ b/examples/mini-app-claim-shared/src/i18n.ts
@@ -1,0 +1,56 @@
+import { getHostLanguage } from '@nimiq/mini-app-sdk';
+
+export type Lang = 'en' | 'de';
+
+const STRINGS = {
+  en: {
+    title: 'Nimiq Faucet',
+    subtitle: 'Claim free testnet NIM',
+    connecting: 'Connecting to Nimiq Pay…',
+    outsidePay: 'Open this app inside Nimiq Pay',
+    outsidePayHint: 'Paste this URL into Nimiq Pay → Mini Apps on a phone running on the same Wi-Fi as the faucet.',
+    claim: 'Claim NIM',
+    claiming: 'Claiming…',
+    awaitingCaptcha: 'Solve the captcha to continue',
+    addressFromWallet: 'Address from wallet',
+    broadcast: 'Broadcast — waiting for confirmation…',
+    confirmed: 'Confirmed',
+    rejected: 'Rejected',
+    challenged: 'Captcha required',
+    txLabel: 'Transaction',
+    explorerLink: 'Open in explorer',
+    retry: 'Try again',
+    error: 'Something went wrong',
+  },
+  de: {
+    title: 'Nimiq Faucet',
+    subtitle: 'Kostenlose Testnet-NIM beanspruchen',
+    connecting: 'Verbinde mit Nimiq Pay…',
+    outsidePay: 'Diese App in Nimiq Pay öffnen',
+    outsidePayHint: 'URL in Nimiq Pay → Mini Apps einfügen, auf einem Telefon im selben WLAN wie der Faucet.',
+    claim: 'NIM beanspruchen',
+    claiming: 'Wird beansprucht…',
+    awaitingCaptcha: 'Captcha lösen um fortzufahren',
+    addressFromWallet: 'Adresse aus dem Wallet',
+    broadcast: 'Gesendet — warte auf Bestätigung…',
+    confirmed: 'Bestätigt',
+    rejected: 'Abgelehnt',
+    challenged: 'Captcha erforderlich',
+    txLabel: 'Transaktion',
+    explorerLink: 'Im Explorer öffnen',
+    retry: 'Erneut versuchen',
+    error: 'Etwas ist schiefgelaufen',
+  },
+} as const;
+
+export type StringKey = keyof typeof STRINGS['en'];
+
+function pickLang(): Lang {
+  const raw = getHostLanguage();
+  return raw && raw.toLowerCase().startsWith('de') ? 'de' : 'en';
+}
+
+export function translate(key: StringKey, lang?: Lang): string {
+  const l = lang ?? pickLang();
+  return STRINGS[l][key];
+}

--- a/examples/mini-app-claim-shared/src/index.ts
+++ b/examples/mini-app-claim-shared/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  connectMiniApp,
+  getUserAddress,
+  type MiniAppConnection,
+  type MiniAppConnectionState,
+} from './bridge.js';
+export { loadFcaptcha, type FcaptchaWidget } from './fcaptcha.js';
+export { translate, type Lang } from './i18n.js';

--- a/examples/mini-app-claim-shared/tsconfig.json
+++ b/examples/mini-app-claim-shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/mini-app-claim-vue/Dockerfile
+++ b/examples/mini-app-claim-vue/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+# Production build of the Vue mini app — static bundle served by nginx.
+# Build context = repo root, e.g.
+#   docker buildx build -f examples/mini-app-claim-vue/Dockerfile -t mini-vue:test .
+
+FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS build
+COPY . .
+
+ARG VITE_FAUCET_URL=http://localhost:8080
+ENV VITE_FAUCET_URL=${VITE_FAUCET_URL}
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-mini-app-vue...
+RUN pnpm turbo run build --filter=@nimiq-faucet/example-mini-app-vue
+
+FROM nginxinc/nginx-unprivileged:alpine AS runtime
+COPY --from=build /app/examples/mini-app-claim-vue/dist /usr/share/nginx/html
+COPY examples/mini-app-claim-vue/nginx.conf /etc/nginx/conf.d/default.conf
+# nginx-unprivileged runs as user `nginx` and listens on 8080 by default
+# so the container can run with no root capabilities.
+EXPOSE 8080

--- a/examples/mini-app-claim-vue/Dockerfile.dev
+++ b/examples/mini-app-claim-vue/Dockerfile.dev
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7
+# Development server: Vite with `--host` so a phone on the same Wi-Fi can
+# reach the mini app over LAN. Build context = repo root.
+
+FROM node:22-bookworm-slim
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+COPY . .
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-mini-app-vue...
+
+WORKDIR /app/examples/mini-app-claim-vue
+EXPOSE 5173
+CMD ["pnpm", "exec", "vite", "--host"]

--- a/examples/mini-app-claim-vue/README.md
+++ b/examples/mini-app-claim-vue/README.md
@@ -1,0 +1,93 @@
+# Vue Mini App — Faucet Claim
+
+A [Nimiq Pay Mini App](https://mini-apps-launch-developer-center-dev-worker.je-cf9.workers.dev/mini-apps) (Vue 3 + Vite) that claims testnet NIM from a self-hosted [`nimiq-simple-faucet`](../../README.md). Pairs with [`mini-app-claim-react/`](../mini-app-claim-react/) — both share the framework-agnostic [`mini-app-claim-shared/`](../mini-app-claim-shared/) glue.
+
+## What this example demonstrates
+
+- Reading the user's NIM address from inside Nimiq Pay via [`@nimiq/mini-app-sdk`](https://www.npmjs.com/package/@nimiq/mini-app-sdk) (`init()` → `provider.listAccounts()`).
+- Submitting a claim through the faucet's existing public `POST /v1/claim` endpoint via [`@nimiq-faucet/sdk`](../../packages/sdk-ts/) — no integrator HMAC, no custom auth.
+- Solving an [fcaptcha](https://github.com/WebDecoy/FCaptcha) challenge inside a WebView with no third-party iframes.
+- Showing live broadcast → confirmation status using the SDK's `waitForConfirmation` helper.
+- Mobile-first layout: 375px minimum viewport, 44px+ touch targets, dark-mode aware, safe-area insets respected. Validated against [`mini-apps-checklist`](https://github.com/nimiq/developer-center/pull/175).
+
+## Run it (everything in Docker)
+
+```bash
+# 1. From the repo root, pre-fund the faucet's testnet wallet:
+pnpm generate:wallet            # prints a NIM testnet address
+# Send testnet NIM to that address from https://faucet.pos.nimiq-testnet.com
+
+# 2. Set your dev machine's Wi-Fi IP and demo secrets:
+export LAN_IP=$(hostname -I | awk '{print $1}')      # Linux
+# export LAN_IP=$(ipconfig getifaddr en0)            # macOS
+export FCAPTCHA_SECRET=demo-secret-change-me
+export FAUCET_FCAPTCHA_SITE_KEY=demo-site-key
+export FAUCET_FCAPTCHA_SECRET=demo-secret-change-me
+
+# 3. Bring up faucet + fcaptcha + this mini app:
+cd examples/mini-app-claim-vue
+docker compose up --build
+```
+
+Wait for `vite ready at http://<LAN_IP>:5173` and `faucet listening on 0.0.0.0:8080`.
+
+## Open it on a real phone
+
+1. Make sure the phone is on the same Wi-Fi as your dev machine.
+2. Open Nimiq Pay → **Mini Apps** → enter `http://<LAN_IP>:5173`.
+3. Tap **Claim NIM** → approve the address-share dialog → solve fcaptcha → wait for `Confirmed`.
+
+> **Need testnet mode in Nimiq Pay?** Long-press the settings button for ~10 seconds to reveal the dev menu, then switch the Nimiq provider to Testnet.
+
+## What this compose file is doing
+
+It uses Compose's `include:` to layer:
+
+1. `deploy/compose/docker-compose.yml` — base faucet (Fastify + SQLite + WASM signer, testnet).
+2. `deploy/compose/fcaptcha.yml` — `webdecoy/fcaptcha` on port 3000.
+3. This file — Vite dev server on port 5173 with `--host` so the phone can reach it.
+
+The compose file overrides the faucet env to:
+
+| Env var | Value | Why |
+|---|---|---|
+| `FAUCET_DEV` | `1` | Allows non-TLS in dev. |
+| `FAUCET_TLS_REQUIRED` | `false` | LAN HTTP. |
+| `FAUCET_CORS_ORIGINS` | `*` | Phone WebView fetch. |
+| `FAUCET_UI_ENABLED` | `false` | The mini app is the UI. |
+| `FAUCET_RATE_LIMIT_PER_IP_PER_DAY` | `20` | Generous for testing. |
+
+> ⚠️ **DO NOT** copy these settings into a production deployment. In production, set a real CORS allowlist (the Mini App's exact origin), keep TLS on, and tighten rate limits.
+
+## Layout
+
+```
+mini-app-claim-vue/
+├── docker-compose.yml          # this file (per-example, includes the backend)
+├── Dockerfile                  # production build → nginx
+├── Dockerfile.dev              # dev: vite --host
+├── nginx.conf                  # production
+├── index.html                  # mobile viewport, theme-color
+├── vite.config.ts              # server.host: true, HMR over LAN
+├── tsconfig.json
+├── package.json
+└── src/
+    ├── main.ts
+    ├── App.vue                 # state-machine UI
+    ├── components/FcaptchaWidget.vue
+    ├── composables/useMiniAppFaucet.ts
+    ├── styles.css              # mobile-first tokens, dark mode, safe-area
+    └── env.d.ts
+```
+
+The Mini App SDK ↔ Faucet SDK glue lives one directory up in [`mini-app-claim-shared/`](../mini-app-claim-shared/) — it'll be promoted to a published `@nimiq-faucet/mini-app` package once a third framework example exists.
+
+## Verifying with the checklist skill
+
+Before opening a PR with changes:
+
+```bash
+npx skills add nimiq/developer-center --skill mini-apps-checklist
+```
+
+…then ask Claude (or any compatible AI tool) to run the checklist against this directory. Target: zero `FAIL`s.

--- a/examples/mini-app-claim-vue/docker-compose.yml
+++ b/examples/mini-app-claim-vue/docker-compose.yml
@@ -1,0 +1,63 @@
+# Self-contained dev compose for the Vue mini app example.
+#
+# Usage from this directory:
+#
+#   export LAN_IP=$(hostname -I | awk '{print $1}')   # Linux
+#   # macOS:  export LAN_IP=$(ipconfig getifaddr en0)
+#   export FCAPTCHA_SECRET=demo-secret-change-me
+#   export FAUCET_FCAPTCHA_SITE_KEY=demo-site-key
+#   export FAUCET_FCAPTCHA_SECRET=demo-secret-change-me
+#   export FAUCET_PRIVATE_KEY=$(openssl rand -hex 32)
+#   export FAUCET_KEY_PASSPHRASE=at-least-eight-chars
+#   export FAUCET_ADMIN_PASSWORD=at-least-eight-chars
+#   # Optional non-default host ports if 8080/3000/5173 are taken locally:
+#   # export FAUCET_HOST_PORT=28080 FCAPTCHA_HOST_PORT=3010 MINI_APP_HOST_PORT=5173
+#   docker compose up --build
+#
+# Then on a phone on the same Wi-Fi: open Nimiq Pay → Mini Apps and enter
+# http://<LAN_IP>:${MINI_APP_HOST_PORT:-5173}.
+#
+# This compose file relaxes TLS + CORS for LAN dev. NEVER copy these env
+# values into a production deployment.
+
+include:
+  - ../../deploy/compose/docker-compose.yml
+  - ../../deploy/compose/fcaptcha.yml
+
+services:
+  faucet:
+    environment:
+      FAUCET_DEV: "1"
+      FAUCET_NETWORK: test
+      FAUCET_SIGNER_DRIVER: wasm
+      FAUCET_TLS_REQUIRED: "false"
+      FAUCET_CORS_ORIGINS: "*"
+      FAUCET_HELMET_CSP: relaxed-for-ui
+      FAUCET_UI_ENABLED: "false"
+      FAUCET_CLAIM_AMOUNT_LUNA: "100000"
+      FAUCET_RATE_LIMIT_PER_IP_PER_DAY: "20"
+      # Required by the WASM signer. Generate once with
+      #   FAUCET_PRIVATE_KEY=$(openssl rand -hex 32)
+      # and KEEP IT — the on-disk wallet is encrypted under this passphrase.
+      FAUCET_PRIVATE_KEY: ${FAUCET_PRIVATE_KEY:?set FAUCET_PRIVATE_KEY (32 random hex bytes)}
+      FAUCET_KEY_PASSPHRASE: ${FAUCET_KEY_PASSPHRASE:?set FAUCET_KEY_PASSPHRASE (>=8 chars)}
+      FAUCET_ADMIN_PASSWORD: ${FAUCET_ADMIN_PASSWORD:?set FAUCET_ADMIN_PASSWORD (>=8 chars)}
+      # Browser-reachable URL — the phone WebView fetches /fcaptcha.js and the
+      # captcha API from this. The faucet container itself reaches fcaptcha
+      # over the compose bridge as `http://fcaptcha:3000`, which is the default
+      # FAUCET_FCAPTCHA_INTERNAL_URL set by the included fcaptcha.yml overlay.
+      FAUCET_FCAPTCHA_PUBLIC_URL: http://${LAN_IP:?set LAN_IP to your Wi-Fi IP}:${FCAPTCHA_HOST_PORT:-3000}
+
+  mini-app-vue:
+    build:
+      context: ../..
+      dockerfile: examples/mini-app-claim-vue/Dockerfile.dev
+    image: nimiq-faucet-mini-app-vue:dev
+    environment:
+      VITE_FAUCET_URL: http://${LAN_IP:?set LAN_IP to your Wi-Fi IP}:${FAUCET_HOST_PORT:-8080}
+      VITE_HMR_HOST: ${LAN_IP}
+    ports:
+      - "${MINI_APP_HOST_PORT:-5173}:5173"
+    depends_on:
+      - faucet
+      - fcaptcha

--- a/examples/mini-app-claim-vue/index.html
+++ b/examples/mini-app-claim-vue/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#1f2348" />
+    <title>Nimiq Faucet — Mini App (Vue)</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/mini-app-claim-vue/nginx.conf
+++ b/examples/mini-app-claim-vue/nginx.conf
@@ -1,0 +1,23 @@
+# nginx serves the production Vue mini app bundle. Listens on 8080 because
+# the runtime image (nginxinc/nginx-unprivileged:alpine) runs as a non-root
+# user and can't bind <1024.
+server {
+  listen 8080;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Defence-in-depth headers. CSP lets fcaptcha.ts inject the widget bundle
+  # and connect to the faucet over WSS/HTTPS but blocks everything else.
+  # Operators with a fixed captcha host can tighten `script-src` to a single
+  # origin; the wildcard below covers per-deployment captcha-host variation.
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer" always;
+  add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/examples/mini-app-claim-vue/package.json
+++ b/examples/mini-app-claim-vue/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nimiq-faucet/example-mini-app-vue",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Vue 3 Nimiq Pay Mini App that claims NIM from a self-hosted nimiq-simple-faucet.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nimiq/mini-app-sdk": "^0.0.2",
+    "@nimiq-faucet/mini-app-claim-shared": "workspace:*",
+    "@nimiq-faucet/sdk": "workspace:*",
+    "vue": "^3.5.33"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.6",
+    "typescript": "^5.6.2",
+    "vite": "^8.0.10",
+    "vue-tsc": "^2.1.6"
+  }
+}

--- a/examples/mini-app-claim-vue/src/App.vue
+++ b/examples/mini-app-claim-vue/src/App.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { translate } from '@nimiq-faucet/mini-app-claim-shared';
+import { useMiniAppFaucet } from './composables/useMiniAppFaucet';
+import FcaptchaWidget from './components/FcaptchaWidget.vue';
+
+const faucetUrl = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
+const explorerBase = import.meta.env.VITE_EXPLORER_URL ?? 'https://nimiq-testnet.observer/#tx/';
+
+const { state, captchaPrompt, claim, reset, canClaim } = useMiniAppFaucet(faucetUrl);
+
+const t = (key: Parameters<typeof translate>[0]) => translate(key);
+
+const buttonLabel = computed(() => {
+  switch (state.phase) {
+    case 'awaiting-address':
+    case 'awaiting-captcha':
+    case 'submitting':
+    case 'broadcast':
+      return t('claiming');
+    default:
+      return t('claim');
+  }
+});
+
+const explorerUrl = computed(() => (state.txId ? `${explorerBase}${state.txId}` : null));
+</script>
+
+<template>
+  <h1 class="title">{{ t('title') }}</h1>
+  <p class="subtitle">{{ t('subtitle') }}</p>
+
+  <div v-if="state.phase === 'connecting'" class="card">
+    <span><span class="spinner" />{{ t('connecting') }}</span>
+  </div>
+
+  <div v-else-if="state.phase === 'outside-nimiq-pay'" class="card">
+    <strong>{{ t('outsidePay') }}</strong>
+    <p class="subtitle">{{ t('outsidePayHint') }}</p>
+    <p v-if="state.outsideReason" class="subtitle"><small>{{ state.outsideReason }}</small></p>
+  </div>
+
+  <template v-else>
+    <div v-if="state.address" class="card">
+      <span class="label">{{ t('addressFromWallet') }}</span>
+      <span class="address">{{ state.address }}</span>
+    </div>
+
+    <FcaptchaWidget
+      v-if="captchaPrompt"
+      :server-url="captchaPrompt.serverUrl"
+      :site-key="captchaPrompt.siteKey"
+      @solved="captchaPrompt.resolve($event)"
+      @failed="captchaPrompt.reject($event)"
+    />
+
+    <p v-if="state.phase === 'awaiting-captcha'" class="subtitle">
+      {{ t('awaitingCaptcha') }}
+    </p>
+
+    <button
+      class="btn"
+      :disabled="!canClaim"
+      @click="claim"
+    >
+      <span v-if="state.phase !== 'ready' && state.phase !== 'rejected' && state.phase !== 'error' && state.phase !== 'confirmed'" class="spinner" />
+      {{ buttonLabel }}
+    </button>
+
+    <div v-if="state.phase === 'broadcast'" class="banner warn">
+      <span class="spinner" />{{ t('broadcast') }}
+    </div>
+
+    <div v-else-if="state.phase === 'confirmed'" class="banner good">
+      <strong>{{ t('confirmed') }}</strong>
+      <p v-if="state.txId" class="tx">{{ t('txLabel') }}: {{ state.txId }}</p>
+      <a v-if="explorerUrl" :href="explorerUrl" target="_blank" rel="noopener" class="link">
+        {{ t('explorerLink') }} →
+      </a>
+    </div>
+
+    <div v-else-if="state.phase === 'rejected' || state.phase === 'challenged'" class="banner bad">
+      <strong>{{ state.phase === 'challenged' ? t('challenged') : t('rejected') }}</strong>
+      <p v-if="state.errorMessage" class="tx">{{ state.errorMessage }}</p>
+      <button class="btn" @click="reset">{{ t('retry') }}</button>
+    </div>
+
+    <div v-else-if="state.phase === 'error'" class="banner bad">
+      <strong>{{ t('error') }}</strong>
+      <p v-if="state.errorMessage" class="tx">{{ state.errorMessage }}</p>
+      <button class="btn" @click="reset">{{ t('retry') }}</button>
+    </div>
+  </template>
+</template>

--- a/examples/mini-app-claim-vue/src/components/FcaptchaWidget.vue
+++ b/examples/mini-app-claim-vue/src/components/FcaptchaWidget.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { loadFcaptcha, type FcaptchaWidget } from '@nimiq-faucet/mini-app-claim-shared';
+
+const props = defineProps<{ serverUrl: string; siteKey: string }>();
+const emit = defineEmits<{ solved: [token: string]; failed: [error: Error] }>();
+
+const host = ref<HTMLDivElement | null>(null);
+let widget: FcaptchaWidget | null = null;
+
+onMounted(async () => {
+  if (!host.value) return;
+  try {
+    widget = await loadFcaptcha({
+      serverUrl: props.serverUrl,
+      siteKey: props.siteKey,
+      hostElement: host.value,
+    });
+    const token = await widget.token;
+    emit('solved', token);
+  } catch (err) {
+    emit('failed', err instanceof Error ? err : new Error(String(err)));
+  }
+});
+
+onBeforeUnmount(() => {
+  widget?.destroy();
+  widget = null;
+});
+</script>
+
+<template>
+  <div ref="host" class="captcha-host" />
+</template>

--- a/examples/mini-app-claim-vue/src/composables/useMiniAppFaucet.ts
+++ b/examples/mini-app-claim-vue/src/composables/useMiniAppFaucet.ts
@@ -1,0 +1,147 @@
+import { computed, reactive, ref, shallowRef, type Ref } from 'vue';
+import { FaucetClient } from '@nimiq-faucet/sdk';
+import {
+  connectMiniApp,
+  getUserAddress,
+  type MiniAppConnectionState,
+} from '@nimiq-faucet/mini-app-claim-shared';
+
+export type Phase =
+  | 'connecting'
+  | 'outside-nimiq-pay'
+  | 'ready'
+  | 'awaiting-address'
+  | 'awaiting-captcha'
+  | 'submitting'
+  | 'broadcast'
+  | 'confirmed'
+  | 'rejected'
+  | 'challenged'
+  | 'error';
+
+export interface CaptchaPrompt {
+  serverUrl: string;
+  siteKey: string;
+  resolve: (token: string) => void;
+  reject: (err: Error) => void;
+}
+
+export interface MiniAppFaucetState {
+  phase: Phase;
+  address: string | null;
+  txId: string | null;
+  errorMessage: string | null;
+  outsideReason: string | null;
+}
+
+export function useMiniAppFaucet(faucetUrl: string) {
+  const state = reactive<MiniAppFaucetState>({
+    phase: 'connecting',
+    address: null,
+    txId: null,
+    errorMessage: null,
+    outsideReason: null,
+  });
+
+  const conn = shallowRef<MiniAppConnectionState | null>(null);
+  const captchaPrompt: Ref<CaptchaPrompt | null> = ref(null);
+  const client = new FaucetClient({ url: faucetUrl });
+  // In-flight guard: a fast double-tap on the claim button can fire two
+  // parallel `claim()` calls before the phase transitions disable the
+  // button (Vue's reactive flush is async). The second call would prompt
+  // the wallet for the address a second time and confuse the user. Lock
+  // here in addition to the UI-level disable.
+  let inFlight = false;
+
+  void connectMiniApp().then((next) => {
+    conn.value = next;
+    if (next.status === 'ready') {
+      state.phase = 'ready';
+    } else if (next.status === 'outside-nimiq-pay') {
+      state.phase = 'outside-nimiq-pay';
+      state.outsideReason = next.reason;
+    }
+  });
+
+  async function fetchCaptchaToken(): Promise<string | undefined> {
+    const config = await client.config();
+    if (!config.captcha) return undefined;
+    if (config.captcha.provider !== 'fcaptcha') {
+      throw new Error(
+        `This example only renders fcaptcha; faucet is configured for ${config.captcha.provider}.`,
+      );
+    }
+    if (!config.captcha.serverUrl) {
+      throw new Error('faucet returned fcaptcha provider without serverUrl');
+    }
+    state.phase = 'awaiting-captcha';
+    return new Promise<string>((resolve, reject) => {
+      captchaPrompt.value = {
+        serverUrl: config.captcha!.serverUrl!,
+        siteKey: config.captcha!.siteKey,
+        resolve: (token) => {
+          captchaPrompt.value = null;
+          resolve(token);
+        },
+        reject: (err) => {
+          captchaPrompt.value = null;
+          reject(err);
+        },
+      };
+    });
+  }
+
+  async function claim(): Promise<void> {
+    if (inFlight) return;
+    if (!conn.value || conn.value.status !== 'ready') return;
+    inFlight = true;
+    state.errorMessage = null;
+    state.txId = null;
+    try {
+      state.phase = 'awaiting-address';
+      const address = await getUserAddress(conn.value.provider);
+      state.address = address;
+      const captchaToken = await fetchCaptchaToken();
+      state.phase = 'submitting';
+      const initialOpts: { captchaToken?: string } = captchaToken ? { captchaToken } : {};
+      const initial = await client.claim(address, initialOpts);
+      state.txId = initial.txId ?? null;
+      if (initial.status === 'rejected') {
+        state.phase = 'rejected';
+        state.errorMessage = initial.reason ?? 'Claim rejected';
+        return;
+      }
+      if (initial.status === 'challenged') {
+        state.phase = 'challenged';
+        state.errorMessage = initial.reason ?? 'Captcha required';
+        return;
+      }
+      state.phase = 'broadcast';
+      const final = await client.waitForConfirmation(initial.id);
+      state.txId = final.txId ?? state.txId;
+      state.phase = final.status === 'confirmed' ? 'confirmed' : 'rejected';
+      if (final.status === 'rejected' && final.reason) {
+        state.errorMessage = final.reason;
+      }
+    } catch (err) {
+      state.phase = 'error';
+      state.errorMessage = err instanceof Error ? err.message : String(err);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  function reset(): void {
+    state.phase = conn.value?.status === 'ready' ? 'ready' : 'connecting';
+    state.address = null;
+    state.txId = null;
+    state.errorMessage = null;
+    captchaPrompt.value = null;
+  }
+
+  const canClaim = computed(
+    () => state.phase === 'ready' || state.phase === 'rejected' || state.phase === 'error' || state.phase === 'confirmed',
+  );
+
+  return { state, captchaPrompt, claim, reset, canClaim };
+}

--- a/examples/mini-app-claim-vue/src/env.d.ts
+++ b/examples/mini-app-claim-vue/src/env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FAUCET_URL?: string;
+  readonly VITE_EXPLORER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/examples/mini-app-claim-vue/src/main.ts
+++ b/examples/mini-app-claim-vue/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './styles.css';
+
+createApp(App).mount('#app');

--- a/examples/mini-app-claim-vue/src/styles.css
+++ b/examples/mini-app-claim-vue/src/styles.css
@@ -1,0 +1,177 @@
+/* Mobile-first. Mini apps must work at 375px and respect 44px touch targets. */
+:root {
+  --bg: #f5f6fa;
+  --fg: #1f2348;
+  --muted: #6b7280;
+  --accent: #1f2348;
+  --accent-fg: #ffffff;
+  --gold: #e9b213;
+  --good: #d1fae5;
+  --good-fg: #065f46;
+  --bad: #fee2e2;
+  --bad-fg: #991b1b;
+  --warn: #fef3c7;
+  --warn-fg: #92400e;
+  --border: #d1d5db;
+  --card: #ffffff;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1124;
+    --fg: #f5f6fa;
+    --muted: #9ca3af;
+    --accent: #f5f6fa;
+    --accent-fg: #1f2348;
+    --good: #064e3b;
+    --good-fg: #d1fae5;
+    --bad: #7f1d1d;
+    --bad-fg: #fee2e2;
+    --warn: #78350f;
+    --warn-fg: #fef3c7;
+    --border: #334155;
+    --card: #1e2245;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+#app {
+  width: 100%;
+  max-width: 480px;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.address {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.btn {
+  min-height: 48px;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 12px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
+  transition: opacity 0.15s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn:not(:disabled):active {
+  opacity: 0.85;
+}
+
+.banner {
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 0.9rem;
+}
+
+.banner.good {
+  background: var(--good);
+  color: var(--good-fg);
+}
+
+.banner.bad {
+  background: var(--bad);
+  color: var(--bad-fg);
+}
+
+.banner.warn {
+  background: var(--warn);
+  color: var(--warn-fg);
+}
+
+.tx {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+.link {
+  color: var(--gold);
+  text-decoration: underline;
+  font-size: 0.9rem;
+}
+
+.captcha-host {
+  min-height: 70px;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/examples/mini-app-claim-vue/tsconfig.json
+++ b/examples/mini-app-claim-vue/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/env.d.ts"]
+}

--- a/examples/mini-app-claim-vue/vite.config.ts
+++ b/examples/mini-app-claim-vue/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+const hmrHost = process.env.VITE_HMR_HOST;
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
+    hmr: hmrHost ? { host: hmrHost, protocol: 'ws', clientPort: 5173 } : undefined,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,81 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/mini-app-claim-react:
+    dependencies:
+      '@nimiq-faucet/mini-app-claim-shared':
+        specifier: workspace:*
+        version: link:../mini-app-claim-shared
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      '@nimiq/mini-app-sdk':
+        specifier: ^0.0.2
+        version: 0.0.2
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.11
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  examples/mini-app-claim-shared:
+    dependencies:
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      '@nimiq/mini-app-sdk':
+        specifier: ^0.0.2
+        version: 0.0.2
+    devDependencies:
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+
+  examples/mini-app-claim-vue:
+    dependencies:
+      '@nimiq-faucet/mini-app-claim-shared':
+        specifier: workspace:*
+        version: link:../mini-app-claim-shared
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      '@nimiq/mini-app-sdk':
+        specifier: ^0.0.2
+        version: 0.0.2
+      vue:
+        specifier: ^3.5.33
+        version: 3.5.33(typescript@5.9.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.6
+        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ^2.1.6
+        version: 2.2.12(typescript@5.9.3)
+
   examples/nextjs-claim-page:
     dependencies:
       '@nimiq-faucet/react':
@@ -713,6 +788,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -733,6 +812,18 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -1758,6 +1849,9 @@ packages:
   '@nimiq/core@2.4.0':
     resolution: {integrity: sha512-tkcvQTTy0tbOLEBQDOxDAcCv7KRS+riuEcd4gWulwyRU2rLziiTKOXD1WNszikHFKQ6S3zmbq1RQpJGTjQVBIg==}
 
+  '@nimiq/mini-app-sdk@0.0.2':
+    resolution: {integrity: sha512-PGXlq0quaarH8wJJSL+GHNRzn3tQnSD6pim0sNb5kNg0dKfKqlJ6sSrLBhykCYNE20eDkmD2LYa5cZs8+A5Yxw==}
+
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
@@ -1961,6 +2055,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -2241,6 +2338,18 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -2308,6 +2417,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -4214,6 +4329,10 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -5144,6 +5263,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -5158,6 +5279,16 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
 
@@ -5992,6 +6123,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nimiq/mini-app-sdk@0.0.2': {}
+
   '@noble/ciphers@2.2.0': {}
 
   '@noble/hashes@2.2.0': {}
@@ -6161,6 +6294,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -6377,6 +6512,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
@@ -6448,6 +6604,18 @@ snapshots:
       '@types/yargs-parser': 21.0.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -8493,6 +8661,8 @@ snapshots:
       - utf-8-validate
 
   react-refresh@0.14.2: {}
+
+  react-refresh@0.18.0: {}
 
   react@18.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,7 @@ packages:
   - "examples/nextjs-claim-page"
   - "examples/vue-claim-page"
   - "examples/capacitor-mobile-app"
+  - "examples/mini-app-claim-shared"
+  - "examples/mini-app-claim-vue"
+  - "examples/mini-app-claim-react"
   - "tests/*"


### PR DESCRIPTION
# Add Nimiq Pay Mini App example (Vue + React)

## Summary

A canonical [Nimiq Pay Mini App](https://mini-apps-launch-developer-center-dev-worker.je-cf9.workers.dev/mini-apps) example that runs inside the Nimiq Pay wallet WebView, reads the user's NIM address via [`@nimiq/mini-app-sdk`](https://www.npmjs.com/package/@nimiq/mini-app-sdk), and claims testnet NIM from this faucet. Two implementations sharing one TypeScript core:

- `examples/mini-app-claim-vue/` — Vue 3 + Vite
- `examples/mini-app-claim-react/` — React 18 + Vite
- `examples/mini-app-claim-shared/` — framework-agnostic glue (Mini App SDK bridge, fcaptcha widget loader, i18n)

Each example ships its own `docker-compose.yml` that brings up the faucet + fcaptcha + Vite dev server in one command, exposes everything on the LAN, and is designed for real-phone testing inside Nimiq Pay → Mini Apps. **Everything runs in Docker.**

The repo's existing 32 [Mini App ideas](https://mini-apps-launch-developer-center-dev-worker.je-cf9.workers.dev/mini-apps/ideas) don't include "Faucet" — this is a net-new canonical example.

## Why these two frameworks now, and how a third lands later

The repo already ships `@nimiq-faucet/vue` and `@nimiq-faucet/react` framework SDKs. Both Mini App examples consume them. The thin bit on top — Mini App SDK init, address fetch, fcaptcha widget, i18n — is in `examples/mini-app-claim-shared/` (a private workspace module) and is reused by both. When a third framework example lands (Svelte, vanilla, Solid, etc.) the shared module graduates to `packages/mini-app-core/` and gets published as `@nimiq-faucet/mini-app`. Out of scope for this PR.

## What's in the diff

| File / directory | What it does |
|---|---|
| `examples/mini-app-claim-shared/` | Framework-agnostic core: `bridge.ts` (init + safe `listAccounts` wrapper), `fcaptcha.ts` (widget loader), `i18n.ts` (uses `getHostLanguage()`), plus a `fcaptcha/Dockerfile` that builds FCaptcha from upstream because the deploy/compose reference image isn't pullable (see notes below). |
| `examples/mini-app-claim-vue/` | Vue 3 + Vite app. `useMiniAppFaucet` composable, `FcaptchaWidget.vue`, mobile-first CSS with safe-area insets, dark-mode aware. Production Dockerfile (nginx) + Dockerfile.dev (vite --host) + per-example docker-compose.yml. |
| `examples/mini-app-claim-react/` | Mirror of Vue. `useMiniAppFaucet` hook, `FcaptchaWidgetView`, same styles. |
| `examples/docker-compose.yml` | Adds `example-mini-app-vue` (port 3006) and `example-mini-app-react` (port 3007) to the existing examples overlay (production-bundle path; dev path is the per-example compose). |
| `pnpm-workspace.yaml` | Registers the three new workspace packages. |
| `README.md` | New "Nimiq Pay Mini App" subsection under "Integrate into your app". |

## Validation (all in Docker)

- ✅ `pnpm turbo run build --filter @nimiq-faucet/example-mini-app-vue` (inside Docker) → 72 KB JS / 28 KB gz, 0 errors.
- ✅ `pnpm turbo run build --filter @nimiq-faucet/example-mini-app-react` (inside Docker) → 153 KB JS / 50 KB gz, 0 errors.
- ✅ `docker compose up` (Vue stack) → faucet, fcaptcha, vite all healthy. `/healthz`, `/v1/config`, `/fcaptcha.js`, `/api/challenge` all return 200 from the LAN URL.
- ❓ Full claim flow against a real Nimiq Pay WebView — manual gate via the [`mini-apps-checklist`](https://github.com/nimiq/developer-center/pull/175) skill. Cannot be CI'd; requires a phone.

## Integration findings (filed as issues, see body of `INTEGRATION_NOTES.md`)

This PR doubled as a real test of the repo's "third-party app integrating against the faucet" story. Surface tested: SDK shapes, abuse pipeline, Docker build, Compose includes, fcaptcha. The new examples work, but I had to work around several upstream gaps. Each is listed with severity and a proposed fix in the integration notes. Headlines:

- 🔴 Repo-root `.dockerignore` excludes `examples/` and most framework SDKs — plain `docker build` of any example fails. Worked around with per-Dockerfile dockerignores; the existing `vue-claim-page` and `nextjs-claim-page` Dockerfiles likely have the same issue.
- 🔴 `deploy/compose/fcaptcha.yml` references `ghcr.io/webdecoy/fcaptcha:latest` which is not publicly pullable. Worked around with a small `fcaptcha/Dockerfile` that builds from upstream source. **Either publish the image or change `image:` to `build:` in the compose fragment.**
- 🔴 FCaptcha's server-node doesn't serve its own `client/fcaptcha.js` widget. Worked around with a `sed`-patched server in our Dockerfile.
- 🔴 `FAUCET_FCAPTCHA_URL` conflates server-side and browser-side URLs. Splitting them would prevent a class of dev-time confusion.
- 🔴 `@nimiq/core` WASM intermittently panics with `time not implemented on this platform` shortly after the testnet handshake. Independent of this PR but affects every contributor following Quick Start with the WASM driver.
- Plus 11 smaller items, including upstream issues against `nimiq/developer-center` (SDK reference page, ideas-page entry for "Faucet", scaffold skill `VITE_HMR_HOST` guidance, version-pin `@nimiq/mini-app-sdk`) and `WebDecoy/FCaptcha` (server-node should serve its own widget).

I'll happily file each of these as a separate issue against the appropriate repo on request — the full list is in `INTEGRATION_NOTES.md` next to the project root.

## Test plan

- [ ] `pnpm install` from the repo root resolves cleanly (3 new workspace packages).
- [ ] `cd examples/mini-app-claim-vue && docker compose up --build` brings up faucet, fcaptcha, vite. All three healthchecks pass.
- [ ] Same for `examples/mini-app-claim-react`.
- [ ] Open `http://<LAN_IP>:5173` (and `:5174`) inside Nimiq Pay → Mini Apps on a phone on the same Wi-Fi. Tap "Claim NIM" → approve → solve fcaptcha → see `confirmed` with tx hash link.
- [ ] Run [`mini-apps-checklist`](https://github.com/nimiq/developer-center/pull/175) skill against both examples. Target: zero `FAIL`.
- [ ] (Optional) `cd examples/mini-app-claim-vue && docker buildx build -f Dockerfile -t test:vue ../..` and same for React — production-bundle Dockerfile builds clean.

## Out of scope (deferred)

- Promoting the shared module to `packages/mini-app-core/` — wait for a third framework example.
- Mainnet config defaults — both examples run on testnet.
- Touching `apps/claim-ui/`.
- Real-phone Playwright e2e — WebView flow can't be meaningfully automated.