### PR TITLE
fix(server): strip trust-claim fields from unsigned hostContext (closes #96)

### DIFF
--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -2,7 +2,12 @@ import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { and, desc, eq, gte, isNull, isNotNull, or, sql } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
-import { DriverError, canonicalizeHostContext, type ClaimRequest } from '@faucet/core';
+import {
+  DriverError,
+  canonicalizeHostContext,
+  stripUnsignedHostContext,
+  type ClaimRequest,
+} from '@faucet/core';
 import { mintChallenge } from '@faucet/abuse-hashcash';
 import { claims, integratorKeys } from '../db/schema.js';
 import type { AppContext } from '../context.js';
@@ -195,6 +200,20 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     // counter immediately. Rejected/challenged claims decrement below.
     await incrementIpCounter(ctx.db, req.ip, now);
 
+    // #96 trust-boundary: when hostContext is present but unverified
+    // (no/bad integrator HMAC), strip every claim-bearing field before
+    // the abuse pipeline sees it. A forged `kycLevel: 'id'` /
+    // `verifiedIdentities: [...]` / etc. must not nudge scoring in the
+    // attacker's favour. The empty-object form preserves the
+    // "context attempted, failed verification" signal that fingerprint
+    // already penalises softly.
+    const safeHostContext =
+      parsed.data.hostContext !== undefined
+        ? hostContextVerified
+          ? parsed.data.hostContext
+          : stripUnsignedHostContext(parsed.data.hostContext)
+        : undefined;
+
     const claimReq: ClaimRequest = {
       address,
       ip: req.ip,
@@ -202,7 +221,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       captchaToken: parsed.data.captchaToken,
       hashcashSolution: parsed.data.hashcashSolution,
       fingerprint: parsed.data.fingerprint,
-      hostContext: parsed.data.hostContext,
+      hostContext: safeHostContext,
       hostContextVerified,
       integratorId,
       requestedAt: now,

--- a/apps/server/test/host-context-trust-boundary.e2e.test.ts
+++ b/apps/server/test/host-context-trust-boundary.e2e.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for #96: a forged hostContext (no integrator HMAC, no
+ * per-field signature) must not contribute trust-claim fields to the
+ * abuse pipeline. The route strips kycLevel / accountAgeDays /
+ * emailDomainHash / tags / verifiedIdentities before the request hits
+ * the pipeline; correlation hashes (uid / cookieHash / sessionHash) are
+ * preserved so the fingerprint layer can still do its work.
+ *
+ * We assert at the seam: read back the persisted claim row's
+ * `signalsJson` and confirm the AI layer's feature bundle saw an empty
+ * `verifiedIdentityCount` and `hostContextVerified === 0` (unsigned-
+ * present), regardless of what the request body claimed.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { claims } from '../src/db/schema.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+
+class FakeDriver extends BaseTestDriver {
+  override async send(): Promise<string> { return 'tx_x'; }
+  override async waitForConfirmation(): Promise<void> {}
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: 'test-password-123',
+    aiEnabled: 'true',
+    dev: 'true',
+    ...overrides,
+  });
+}
+
+describe('hostContext trust-boundary (#96)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-host-trust-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('strips trust-claim fields from an unsigned hostContext before the AI scorer sees them', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+
+    // Forged context: claims maximum trust without any HMAC. Includes
+    // correlation hashes that should survive (preserved for fingerprint).
+    const res = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: {
+        address: USER_ADDR,
+        hostContext: {
+          uid: 'u-forged',
+          cookieHash: 'c-forged',
+          kycLevel: 'id',
+          accountAgeDays: 365,
+          emailDomainHash: 'forged-domain',
+          verifiedIdentities: ['google', 'apple', 'github'],
+          tags: ['premium'],
+          // No signature → request never enters the verified path.
+        },
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBe(200);
+
+    // The persisted claim's signalsJson is the per-check bundle the
+    // pipeline emitted. Pull the latest row and assert the AI layer's
+    // features saw zero verified identities + hostContextVerified === 0.
+    const [row] = await built.ctx.db
+      .select()
+      .from(claims)
+      .where(eq(claims.address, USER_ADDR))
+      .limit(1);
+    expect(row).toBeTruthy();
+    const signals = JSON.parse(row!.signalsJson) as Record<string, unknown>;
+    const ai = signals.ai as { features?: Record<string, number> } | undefined;
+    expect(ai).toBeDefined();
+    expect(ai!.features).toBeDefined();
+    expect(ai!.features!.verifiedIdentityCount).toBe(0);
+    // 0 = unsigned-present (because cookieHash/uid kept the object truthy);
+    // 0.5 would be absent. The forged trust fields were dropped before
+    // the features extractor ran.
+    expect(ai!.features!.hostContextVerified).toBe(0);
+  });
+});

--- a/packages/core/src/hostContext.ts
+++ b/packages/core/src/hostContext.ts
@@ -37,3 +37,35 @@ export function canonicalizeHostContext(ctx: HostContext): string {
   }
   return JSON.stringify(entries);
 }
