### PR TITLE
fix(abuse): canonicalise blocklist values on insert + lookup (closes #94)

### DIFF
--- a/apps/server/src/abuse/blocklist.ts
+++ b/apps/server/src/abuse/blocklist.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import type { AbuseCheck, CheckResult } from '@faucet/core';
+import { normalizeBlocklistValue, type AbuseCheck, type CheckResult } from '@faucet/core';
 import type { Db } from '../db/index.js';
 import { blocklist } from '../db/schema.js';
 
@@ -14,8 +14,12 @@ export function blocklistCheck(db: Db): AbuseCheck {
         ['address', req.address],
         ['uid', req.hostContext?.uid],
       ];
-      for (const [kind, value] of kinds) {
-        if (!value) continue;
+      for (const [kind, raw] of kinds) {
+        if (!raw) continue;
+        // Canonicalise so the lookup matches what the admin saved (#94).
+        // Stored rows are normalised on insert via the same helper; existing
+        // rows are migrated on boot — see migrateBlocklistNormalization().
+        const value = normalizeBlocklistValue(kind, raw);
         const [hit] = await db
           .select()
           .from(blocklist)

--- a/apps/server/src/abuse/blocklistMigrate.ts
+++ b/apps/server/src/abuse/blocklistMigrate.ts
@@ -1,0 +1,34 @@
+/**
+ * One-shot migration: walk every `blocklist` row at boot and rewrite its
+ * `value` column with the canonical form from `normalizeBlocklistValue`.
+ * Without this, entries created before the normalization fix (#94) are
+ * still in their raw shape (e.g. `::ffff:1.2.3.4`) and the now-normalised
+ * lookup quietly misses them.
+ *
+ * Idempotent: re-normalising an already-canonical value is a no-op, so a
+ * row that was created post-fix doesn't change. We skip the UPDATE when
+ * the new value equals the old to avoid churning timestamps in any
+ * downstream materialised view.
+ */
+import { eq } from 'drizzle-orm';
+import { normalizeBlocklistValue } from '@faucet/core';
+import type { Db } from '../db/index.js';
+import { blocklist } from '../db/schema.js';
+
+export interface MigrateResult {
+  inspected: number;
+  updated: number;
+}
+
+export async function migrateBlocklistNormalization(db: Db): Promise<MigrateResult> {
+  const rows = await db.select().from(blocklist);
+  let updated = 0;
+  for (const row of rows) {
+    const canonical = normalizeBlocklistValue(row.kind, row.value);
+    if (canonical !== row.value) {
+      await db.update(blocklist).set({ value: canonical }).where(eq(blocklist.id, row.id));
+      updated += 1;
+    }
+  }
+  return { inspected: rows.length, updated };
+}

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,6 +10,7 @@ import type { ServerConfig } from './config.js';
 import { openDb } from './db/index.js';
 import { buildDriver } from './drivers.js';
 import { buildPipeline } from './abuse/pipeline.js';
+import { migrateBlocklistNormalization } from './abuse/blocklistMigrate.js';
 import { EventStream, streamRoute } from './stream.js';
 import { claimRoutes } from './routes/claim.js';
 import { adminRoutes } from './routes/admin/index.js';
@@ -74,6 +75,14 @@ export async function buildApp(
   await app.register(rateLimit, rateLimitOpts);
 
   const db = openDb({ dataDir: config.dataDir, databaseUrl: config.databaseUrl });
+  // One-shot canonicalise of any pre-#94 blocklist rows (idempotent).
+  const migrate = await migrateBlocklistNormalization(db);
+  if (migrate.updated > 0) {
+    app.log.info(
+      { inspected: migrate.inspected, updated: migrate.updated },
+      'blocklist values renormalised on boot',
+    );
+  }
   const driver = opts.driverOverride ?? (await buildDriver(config));
   const pipeline = buildPipeline(
     db,

--- a/apps/server/src/routes/admin/blocklist.ts
+++ b/apps/server/src/routes/admin/blocklist.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { desc, eq, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
+import { normalizeBlocklistValue } from '@faucet/core';
 import type { AppContext } from '../../context.js';
 import { blocklist } from '../../db/schema.js';
 import { writeAudit } from '../../auth/audit.js';
@@ -43,10 +44,13 @@ export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext
         }
         expiresAt = d;
       }
+      // Canonicalise on insert so the lookup at request time matches
+      // regardless of how the admin typed the value (#94).
+      const normalizedValue = normalizeBlocklistValue(parsed.data.kind, parsed.data.value);
       await ctx.db.insert(blocklist).values({
         id,
         kind: parsed.data.kind,
-        value: parsed.data.value,
+        value: normalizedValue,
         reason: parsed.data.reason ?? null,
         createdAt: new Date(),
         expiresAt,
@@ -55,7 +59,7 @@ export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext
         actor: req.adminUser?.id ?? 'admin',
         action: 'blocklist.add',
         target: id,
-        signals: { kind: parsed.data.kind, value: parsed.data.value },
+        signals: { kind: parsed.data.kind, value: normalizedValue },
       });
       return reply.code(201).send({ id });
     },

--- a/apps/server/test/blocklist-normalization.e2e.test.ts
+++ b/apps/server/test/blocklist-normalization.e2e.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for #94: blocklist normalization. Two end-to-end paths:
+ *
+ * 1. An admin (or seed migration) stored a value in the canonical form
+ *    (`1.2.3.4`). A request arrives over an IPv6 socket and surfaces as
+ *    `::ffff:1.2.3.4` in `req.ip`. Before normalization the lookup
+ *    missed; now the normalization on the read path canonicalises both
+ *    sides to `1.2.3.4` and the block fires (deny).
+ *
+ * 2. The boot-time migration. A pre-existing row with the
+ *    non-canonical `::ffff:1.2.3.4` form gets rewritten to `1.2.3.4`.
+ *    `migrateBlocklistNormalization` runs at app boot, so the second
+ *    `buildApp()` call here exercises that path.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { blocklist } from '../src/db/schema.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+
+class FakeDriver extends BaseTestDriver {
+  override async send(): Promise<string> { return 'tx_x'; }
+  override async waitForConfirmation(): Promise<void> {}
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: 'test-password-123',
+    dev: 'true',
+    // Trust loopback (added automatically in dev) so XFF in tests is
+    // honoured — the e2e mocks the socket as 127.0.0.1.
+    ...overrides,
+  });
+}
+
+describe('blocklist normalization (#94)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-blocklist-norm-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('matches an IPv6-mapped IPv4 caller against an IPv4-stored block', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+
+    // Seed a canonical IPv4 block directly in the DB.
+    await built.ctx.db.insert(blocklist).values({
+      id: nanoid(),
+      kind: 'ip',
+      value: '203.0.113.42',
+      reason: 'test',
+      createdAt: new Date(),
+      expiresAt: null,
+    });
+
+    // Caller arrives via IPv6-mapped IPv4. With dev=true, loopback is in
+    // the trustProxy CIDR allow-list so XFF is honoured.
+    const res = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR },
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '::ffff:203.0.113.42',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    const body = res.json();
+    expect(body.decision).toBe('deny');
+    expect(body.reason).toMatch(/blocklisted ip/i);
+  });
+
+  it('re-normalises pre-existing rows on boot (idempotent migration)', async () => {
+    // Boot once just to create the schema, then seed a non-canonical row
+    // that simulates a value inserted by an older build. Closing the first
+    // app and booting again triggers the migration.
+    const first = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(first.app);
+    await first.app.ready();
+    const id = nanoid();
+    await first.ctx.db.insert(blocklist).values({
+      id,
+      kind: 'ip',
+      value: '::ffff:198.51.100.1', // non-canonical IPv6-mapped form
+      reason: 'pre-existing',
+      createdAt: new Date(),
+      expiresAt: null,
+    });
+
+    // Bring up a second instance against the same data dir → migration runs.
+    const second = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(second.app);
+    await second.app.ready();
+
+    const [row] = await second.ctx.db
+      .select()
+      .from(blocklist)
+      .where(eq(blocklist.id, id))
+      .limit(1);
+    expect(row?.value).toBe('198.51.100.1');
+  });
+});

