### PR TITLE
test(e2e): harden admin doLogin against Firefox flake

### DIFF
--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -33,15 +33,34 @@ async function doLogin(page: Page, withTotp: boolean): Promise<void> {
     const code = totpCode(ADMIN_TOTP_SECRET);
     await page.locator('input[autocomplete="one-time-code"]').fill(code);
   }
-  await page.locator('button[type="submit"]').click();
-  // Ensure the login round-trip completes (cookies set, router moved) before
-  // the caller navigates away — otherwise subsequent goto()s race and the
-  // SPA sees no session yet.
+
+  // Wait for the login round-trip explicitly. `argon2id verifyPassword`
+  // dominates the cost on the second-login path and can take 1–3 s on
+  // a contended CI runner; combined with router.replace + Vue mount,
+  // the prior 10 s budget on `waitForURL` was tight enough to flake on
+  // Firefox specifically (twice — see admin.spec.ts:85 and :159 in
+  // recent runs). Awaiting the response in parallel with the click
+  // catches login failures with a clear error and bounds the wall-clock
+  // budget to a single round-trip plus 20 s for the SPA navigation.
+  const [loginResponse] = await Promise.all([
+    page.waitForResponse(
+      (res) =>
+        res.url().endsWith('/admin/auth/login') && res.request().method() === 'POST',
+      { timeout: 20_000 },
+    ),
+    page.locator('button[type="submit"]').click(),
+  ]);
+  if (loginResponse.status() !== 200) {
+    throw new Error(
+      `login POST returned ${loginResponse.status()}: ${await loginResponse.text()}`,
+    );
+  }
+
   if (withTotp) {
-    await page.waitForURL(/\/admin\/overview$/, { timeout: 10_000 });
+    await page.waitForURL(/\/admin\/overview$/, { timeout: 20_000 });
   } else {
     // First-login flow flips the login view into the enrolment panel.
-    await page.getByLabel('TOTP provisioning URI').waitFor({ timeout: 10_000 });
+    await page.getByLabel('TOTP provisioning URI').waitFor({ timeout: 20_000 });
   }
 }
 


### PR DESCRIPTION
## Summary

Two recent Firefox failures landed on the same line in `tests/e2e/admin.spec.ts:doLogin`:

- `admin.spec.ts:85` — *second login with password + TOTP lands on overview* (10.5 s)
- `admin.spec.ts:159` — *logout clears the session …* (10.5 s — entered via `doLogin`)

Both timed out at `page.waitForURL(/overview$/, { timeout: 10_000 })` after submitting password + TOTP. The cause: the login round-trip on the post-seed path runs argon2id `verifyPassword` (memoryCost=19 MiB, timeCost=2). On a contended CI runner that's 1–3 s; combined with the SPA's `await nextTick(); router.replace(...)` + Vue mount of the destination view + Firefox-specific overhead, the 10 s budget left no headroom.

### Changes

1. **Explicit response wait** — `Promise.all([waitForResponse, click])`. Login failures (401 / network) now throw with a clear error including status + body, instead of silently leaving the URL on `/login` until the URL-wait times out.
2. **Bump timeouts** — both `waitForURL(/overview$/)` and the first-login `getByLabel('TOTP provisioning URI').waitFor` go 10 s → 20 s. Plenty of headroom for argon2id + SPA navigation even on the slowest CI worker.

### Verification

Three consecutive full Firefox runs of `admin.spec.ts` locally — **8/8 passed** each time, total **24/24 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)