### PR TITLE
fix(server): scope idempotency by integratorId + address (closes #86)

### DIFF
--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -37,7 +37,18 @@ export function migrationStatements(dialect: Dialect): string[] {
     'CREATE INDEX IF NOT EXISTS idx_claims_created_at ON claims(created_at DESC)',
     'CREATE INDEX IF NOT EXISTS idx_claims_address ON claims(address)',
     'CREATE INDEX IF NOT EXISTS idx_claims_ip ON claims(ip)',
-    'CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_idempotency ON claims(idempotency_key) WHERE idempotency_key IS NOT NULL',
+    // #86: idempotency was previously keyed by `idempotency_key` alone,
+    // letting callers across unrelated integrators collide on the same
+    // string and read each other's claim status. Drop the global index
+    // and replace with a composite that's only enforced when an
+    // integrator is identified — `(integrator_id, idempotency_key)` with
+    // a partial-index predicate excluding nulls. The unauthenticated
+    // path scopes idempotency app-side by `(idempotency_key, address)`
+    // (see apps/server/src/routes/claim.ts).
+    'DROP INDEX IF EXISTS idx_claims_idempotency',
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_claims_idempotency_integrator
+      ON claims(integrator_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL AND integrator_id IS NOT NULL`,
 
     // --- blocklist ---
     `CREATE TABLE IF NOT EXISTS blocklist (

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -100,23 +100,6 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       return reply.code(400).send({ error: 'invalid body', issues: parsed.error.issues });
     }
 
-    // Idempotency: if the same key was used before, return the original result.
-    if (parsed.data.idempotencyKey) {
-      const [existing] = await ctx.db
-        .select()
-        .from(claims)
-        .where(eq(claims.idempotencyKey, parsed.data.idempotencyKey))
-        .limit(1);
-      if (existing) {
-        return reply.code(200).send({
-          id: existing.id,
-          status: existing.status,
-          txId: existing.txId ?? undefined,
-          idempotent: true,
-        });
-      }
-    }
-
     let integratorId: string | undefined;
     let hostContextVerified = false;
     const apiKey = req.headers['x-faucet-api-key'];
@@ -193,6 +176,37 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       return reply
         .code(400)
         .send({ error: 'invalid address', message: (err as Error).message });
+    }
+
+    // Idempotency lookup (#86). Scoped by:
+    //   - (integratorId, idempotencyKey) for authenticated callers — each
+    //     integrator's namespace is isolated; a colliding key from another
+    //     integrator never reads this one's claim.
+    //   - (idempotencyKey, address) for unauthenticated callers — the
+    //     "same logical request" can only be inferred from address + key.
+    // This sits AFTER auth + address parsing so we know the scope; before
+    // any IP counter / pipeline work, so a legitimate retry costs nothing.
+    if (parsed.data.idempotencyKey) {
+      const conds =
+        integratorId !== undefined
+          ? and(
+              eq(claims.idempotencyKey, parsed.data.idempotencyKey),
+              eq(claims.integratorId, integratorId),
+            )
+          : and(
+              eq(claims.idempotencyKey, parsed.data.idempotencyKey),
+              isNull(claims.integratorId),
+              eq(claims.address, address),
+            );
+      const [existing] = await ctx.db.select().from(claims).where(conds).limit(1);
+      if (existing) {
+        return reply.code(200).send({
+          id: existing.id,
+          status: existing.status,
+          txId: existing.txId ?? undefined,
+          idempotent: true,
+        });
+      }
     }
 
     // Increment the IP counter BEFORE the abuse pipeline to close the TOCTOU

--- a/apps/server/test/idempotency-scoping.e2e.test.ts
+++ b/apps/server/test/idempotency-scoping.e2e.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Regression tests for #86: idempotency-key scope. Pre-fix, the lookup was
+ * keyed globally on `idempotency_key` alone, so two unrelated callers
+ * could collide on the same string and read each other's claim status.
+ * Post-fix:
+ *
+ *   - Authenticated callers: scoped by (integratorId, idempotencyKey).
+ *     Two integrators with the same key never see each other's claim.
+ *   - Unauthenticated callers: scoped by (idempotencyKey, address). Two
+ *     anonymous callers with the same key but different addresses each
+ *     get their own claim; same key + same address replays.
+ */
+import { createHmac, randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authenticator } from '@otplib/preset-default';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const ADDR_A = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+const ADDR_B = 'NQ00 2222 2222 2222 2222 2222 2222 2222 2222';
+
+class FakeDriver extends BaseTestDriver {
+  public sends: Array<{ to: string; amount: bigint }> = [];
+  override async getBalance() { return 10_000_000n; }
+  override async send(to: string, amount: bigint): Promise<string> {
+    this.sends.push({ to, amount });
+    return `tx_${this.sends.length}`;
+  }
+}
+
+function signHmac(secret: string, parts: string[]): string {
+  return createHmac('sha256', secret).update(parts.join('\n')).digest('hex');
+}
+
+function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: dir,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: 'test-password-123',
+    dev: 'true',
+    ...overrides,
+  });
+}
+
+/** Seed admin + step-up TOTP, return cookies + secret for integrator-creation calls. */
+async function adminLogin(app: Awaited<ReturnType<typeof buildApp>>['app']) {
+  const seed = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: 'test-password-123' },
+    headers: { 'content-type': 'application/json' },
+  });
+  return {
+    session: parseCookie(seed.headers['set-cookie'], 'faucet_session')!,
+    csrf: parseCookie(seed.headers['set-cookie'], 'faucet_csrf')!,
+    totpSecret: seed.json().totpSecret as string,
+  };
+}
+
+async function createIntegrator(
+  app: Awaited<ReturnType<typeof buildApp>>['app'],
+  auth: { session: string; csrf: string; totpSecret: string },
+  id: string,
+): Promise<{ apiKey: string; hmacSecret: string }> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/admin/integrators',
+    payload: { id },
+    headers: {
+      'content-type': 'application/json',
+      'x-faucet-csrf': auth.csrf,
+      'x-faucet-totp': authenticator.generate(auth.totpSecret),
+    },
+    cookies: { faucet_session: auth.session, faucet_csrf: auth.csrf },
+  });
+  if (res.statusCode !== 201) throw new Error(`integrator create failed: ${res.statusCode} ${res.body}`);
+  const body = res.json();
+  return { apiKey: body.apiKey, hmacSecret: body.hmacSecret };
+}
+
+async function authenticatedClaim(
+  app: Awaited<ReturnType<typeof buildApp>>['app'],
+  integrator: { apiKey: string; hmacSecret: string },
+  body: Record<string, unknown>,
+) {
+  const payload = JSON.stringify(body);
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const sig = signHmac(integrator.hmacSecret, ['POST', '/v1/claim', ts, nonce, payload]);
+  return app.inject({
+    method: 'POST',
+    url: '/v1/claim',
+    payload,
+    headers: {
+      'content-type': 'application/json',
+      'x-faucet-api-key': integrator.apiKey,
+      'x-faucet-timestamp': ts,
+      'x-faucet-nonce': nonce,
+      'x-faucet-signature': sig,
+    },
+  });
+}
+
+describe('idempotency-key scoping (#86)', () => {
+  let tmp: string;
+  let apps: Array<Awaited<ReturnType<typeof buildApp>>['app']> = [];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-idem-'));
+  });
+
+  afterEach(async () => {
+    for (const a of apps) await a.close();
+    apps = [];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('two integrators using the same idempotency key get distinct claims', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+    const auth = await adminLogin(built.app);
+    const partnerA = await createIntegrator(built.app, auth, 'partner-a');
+    const partnerB = await createIntegrator(built.app, auth, 'partner-b');
+
+    const a = await authenticatedClaim(built.app, partnerA, {
+      address: ADDR_A,
+      idempotencyKey: 'shared-key',
+    });
+    expect(a.statusCode).toBe(200);
+    const aBody = a.json();
+    expect(aBody.idempotent).toBeUndefined();
+
+    const b = await authenticatedClaim(built.app, partnerB, {
+      address: ADDR_B,
+      idempotencyKey: 'shared-key',
+    });
+    expect(b.statusCode).toBe(200);
+    const bBody = b.json();
+    // Different claim id — partner B did NOT read partner A's row.
+    expect(bBody.id).not.toBe(aBody.id);
+    expect(bBody.idempotent).toBeUndefined();
+  });
+
+  it('the same integrator replaying the same key returns the original claim', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+    const auth = await adminLogin(built.app);
+    const partner = await createIntegrator(built.app, auth, 'partner-a');
+
+    const first = await authenticatedClaim(built.app, partner, {
+      address: ADDR_A,
+      idempotencyKey: 'retry-me',
+    });
+    expect(first.statusCode).toBe(200);
+    const firstId = first.json().id;
+
+    const second = await authenticatedClaim(built.app, partner, {
+      address: ADDR_A,
+      idempotencyKey: 'retry-me',
+    });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json();
+    expect(secondBody.idempotent).toBe(true);
+    expect(secondBody.id).toBe(firstId);
+  });
+
+  it('unauthenticated callers: same key + different addresses get distinct claims', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+
+    const a = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: ADDR_A, idempotencyKey: 'shared-anon-key' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(a.statusCode).toBe(200);
+    const aId = a.json().id;
+
+    const b = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: ADDR_B, idempotencyKey: 'shared-anon-key' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(b.statusCode).toBe(200);
+    const bBody = b.json();
+    expect(bBody.id).not.toBe(aId);
+    expect(bBody.idempotent).toBeUndefined();
+  });
+
+  it('unauthenticated callers: same key + same address replays the original', async () => {
+    const built = await buildApp(baseConfig(tmp), {
+      driverOverride: new FakeDriver(),
+      quietLogs: true,
+    });
+    apps.push(built.app);
+    await built.app.ready();
+
+    const first = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: ADDR_A, idempotencyKey: 'anon-retry' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(first.statusCode).toBe(200);
+    const firstId = first.json().id;
+
+    const second = await built.app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: ADDR_A, idempotencyKey: 'anon-retry' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json();
+    expect(secondBody.idempotent).toBe(true);
+    expect(secondBody.id).toBe(firstId);
+  });
+});