--- a/packages/core/src/blocklistNormalize.ts
+++ b/packages/core/src/blocklistNormalize.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonicalise blocklist values so the lookup and insert paths agree
+ * regardless of how an admin or a request arrived at the same logical
+ * entry. Without this, three real-world bypasses are possible:
+ *
+ *   - IPv6-mapped IPv4: an admin types `1.2.3.4`, the request socket
+ *     surfaces `::ffff:1.2.3.4`, the lookup misses.
+ *   - NQ address spacing/case: stored as `NQ07 …` with spaces, the
+ *     incoming claim sends `nq07…` lowercase no spaces, the lookup misses.
+ *   - Country / ASN: case + leading-zero variation.
+ *
+ * Apply on both sides of the boundary (insert + query). See finding #008
+ * in audits/AUDIT-REPORT.md.
+ */
+import { normalizeNimiqAddress } from './nimiqAddress.js';
+
+export type BlocklistKind = 'ip' | 'address' | 'uid' | 'asn' | 'country';
+
+export function normalizeBlocklistValue(kind: string, value: string): string {
+  switch (kind) {
+    case 'ip': {
+      // Strip the IPv6-mapped IPv4 prefix and the optional zone-id, lower-case
+      // the rest. Both `::ffff:1.2.3.4` and `1.2.3.4` collapse to `1.2.3.4`;
+      // `fe80::1%eth0` becomes `fe80::1`.
+      const v = value.trim().toLowerCase();
+      const noZone = v.includes('%') ? (v.split('%')[0] ?? v) : v;
+      return noZone.startsWith('::ffff:') ? noZone.slice('::ffff:'.length) : noZone;
+    }
+    case 'address':
+      // Reuse the existing canonical form: uppercase, single-spaces.
+      return normalizeNimiqAddress(value);
+    case 'country':
+      return value.trim().toUpperCase();
+    case 'asn': {
+      const n = parseInt(value.trim(), 10);
+      return Number.isFinite(n) ? String(n) : value.trim();
+    }
+    case 'uid':
+      return value.trim();
+    default:
+      return value;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './abuse.js';
 export * from './pipeline.js';
 export * from './hostContext.js';
 export * from './nimiqAddress.js';
+export * from './blocklistNormalize.js';

--- a/packages/core/test/blocklistNormalize.test.ts
+++ b/packages/core/test/blocklistNormalize.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBlocklistValue } from '../src/index.js';
+
+describe('normalizeBlocklistValue (#94)', () => {
+  describe('ip', () => {
+    it('strips the IPv6-mapped IPv4 prefix', () => {
+      expect(normalizeBlocklistValue('ip', '::ffff:1.2.3.4')).toBe('1.2.3.4');
+    });
+    it('lower-cases an IPv6 literal', () => {
+      expect(normalizeBlocklistValue('ip', '2001:DB8::1')).toBe('2001:db8::1');
+    });
+    it('strips a zone-id suffix', () => {
+      expect(normalizeBlocklistValue('ip', 'fe80::1%eth0')).toBe('fe80::1');
+    });
+    it('trims surrounding whitespace', () => {
+      expect(normalizeBlocklistValue('ip', '  1.2.3.4  ')).toBe('1.2.3.4');
+    });
+  });
+
+  describe('address', () => {
+    it('canonicalises NQ addresses to uppercase + single-spaced groups', () => {
+      const lowercase = 'nq07 0000 0000 0000 0000 0000 0000 0000 0000';
+      const expected = 'NQ07 0000 0000 0000 0000 0000 0000 0000 0000';
+      expect(normalizeBlocklistValue('address', lowercase)).toBe(expected);
+    });
+    it('collapses multiple internal spaces to single spaces', () => {
+      expect(normalizeBlocklistValue('address', 'NQ07  0000   0000 0000 0000 0000 0000 0000 0000'))
+        .toBe('NQ07 0000 0000 0000 0000 0000 0000 0000 0000');
+    });
+  });
+
+  describe('country', () => {
+    it('uppercases', () => {
+      expect(normalizeBlocklistValue('country', 'us')).toBe('US');
+      expect(normalizeBlocklistValue('country', '  De  ')).toBe('DE');
+    });
+  });
+
+  describe('asn', () => {
+    it('strips leading zeros via integer parsing', () => {
+      expect(normalizeBlocklistValue('asn', '0015169')).toBe('15169');
+      expect(normalizeBlocklistValue('asn', ' 32934 ')).toBe('32934');
+    });
+    it('passes through unparseable values unchanged (defensive)', () => {
+      expect(normalizeBlocklistValue('asn', 'AS15169')).toBe('AS15169');
+    });
+  });
+
+  describe('uid', () => {
+    it('only trims (uids are opaque hashes — case is meaningful)', () => {
+      expect(normalizeBlocklistValue('uid', '  abc123  ')).toBe('abc123');
+      expect(normalizeBlocklistValue('uid', 'ABC123')).toBe('ABC123');
+    });
+  });
+
+  it('returns input unchanged for unknown kinds', () => {
+    expect(normalizeBlocklistValue('weird', '  Mixed Case  ')).toBe('  Mixed Case  ');
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 2 / 2 of 8 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #008 / issue #94.

### Before

[apps/server/src/abuse/blocklist.ts](apps/server/src/abuse/blocklist.ts) did exact-string matching on `req.ip` / `req.address` / `hostContext.uid`. Three real-world bypasses:
- **IPv6-mapped IPv4** — admin types `1.2.3.4`, request socket surfaces `::ffff:1.2.3.4`, lookup misses.
- **NQ address case/spacing** — stored uppercase with single-space groups, incoming claim sends a no-space lowercase form (or vice versa), lookup misses.
- **Country / ASN** — leading zeros and case variation.

The insert path in [apps/server/src/routes/admin/blocklist.ts](apps/server/src/routes/admin/blocklist.ts) had the symmetrical problem: an admin who typed a non-canonical value got an entry that wouldn't match real traffic.

### After

1. **New helper** [`normalizeBlocklistValue(kind, value)`](packages/core/src/blocklistNormalize.ts) in `@faucet/core` (exported alongside `normalizeNimiqAddress`). Strips `::ffff:`/zone-id and lower-cases for `ip`; reuses `normalizeNimiqAddress` for `address`; uppercase for `country`; integer-parse for `asn` (drops leading zeros, defensive passthrough on unparseable); trim for `uid`.
2. **Lookup path** ([apps/server/src/abuse/blocklist.ts](apps/server/src/abuse/blocklist.ts)) canonicalises before each kind's query.
3. **Insert path** ([apps/server/src/routes/admin/blocklist.ts](apps/server/src/routes/admin/blocklist.ts)) canonicalises parsed `value` before INSERT and audit-logs the canonical form.
4. **Boot migration** ([apps/server/src/abuse/blocklistMigrate.ts](apps/server/src/abuse/blocklistMigrate.ts)) walks every existing row at app startup and rewrites the value to its canonical form. Idempotent — re-running is a no-op. Wired into `buildApp()` right after `openDb()`; logs once if any row actually changed.

### Regression coverage

- [packages/core/test/blocklistNormalize.test.ts](packages/core/test/blocklistNormalize.test.ts) — **11 new unit cases** covering ip (mapped v4, v6 case, zone-id, whitespace), address (case + multi-space collapse), country (case), asn (leading zeros, unparseable passthrough), uid (case-preserving trim), and unknown-kind passthrough.
- [apps/server/test/blocklist-normalization.e2e.test.ts](apps/server/test/blocklist-normalization.e2e.test.ts) — **2 e2e cases**: (a) `POST /v1/claim` with `X-Forwarded-For: ::ffff:203.0.113.42` against a stored `203.0.113.42` block returns 403/deny; (b) a row inserted in the non-canonical form gets rewritten on the next `buildApp()` boot.

## Test plan

- [x] `pnpm --filter @faucet/core test` — 19/19 (was 8, +11)
- [x] `pnpm --filter @faucet/server test` — 91/91 (was 89, +2)
- [x] `pnpm -r build` — clean

## Closes

- Closes #94 (audit finding #008)

🤖 Generated with [Claude Code](https://claude.com/claude-code)