### PR TITLE
fix(abuse-fingerprint): count anonymous-uid pool as one bucket (closes #105)

### DIFF
--- a/apps/server/src/abuse/fingerprintStore.ts
+++ b/apps/server/src/abuse/fingerprintStore.ts
@@ -32,8 +32,13 @@ export class DrizzleFingerprintStore implements FingerprintStore {
 
   async countUidsForVisitor(visitorId: string, windowMs: number): Promise<number> {
     const since = Date.now() - windowMs;
+    // #105: SQL's `COUNT(DISTINCT col)` ignores NULLs by definition, so a
+    // pool of purely-anonymous claims (uid IS NULL) under the same
+    // visitor wouldn't trip `maxUidsPerVisitor` at all. Coalesce nulls
+    // to one synthetic '__anon__' bucket so any anonymous traffic under
+    // a visitor counts as one extra distinct identity.
     const [row] = await this.db
-      .select({ n: sql<number>`COUNT(DISTINCT ${fingerprintLinks.uid})` })
+      .select({ n: sql<number>`COUNT(DISTINCT COALESCE(${fingerprintLinks.uid}, '__anon__'))` })
       .from(fingerprintLinks)
       .where(and(eq(fingerprintLinks.visitorId, visitorId), gte(fingerprintLinks.seenAt, since)));
     return row?.n ?? 0;

--- a/apps/server/test/fingerprint-store.test.ts
+++ b/apps/server/test/fingerprint-store.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the Drizzle fingerprint store. Exercises the post-#105
+ * COALESCE behaviour on `countUidsForVisitor` directly against a fresh
+ * SQLite DB rather than going through the full claim route.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { openDb, type Db } from '../src/db/index.js';
+import { DrizzleFingerprintStore } from '../src/abuse/fingerprintStore.js';
+
+describe('DrizzleFingerprintStore (#105)', () => {
+  let tmp: string;
+  let db: Db;
+  let store: DrizzleFingerprintStore;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-fp-store-'));
+    db = openDb({ dataDir: tmp });
+    store = new DrizzleFingerprintStore(db);
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('counts a pool of anonymous claims as one bucket (was zero pre-fix)', async () => {
+    const now = Date.now();
+    for (let i = 0; i < 5; i++) {
+      await store.record({
+        visitorId: 'visitor-X',
+        uid: null,
+        cookieHash: `cookie-${i}`,
+        seenAt: now,
+      });
+    }
+    const n = await store.countUidsForVisitor('visitor-X', 60_000);
+    // Pre-fix: 0 (NULLs ignored by COUNT(DISTINCT)).
+    // Post-fix: 1 (all NULLs collapse into the '__anon__' synthetic bucket).
+    expect(n).toBe(1);
+  });
+
+  it('counts mixed anonymous + named claims correctly', async () => {
+    const now = Date.now();
+    await store.record({ visitorId: 'visitor-Y', uid: null, cookieHash: 'c-a', seenAt: now });
+    await store.record({ visitorId: 'visitor-Y', uid: null, cookieHash: 'c-b', seenAt: now });
+    await store.record({ visitorId: 'visitor-Y', uid: 'real-uid-1', cookieHash: 'c-c', seenAt: now });
+    await store.record({ visitorId: 'visitor-Y', uid: 'real-uid-2', cookieHash: 'c-d', seenAt: now });
+    const n = await store.countUidsForVisitor('visitor-Y', 60_000);
+    // 1 anon bucket + 2 distinct real uids = 3.
+    expect(n).toBe(3);
+  });
+
+  it('counts two distinct named uids as two (regression: no double-counting)', async () => {
+    const now = Date.now();
+    await store.record({ visitorId: 'visitor-Z', uid: 'a', cookieHash: 'c-a', seenAt: now });
+    await store.record({ visitorId: 'visitor-Z', uid: 'b', cookieHash: 'c-b', seenAt: now });
+    const n = await store.countUidsForVisitor('visitor-Z', 60_000);
+    expect(n).toBe(2);
+  });
+
+  it('respects the time window — old rows do not contribute', async () => {
+    const now = Date.now();
+    await store.record({ visitorId: 'visitor-W', uid: null, cookieHash: 'old', seenAt: now - 120_000 });
+    await store.record({ visitorId: 'visitor-W', uid: 'fresh', cookieHash: 'new', seenAt: now });
+    const n = await store.countUidsForVisitor('visitor-W', 60_000);
+    // Only the fresh row falls inside the 60s window.
+    expect(n).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 2 / 6 of 8 from [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md). Closes audit finding #019 / issue #105.

### Before

[`apps/server/src/abuse/fingerprintStore.ts:countUidsForVisitor`](apps/server/src/abuse/fingerprintStore.ts) ran `COUNT(DISTINCT uid)`. SQL's `DISTINCT` ignores `NULL`s by definition, so a pool of purely-anonymous claims (`uid IS NULL`) under one visitor returned `0` — `maxUidsPerVisitor` could never fire. An attacker submitting N claims with `fingerprint.visitorId='X'` and no signed `hostContext` faced only the per-IP rate-limit, not fingerprint correlation.

### After

```sql
COUNT(DISTINCT COALESCE(uid, '__anon__'))
```

NULLs collapse into one synthetic anonymous bucket, so any amount of anonymous traffic under a visitor counts as one extra distinct identity. A second distinct identity (anonymous bucket + one real uid, or two real uids) trips the threshold the same way it did before for non-null cases.

The companion `countVisitorsForUid` is unaffected — it filters by `uid = <known-uid>` which can never match a `NULL` row by SQL semantics, and the consumer in `check.ts` only invokes that branch when uid is non-null.

### Regression coverage

[apps/server/test/fingerprint-store.test.ts](apps/server/test/fingerprint-store.test.ts) — 4 new cases against the store directly (no Fastify boot, no claim route):
1. **Pure anonymous pool** of 5 rows → returns 1 (was 0 pre-fix).
2. **Mixed** 2 anon rows + 2 distinct named → returns 3.
3. **Two distinct named** → returns 2 (regression: no double-counting from coalesce).
4. **Time window** respected — rows outside the lookback don't contribute.

## Test plan

- [x] `pnpm --filter @faucet/server test` — 96/96 (was 92, +4)
- [x] `pnpm -r build` — clean

## Closes

- Closes #105 (audit finding #019)

🤖 Generated with [Claude Code](https://claude.com/claude-code)