### PR TITLE
chore(helm): safe-default NetworkPolicy + opt-in PodDisruptionBudget

### DIFF
--- a/deploy/helm/templates/networkpolicy.yaml
+++ b/deploy/helm/templates/networkpolicy.yaml
@@ -1,4 +1,18 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- /*
+  Audit finding #021 / issue #101: when the operator opts into a
+  NetworkPolicy, default to a deny-all stance and let them whitelist what
+  the faucet actually needs. Previously the chart rendered empty
+  Ingress/Egress lists when no rules were supplied — Kubernetes treats
+  an empty rule list under `policyTypes: [Egress]` as **deny all egress**,
+  which broke the chart silently. The new default explicitly allows:
+    - DNS (53/UDP+TCP) so the faucet can resolve RPC + captcha hostnames
+    - Egress 443/TCP for HTTPS to captcha + RPC providers
+    - Egress 8648/TCP for the self-hosted Nimiq JSON-RPC default
+    - Ingress on the configured `service.targetPort` from any source
+  Operators with a stricter posture override `networkPolicy.ingress`
+  and `networkPolicy.egress` directly.
+*/ -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -12,12 +26,36 @@ spec:
   policyTypes:
     - Ingress
     - Egress
-  {{- with .Values.networkPolicy.ingress }}
   ingress:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.networkPolicy.egress }}
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    - from: []
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort | default 8080 }}
+    {{- end }}
   egress:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    # DNS (cluster-scoped resolver — kube-dns / coredns).
+    - to: []
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # HTTPS egress for captcha verification + remote Nimiq RPC.
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 443
+    # Self-hosted Nimiq JSON-RPC (default port 8648) — narrow this in
+    # production if the RPC node is in a known CIDR.
+    - to: []
+      ports:
+        - protocol: TCP
+          port: 8648
+    {{- end }}
 {{- end }}

--- a/deploy/helm/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/templates/poddisruptionbudget.yaml
@@ -1,0 +1,29 @@
+{{- /*
+  Audit finding #019 / issue #101: ship a PodDisruptionBudget template so
+  voluntary node drains (cluster autoscaler, version upgrades) don't take
+  down the faucet for the duration of a pod restart. Opt-in by default —
+  small clusters running `replicaCount: 1` shouldn't accidentally block
+  drains; bumping `replicaCount: 2+` and flipping `podDisruptionBudget.enabled`
+  is the recommended production path.
+
+  Operators set EITHER `minAvailable` OR `maxUnavailable`, not both
+  (Kubernetes rejects setting both). Default `minAvailable: 1` is safe
+  for replicaCount: 2+ and is a no-op for replicaCount: 1.
+*/ -}}
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nimiq-simple-faucet.fullname" . }}
+  labels:
+    {{- include "nimiq-simple-faucet.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "nimiq-simple-faucet.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -206,10 +206,23 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# Set enabled=true and the chart renders a NetworkPolicy. Commented block
-# below is a starting point for Nimiq RPC + captcha CDNs egress.
+# Audit finding #021 / issue #101: when enabled, the chart renders a
+# NetworkPolicy with safe defaults — ingress on `service.targetPort`,
+# egress on DNS + 443 + 8648 — so opting in doesn't silently DoS the
+# pod the way an empty `egress: []` rule list would.
+#
+# Override `ingress` / `egress` to lock egress down to specific CIDRs
+# in production (Nimiq RPC node, captcha provider IP ranges, etc.).
 networkPolicy:
   enabled: false
+  # ingress:
+  #   - from:
+  #       - namespaceSelector:
+  #           matchLabels:
+  #             kubernetes.io/metadata.name: ingress-nginx
+  #     ports:
+  #       - protocol: TCP
+  #         port: 8080
   # egress:
   #   - to:
   #       - ipBlock:
@@ -220,14 +233,18 @@ networkPolicy:
   #             - 192.168.0.0/16
   #     ports:
   #       - protocol: TCP
-  #         port: 443    # Nimiq RPC (https) + challenges.cloudflare.com + hcaptcha.com
+  #         port: 443
   #       - protocol: TCP
-  #         port: 8648   # Nimiq JSON-RPC (self-hosted node)
-  # ingress:
-  #   - from: []
-  #     ports:
-  #       - protocol: TCP
-  #         port: 8080
+  #         port: 8648
+
+# Audit finding #019 / issue #101: opt-in PodDisruptionBudget so cluster
+# drains / autoscaler-evictions don't take the faucet down. Set enabled
+# to true once `replicaCount` is 2 or higher; at 1 replica the PDB is a
+# no-op (any disruption is necessarily 100%).
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1   # set this OR minAvailable, not both
 
 # Bitnami subchart passthrough. See their docs for full values.
 #


### PR DESCRIPTION
## Summary

Tranche 3d — closes audit findings #019 + #021 / issue #101.

### NetworkPolicy

Previously the chart rendered empty \`ingress: []\` / \`egress: []\` lists when an operator set \`networkPolicy.enabled=true\` without supplying rules. Kubernetes treats an empty list under \`policyTypes: [Egress]\` as **deny all egress**, which silently broke the chart — captcha verification, RPC calls, and even DNS were all blocked.

Default rules now render when \`ingress\` / \`egress\` are unset:
- **Ingress**: on \`service.targetPort\` (default 8080) from any source
- **Egress**: DNS (53/UDP+TCP) + HTTPS (443/TCP) + Nimiq JSON-RPC (8648/TCP)

Operators with a stricter posture override the rules to lock egress down to specific CIDRs (RPC node, captcha provider IP ranges).

Default \`enabled: false\` is unchanged — small clusters and dev environments don't need to opt in.

### PodDisruptionBudget

New optional template \`poddisruptionbudget.yaml\`, gated by \`podDisruptionBudget.enabled\` (default \`false\`). When enabled, \`minAvailable: 1\` is the safe default; production deployments at \`replicaCount: 2+\` flip it to true so cluster drains and autoscaler evictions don't take the faucet down. At \`replicaCount: 1\` the PDB is a no-op so leaving it disabled-by-default avoids a footgun for small deployments.

## Test plan

- [x] \`values.yaml\` parses as YAML
- [ ] \`helm lint deploy/helm\` passes (CI runs this on the chart-publish path; local helm not available)
- [ ] \`helm template deploy/helm --set networkPolicy.enabled=true\` renders the new default ingress/egress
- [ ] \`helm template deploy/helm --set podDisruptionBudget.enabled=true\` renders the PDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)