+
+/**
+ * Trust-boundary defence (#96). When the integrator's HMAC signature on a
+ * `hostContext` is missing or invalid, the **trust-claim** fields are
+ * attacker-controlled — a forged `kycLevel: 'id'` or
+ * `verifiedIdentities: ['google']` could nudge scoring in the attacker's
+ * favour without any cryptographic backing. Strip these.
+ *
+ * Correlation fields (`uid`, `cookieHash`, `sessionHash`) are also
+ * attacker-controllable, but the fingerprint layer's job is precisely
+ * to detect inconsistencies *between* them and a stable visitor-id —
+ * lying about a UID either lets the attacker evade correlation (no worse
+ * than not sending a UID at all) or trips correlation themselves. Keep
+ * these fields so fingerprint can still do its work on unsigned traffic.
+ *
+ * The route layer calls this on the unsigned path before the value
+ * enters the abuse pipeline, so no AbuseCheck implementation needs to
+ * know about the threat.
+ */
+export function stripUnsignedHostContext(ctx: HostContext): HostContext {
+  const stripped: HostContext = {};
+  // Correlation hashes — attacker-controlled but not trust-claiming.
+  if (ctx.uid !== undefined) stripped.uid = ctx.uid;
+  if (ctx.cookieHash !== undefined) stripped.cookieHash = ctx.cookieHash;
+  if (ctx.sessionHash !== undefined) stripped.sessionHash = ctx.sessionHash;
+  // Preserve `signature` so request logs reflect that one was attempted
+  // (value is already known-bad here).
+  if (ctx.signature !== undefined) stripped.signature = ctx.signature;
+  // INTENTIONALLY DROPPED on the unsigned path:
+  //   accountAgeDays, emailDomainHash, kycLevel, tags, verifiedIdentities
+  return stripped;
+}

--- a/packages/core/test/hostContextStrip.test.ts
+++ b/packages/core/test/hostContextStrip.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { stripUnsignedHostContext } from '../src/index.js';
+
+describe('stripUnsignedHostContext (#96)', () => {
+  it('drops every trust-claim field', () => {
+    const forged = {
+      kycLevel: 'id' as const,
+      accountAgeDays: 365,
+      emailDomainHash: 'abcd',
+      verifiedIdentities: ['google', 'apple'],
+      tags: ['premium'],
+    };
+    const stripped = stripUnsignedHostContext(forged);
+    expect(stripped).toEqual({});
+  });
+
+  it('preserves correlation hashes (uid / cookieHash / sessionHash)', () => {
+    const ctx = {
+      uid: 'u-1',
+      cookieHash: 'c-1',
+      sessionHash: 's-1',
+      kycLevel: 'id' as const,
+      verifiedIdentities: ['google'],
+    };
+    const stripped = stripUnsignedHostContext(ctx);
+    expect(stripped).toEqual({
+      uid: 'u-1',
+      cookieHash: 'c-1',
+      sessionHash: 's-1',
+    });
+  });
+
+  it('preserves the (already-known-bad) signature for audit logging', () => {
+    const stripped = stripUnsignedHostContext({
+      signature: 'integrator:not-real-base64',
+      kycLevel: 'phone',
+    });
+    expect(stripped.signature).toBe('integrator:not-real-base64');
+    expect(stripped.kycLevel).toBeUndefined();
+  });
+
+  it('returns an empty object on an empty input', () => {
+    expect(stripUnsignedHostContext({})).toEqual({});
+  });
+
+  it('does not mutate the input', () => {
+    const original = {
+      uid: 'u-1',
+      kycLevel: 'id' as const,
+      verifiedIdentities: ['google'],
+    };
+    const snapshot = { ...original, verifiedIdentities: [...original.verifiedIdentities] };
+    stripUnsignedHostContext(original);
+    expect(original).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 2 / 4 of 8 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #010 / issue #96.

### Before

When a claim arrived with a `hostContext` object but no/invalid integrator HMAC, the server set `hostContextVerified = false` and **kept the entire object**. The AI rules layer's negative-weight bonus is already gated on `hostContextVerified === 1`, so the audit's worst-case scenario (a forged `verifiedIdentities` reducing risk score) didn't actually fire today — but every claim-bearing field still entered the pipeline. Any future rule that consumed forged `kycLevel: 'id'` or `accountAgeDays: 365` to soften an unrelated escalation would silently regress. Lock the boundary now.

### After

New helper [`stripUnsignedHostContext`](packages/core/src/hostContext.ts) in `@faucet/core`:

- **Preserved (correlation hashes)** — `uid`, `cookieHash`, `sessionHash`, `signature`. These are equally attacker-controllable, but the fingerprint layer's whole job is detecting inconsistencies between them and a stable visitor-id; dropping them would break correlation on unsigned traffic. Signature is kept so request logs reflect the (known-bad) value that was attempted.
- **Dropped (trust claims)** — `accountAgeDays`, `emailDomainHash`, `kycLevel`, `tags`, `verifiedIdentities`.

[apps/server/src/routes/claim.ts](apps/server/src/routes/claim.ts) feeds the stripped form into the `ClaimRequest` passed to the pipeline. The empty-but-truthy object keeps fingerprint's existing `unsignedContextPenalty` firing — we don't lose the "context attempted, failed verification" signal.

### Regression coverage

- [packages/core/test/hostContextStrip.test.ts](packages/core/test/hostContextStrip.test.ts) — 5 unit cases: strips trust fields, preserves correlation hashes, preserves signature for logging, no-op on empty, doesn't mutate input.
- [apps/server/test/host-context-trust-boundary.e2e.test.ts](apps/server/test/host-context-trust-boundary.e2e.test.ts) — e2e asserts the AI layer's persisted feature bundle for a claim with a forged hostContext shows `verifiedIdentityCount=0` and `hostContextVerified=0` (unsigned-present), regardless of what the request body claimed.

## Test plan

- [x] `pnpm --filter @faucet/core test` — 24/24 (was 19, +5)
- [x] `pnpm --filter @faucet/server test` — 92/92 (was 91, +1)
- [x] `pnpm -r build` — clean

## Closes

- Closes #96 (audit finding #010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)