### PR DESCRIPTION
## Summary

Tranche 2 / 8 of 8 — final Tranche 2 item. Closes pre-existing audit issue #86.

### Before

`POST /v1/claim`'s idempotency lookup keyed solely on `idempotency_key`, and the unique index was global ([apps/server/src/db/migrations.ts:40](apps/server/src/db/migrations.ts#L40)). Two unrelated callers — different integrators, or anonymous callers with different addresses — could collide on the same key string and read each other's claim status, including the txId. The lookup also ran *before* auth verification, so a malicious caller could probe an integrator's keyspace without authenticating.

### After

Three coordinated changes:

1. **Move the lookup after auth + address parsing.** We need both `integratorId` and the parsed address to compute the scope.
2. **Scope the lookup**:
   - Authenticated: `WHERE idempotencyKey = ? AND integratorId = ?`
   - Unauthenticated: `WHERE idempotencyKey = ? AND integratorId IS NULL AND address = ?`
   For anonymous callers, address is the stable "same logical request" component — two anonymous callers asking for different addresses with the same key are clearly not the same request.
3. **Replace the global unique index** with a partial composite:
   ```sql
   CREATE UNIQUE INDEX idx_claims_idempotency_integrator
   ON claims(integrator_id, idempotency_key)
   WHERE idempotency_key IS NOT NULL AND integrator_id IS NOT NULL
   ```
   Protects authenticated paths at the DB level. Unauthenticated paths rely on app-level dedup (sufficient because anonymous callers don't have business-critical idempotency guarantees beyond their own retry).

### Regression coverage

[apps/server/test/idempotency-scoping.e2e.test.ts](apps/server/test/idempotency-scoping.e2e.test.ts) — 4 new cases:
1. **Two integrators, same key** → distinct claims (both succeed, ids differ).
2. **Same integrator, same key** → second call returns the first claim with `idempotent: true`.
3. **Anonymous, same key + different addresses** → distinct claims.
4. **Anonymous, same key + same address** → second call replays the first.

## Test plan

- [x] `pnpm --filter @faucet/server test` — 102/102 (was 98, +4)
- [x] `pnpm -r build` — clean

## Tranche 2 status

| # | Status |
|---|---|
| #91 captcha timeout + pipeline error boundary | ✅ #112 |
| #94 blocklist normalization | ✅ #114 |
| #95 hashcash replay cache | ✅ #123 |
| #96 unsigned hostContext zero-out | ✅ #124 |
| #103 geoip unknown-country deny | ✅ #125 |
| #105 fingerprint null-uid count | ✅ #126 |
| #85 integrator TOTP step-up | ✅ #127 |
| **#86 idempotency-key scope** | **this PR** |

Once this lands, Tranche 2 is complete.

## Closes

- Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)