### PR TITLE
fix(abuse-geoip): hard-deny unknown country with allow-list active (closes #103)

### DIFF
--- a/packages/abuse-geoip/src/check.ts
+++ b/packages/abuse-geoip/src/check.ts
@@ -39,7 +39,15 @@ function evaluatePolicy(
       return { score: 1, decision: 'deny', reason: `country ${info.country} not in allow-list` };
     }
   } else if (allow) {
-    return { score: 0.9, reason: 'country unknown while allow-list active' };
+    // #103: an allow-list means "only these countries" — an unresolved
+    // country is by definition not in it. Hard deny instead of a soft
+    // 0.9 score that can be averaged below threshold by clean signals
+    // from other layers.
+    return {
+      score: 1,
+      decision: 'deny',
+      reason: 'country unknown while allow-list active',
+    };
   }
 
   if (info.asn && policy.denyAsns?.includes(info.asn)) {

--- a/packages/abuse-geoip/test/check.test.ts
+++ b/packages/abuse-geoip/test/check.test.ts
@@ -58,6 +58,32 @@ describe('geoipCheck', () => {
     expect(r.decision).toBe('deny');
   });
 
+  it('hard-denies an unresolved country when an allow-list is active (#103)', async () => {
+    // Resolver returns null country (new IP block, anonymizing proxy,
+    // stale DB). Pre-fix this returned a soft 0.9 score that could be
+    // averaged below threshold by clean signals from other layers; an
+    // allow-list means "only these countries" so unknown is by
+    // definition not in it.
+    const check = geoipCheck({
+      resolver: stubResolver({ country: null, asn: 65000 }),
+      policy: { allowCountries: ['US'] },
+    });
+    const r = await check.check(req());
+    expect(r.decision).toBe('deny');
+    expect(r.score).toBe(1);
+    expect(r.reason).toMatch(/country unknown while allow-list active/);
+  });
+
+  it('does not penalise an unresolved country when no allow-list is configured', async () => {
+    const check = geoipCheck({
+      resolver: stubResolver({ country: null }),
+      policy: {},
+    });
+    const r = await check.check(req());
+    expect(r.decision).toBeUndefined();
+    expect(r.score).toBe(0);
+  });
+
   it('denies explicit ASNs', async () => {
     const check = geoipCheck({
       resolver: stubResolver({ country: 'DE', asn: 16509, asnOrg: 'Amazon.com, Inc.' }),
@@ -100,13 +126,7 @@ describe('geoipCheck', () => {
     expect(r.reason).toMatch(/lookup failed/);
   });
 
-  it('treats unknown country as partial risk when allow-list is active', async () => {
-    const check = geoipCheck({
-      resolver: stubResolver({ country: null }),
-      policy: { allowCountries: ['DE'] },
-    });
-    const r = await check.check(req());
-    expect(r.score).toBeGreaterThan(0.5);
-    expect(r.decision).toBeUndefined();
-  });
+  // Pre-fix this asserted the soft-0.9-no-decision behaviour. After #103
+  // the contract is hard deny — covered by the new "hard-denies an
+  // unresolved country when an allow-list is active" test above.
 });


### PR DESCRIPTION
## Summary

Tranche 2 / 5 of 8 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #017 / issue #103.

### Before

[`packages/abuse-geoip/src/check.ts:41-42`](packages/abuse-geoip/src/check.ts) returned a soft score of `0.9` without a hard `decision` when a country allow-list was configured and the resolver returned `null` (new IP block, anonymizing proxy, stale GeoIP DB). The pipeline `denyThreshold` is `0.85`, but it's a weighted average — a single 0.9 signal can land below threshold when combined with clean returns from other layers, undermining the whitelist.

### After

The intent of an allow-list is "only these countries"; an unresolved country is by definition not in it. The branch now returns:

```ts
{ score: 1, decision: 'deny', reason: 'country unknown while allow-list active' }
```

### Regression coverage

[packages/abuse-geoip/test/check.test.ts](packages/abuse-geoip/test/check.test.ts):
- Replaced the existing "treats unknown country as partial risk" case (which asserted the old, buggy contract) with two new cases:
  1. **Hard deny** when an allow-list is active and resolver returns `null`.
  2. **No penalty** when no allow-list is configured (the same null result is silent — only the allow-list flips the policy).

## Test plan

- [x] `pnpm --filter @faucet/abuse-geoip test` — 10/10
- [x] `pnpm --filter @faucet/server test` — 92/92 (unchanged)
- [x] `pnpm -r build` — clean

## Closes

- Closes #103 (audit finding #017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)