### PR TITLE
fix(sdk-*): randomNonce, tx confirmation timeout, cross-SDK hostContext HMAC parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ pnpm-lock.yaml.backup
 .dart_tool
 build
 target
+# Library packages should not commit pubspec.lock (per Dart pub docs).
+packages/sdk-flutter/pubspec.lock
 
 # Test artifacts
 test-results/

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -158,6 +158,20 @@ export const ServerConfigSchema = z.object({
   metricsEnabled: z.coerce.boolean().default(true),
   reconcileEnabled: z.coerce.boolean().default(true),
   reconcileIntervalMs: z.coerce.number().int().min(10_000).default(5 * 60_000),
+
+  /**
+   * How long the driver waits for a broadcast tx to confirm before
+   * marking the claim `timeout`. Issue #84: the previous default of
+   * 60 s was shorter than Albatross's 120-block validity window
+   * (~120 s at 1-second block time), so under network slowdowns the
+   * faucet would prematurely flip a still-valid in-flight tx to
+   * `timeout` even though it eventually got included.
+   *
+   * 180 s gives a full validity window plus a small finality buffer;
+   * operators on a faster/slower network bake their own value via
+   * `FAUCET_CONFIRMATION_TIMEOUT_MS`. Lower bound 30 s for tests.
+   */
+  confirmationTimeoutMs: z.coerce.number().int().min(30_000).default(180_000),
 });
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
@@ -233,6 +247,7 @@ const ENV_KEYS: Record<string, string> = {
   metricsEnabled: 'FAUCET_METRICS_ENABLED',
   reconcileEnabled: 'FAUCET_RECONCILE_ENABLED',
   reconcileIntervalMs: 'FAUCET_RECONCILE_INTERVAL_MS',
+  confirmationTimeoutMs: 'FAUCET_CONFIRMATION_TIMEOUT_MS',
 };
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -366,8 +366,11 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     ctx.stream.publish({ type: 'claim.broadcast', id, address, txId });
 
     // Confirm asynchronously; don't block the response.
+    // Issue #84: pass the configured timeout so the driver default
+    // (60 s) doesn't prematurely flip a still-valid tx to `timeout`
+    // when the network is slow.
     ctx.driver
-      .waitForConfirmation(txId)
+      .waitForConfirmation(txId, ctx.config.confirmationTimeoutMs)
       .then(async () => {
         await ctx.db.update(claims).set({ status: 'confirmed' }).where(eq(claims.id, id));
         ctx.stream.publish({ type: 'claim.confirmed', id, address, txId });

--- a/packages/driver-nimiq-rpc/src/index.ts
+++ b/packages/driver-nimiq-rpc/src/index.ts
@@ -234,7 +234,11 @@ export class NimiqRpcDriver implements CurrencyDriver {
     return hash as TxId;
   }
 
-  async waitForConfirmation(tx: TxId, timeoutMs = 60_000): Promise<void> {
+  // Issue #84: default 180 s ≈ Albatross's 120-block validity window
+  // (~120 s @ 1 s blocks) + a small finality buffer. The previous 60 s
+  // default flipped still-valid in-flight txs to `timeout` whenever the
+  // network slowed. Callers can still pass a shorter value for tests.
+  async waitForConfirmation(tx: TxId, timeoutMs = 180_000): Promise<void> {
     if (this.#readyPromise) await this.#readyPromise;
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/packages/driver-nimiq-wasm/src/index.ts
+++ b/packages/driver-nimiq-wasm/src/index.ts
@@ -189,7 +189,11 @@ export class NimiqWasmDriver implements CurrencyDriver {
     }
   }
 
-  async waitForConfirmation(tx: TxId, timeoutMs = 60_000): Promise<void> {
+  // Issue #84: default 180 s ≈ Albatross's 120-block validity window
+  // (~120 s @ 1 s blocks) + a small finality buffer. The previous 60 s
+  // default flipped still-valid in-flight txs to `timeout` whenever the
+  // network slowed. Callers can still pass a shorter value for tests.
+  async waitForConfirmation(tx: TxId, timeoutMs = 180_000): Promise<void> {
     if (this.#readyPromise) await this.#readyPromise;
     const { client } = this.#requireReady();
     const deadline = Date.now() + timeoutMs;

--- a/packages/sdk-flutter/lib/nimiq_faucet.dart
+++ b/packages/sdk-flutter/lib/nimiq_faucet.dart
@@ -5,5 +5,5 @@ library nimiq_faucet;
 
 export 'src/client.dart';
 export 'src/hashcash.dart' show solveHashcash;
-export 'src/hmac.dart' show signHmac, canonicalString;
+export 'src/hmac.dart' show signHmac, canonicalString, signHostContext;
 export 'src/types.dart';

--- a/packages/sdk-flutter/lib/src/hmac.dart
+++ b/packages/sdk-flutter/lib/src/hmac.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
+import 'types.dart';
+
 /// Canonical string to HMAC-sign, matching apps/server/src/hmac.ts:
 ///   "<METHOD>\n<path>\n<timestamp>\n<nonce>\n<body>"
 String canonicalString(
@@ -17,4 +19,76 @@ String canonicalString(
 String signHmac(String secret, String data) {
   final mac = Hmac(sha256, utf8.encode(secret));
   return mac.convert(utf8.encode(data)).toString();
+}
+
+/// Fields included in the hostContext signature, in the exact order the
+/// server canonicalizes them. Must mirror `CANONICAL_FIELDS` in
+/// packages/core/src/hostContext.ts.
+const _canonicalHostContextFields = <String>[
+  'uid',
+  'cookieHash',
+  'sessionHash',
+  'accountAgeDays',
+  'emailDomainHash',
+  'kycLevel',
+  'tags',
+  'verifiedIdentities',
+];
+
+/// Canonical JSON for HMAC-signing a [HostContext]. Mirrors
+/// `canonicalizeHostContext` in packages/core/src/hostContext.ts: a JSON
+/// array of `[key, value]` pairs in [_canonicalHostContextFields] order,
+/// with array values lexicographically sorted.
+String _canonicalizeHostContext(HostContext ctx) {
+  final values = <String, dynamic>{};
+  if (ctx.uid != null) values['uid'] = ctx.uid;
+  if (ctx.cookieHash != null) values['cookieHash'] = ctx.cookieHash;
+  if (ctx.sessionHash != null) values['sessionHash'] = ctx.sessionHash;
+  if (ctx.accountAgeDays != null) values['accountAgeDays'] = ctx.accountAgeDays;
+  if (ctx.emailDomainHash != null) {
+    values['emailDomainHash'] = ctx.emailDomainHash;
+  }
+  if (ctx.kycLevel != null) values['kycLevel'] = ctx.kycLevel;
+  if (ctx.tags != null && ctx.tags!.isNotEmpty) {
+    final sorted = List<String>.from(ctx.tags!)..sort();
+    values['tags'] = sorted;
+  }
+  // verifiedIdentities not yet on the Dart HostContext; the canonical
+  // order below already accounts for it so once added it lines up.
+  final entries = <List<dynamic>>[];
+  for (final k in _canonicalHostContextFields) {
+    final v = values[k];
+    if (v == null) continue;
+    entries.add([k, v]);
+  }
+  return jsonEncode(entries);
+}
+
+/// Sign a [HostContext] with an integrator HMAC secret and return a copy
+/// whose `signature` is set to `<integratorId>:<base64-hmac>`. Mirrors
+/// `FaucetClient.signHostContext` in packages/sdk-ts/src/index.ts and
+/// `SignHostContext` in packages/sdk-go/hmac.go (closes audit
+/// Improvement #104).
+///
+/// Run this on your BACKEND — never expose [hmacSecret] to the device.
+/// Pass the signed context through to the on-device SDK's claim() call.
+HostContext signHostContext(
+  HostContext ctx,
+  String integratorId,
+  String hmacSecret,
+) {
+  final canonical = _canonicalizeHostContext(ctx);
+  final mac = Hmac(sha256, utf8.encode(hmacSecret));
+  final digest = mac.convert(utf8.encode(canonical));
+  final sig = '$integratorId:${base64.encode(digest.bytes)}';
+  return HostContext(
+    uid: ctx.uid,
+    cookieHash: ctx.cookieHash,
+    sessionHash: ctx.sessionHash,
+    accountAgeDays: ctx.accountAgeDays,
+    emailDomainHash: ctx.emailDomainHash,
+    kycLevel: ctx.kycLevel,
+    tags: ctx.tags,
+    signature: sig,
+  );
 }

--- a/packages/sdk-flutter/test/client_test.dart
+++ b/packages/sdk-flutter/test/client_test.dart
@@ -56,6 +56,27 @@ void main() {
       final got = signHmac('secret', 'data');
       expect(got, '1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db');
     });
+
+    // Cross-SDK fixture: canonical bytes + signature here come from
+    // packages/core/dist/index.js#canonicalizeHostContext (the server's
+    // source-of-truth) and are replayed by every SDK to prove byte-for-
+    // byte parity (closes audit Improvement #104). Same fixture as the
+    // Go test in packages/sdk-go/faucet_test.go.
+    test('signHostContext matches the server fixture', () {
+      const ctx = HostContext(
+        uid: 'user-42',
+        cookieHash: 'a1b2c3',
+        accountAgeDays: 365,
+        kycLevel: 'phone',
+        // Tags supplied UNSORTED on purpose — the canonicalizer must sort.
+        tags: ['z-tag', 'a-tag', 'm-tag'],
+      );
+      final signed = signHostContext(ctx, 'acme-corp', 'super-secret-hmac-key-for-testing');
+      expect(
+        signed.signature,
+        'acme-corp:2ro3gqXVYo9YQf4biq3VQZP9nS2M9LItJESSuXfqxow=',
+      );
+    });
   });
 
   group('FaucetException', () {

--- a/packages/sdk-go/faucet_test.go
+++ b/packages/sdk-go/faucet_test.go
@@ -187,6 +187,69 @@ func TestRequestChallengeAndSolve(t *testing.T) {
 	}
 }
 
+// Cross-SDK fixture: the canonical bytes + signature here are generated
+// from packages/core/dist/index.js#canonicalizeHostContext (the
+// server's source-of-truth implementation) and replayed by every SDK to
+// prove byte-for-byte parity (closes audit Improvement #104).
+//
+// If you change CANONICAL_FIELDS or canonicalizeHostContext in the
+// core package, regenerate the fixture by running the snippet at the
+// top of packages/sdk-go/hmac.go's docstring and update every SDK's
+// copy of these constants — then rerun the cross-SDK tests.
+const fixtureCanonical = `[["uid","user-42"],["cookieHash","a1b2c3"],["accountAgeDays",365],["kycLevel","phone"],["tags",["a-tag","m-tag","z-tag"]]]`
+const fixtureSignature = "acme-corp:2ro3gqXVYo9YQf4biq3VQZP9nS2M9LItJESSuXfqxow="
+
+func TestSignHostContextMatchesServerFixture(t *testing.T) {
+	uid := "user-42"
+	cookieHash := "a1b2c3"
+	var ageDays float64 = 365
+	kyc := "phone"
+	ctx := HostContext{
+		UID:            &uid,
+		CookieHash:     &cookieHash,
+		AccountAgeDays: &ageDays,
+		KYCLevel:       &kyc,
+		// Tags supplied UNSORTED on purpose — the canonicalizer must sort.
+		Tags: []string{"z-tag", "a-tag", "m-tag"},
+	}
+	canonical, err := canonicalizeHostContext(&ctx)
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if canonical != fixtureCanonical {
+		t.Fatalf("canonical mismatch:\n got=%s\nwant=%s", canonical, fixtureCanonical)
+	}
+	signed, err := SignHostContext(ctx, "acme-corp", "super-secret-hmac-key-for-testing")
+	if err != nil {
+		t.Fatalf("sign failed: %v", err)
+	}
+	if signed.Signature == nil || *signed.Signature != fixtureSignature {
+		got := "<nil>"
+		if signed.Signature != nil {
+			got = *signed.Signature
+		}
+		t.Fatalf("signature mismatch:\n got=%s\nwant=%s", got, fixtureSignature)
+	}
+}
+
+func TestSignHostContextDoesNotMutateInput(t *testing.T) {
+	uid := "user-42"
+	ctx := HostContext{UID: &uid, Tags: []string{"b", "a"}}
+	originalTags := append([]string(nil), ctx.Tags...)
+	_, err := SignHostContext(ctx, "id", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range originalTags {
+		if ctx.Tags[i] != v {
+			t.Fatalf("input mutated: tags[%d] = %q, want %q", i, ctx.Tags[i], v)
+		}
+	}
+	if ctx.Signature != nil {
+		t.Fatalf("input mutated: ctx.Signature became %v", *ctx.Signature)
+	}
+}
+
 func TestWaitForConfirmationTimesOut(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ClaimResponse{ID: "x", Status: "broadcast"})

--- a/packages/sdk-go/hmac.go
+++ b/packages/sdk-go/hmac.go
@@ -4,7 +4,10 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"sort"
 	"strings"
 )
 
@@ -33,4 +36,99 @@ func randomNonce() string {
 		return ""
 	}
 	return hex.EncodeToString(buf)
+}
+
+// canonicalHostContextFields lists the fields included in the
+// hostContext signature, in the exact order the server expects. Must
+// match `CANONICAL_FIELDS` in packages/core/src/hostContext.ts.
+var canonicalHostContextFields = [...]string{
+	"uid",
+	"cookieHash",
+	"sessionHash",
+	"accountAgeDays",
+	"emailDomainHash",
+	"kycLevel",
+	"tags",
+	"verifiedIdentities",
+}
+
+// canonicalizeHostContext serialises the trust-claim fields of a HostContext
+// in the same shape the server canonicalizes for HMAC signing — a JSON
+// array of [key, value] pairs in CANONICAL_FIELDS order, with array
+// values lexicographically sorted. Mirrors
+// packages/core/src/hostContext.ts#canonicalizeHostContext.
+//
+// Note: HostContext currently has no VerifiedIdentities field on the
+// Go struct (the server schema does); when that field is added, plumb
+// it through here too.
+func canonicalizeHostContext(ctx *HostContext) (string, error) {
+	if ctx == nil {
+		return "[]", nil
+	}
+	type entry struct {
+		key   string
+		value interface{}
+	}
+	values := map[string]interface{}{}
+	if ctx.UID != nil {
+		values["uid"] = *ctx.UID
+	}
+	if ctx.CookieHash != nil {
+		values["cookieHash"] = *ctx.CookieHash
+	}
+	if ctx.SessionHash != nil {
+		values["sessionHash"] = *ctx.SessionHash
+	}
+	if ctx.AccountAgeDays != nil {
+		values["accountAgeDays"] = *ctx.AccountAgeDays
+	}
+	if ctx.EmailDomainHash != nil {
+		values["emailDomainHash"] = *ctx.EmailDomainHash
+	}
+	if ctx.KYCLevel != nil {
+		values["kycLevel"] = *ctx.KYCLevel
+	}
+	if len(ctx.Tags) > 0 {
+		// Sort a copy so we don't mutate the caller's slice.
+		sorted := append([]string(nil), ctx.Tags...)
+		sort.Strings(sorted)
+		values["tags"] = sorted
+	}
+	// verifiedIdentities not yet on the Go HostContext struct; leave a
+	// hook here so the canonical order matches the server when it is.
+	entries := make([][2]interface{}, 0, len(canonicalHostContextFields))
+	for _, k := range canonicalHostContextFields {
+		v, ok := values[k]
+		if !ok {
+			continue
+		}
+		entries = append(entries, [2]interface{}{k, v})
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// SignHostContext signs a HostContext with an integrator HMAC secret and
+// returns a copy whose Signature is set to "<integratorID>:<base64-hmac>".
+// The signature uses HMAC-SHA256 over the canonical JSON the server
+// reconstructs; mirrors `FaucetClient.signHostContext` in the TS SDK
+// (packages/sdk-ts/src/index.ts).
+//
+// Run this on your BACKEND — never expose hmacSecret to the browser.
+// Pass the signed context through to the browser SDK's Claim() call
+// (closes audit Improvement #104).
+func SignHostContext(ctx HostContext, integratorID, hmacSecret string) (HostContext, error) {
+	canonical, err := canonicalizeHostContext(&ctx)
+	if err != nil {
+		return HostContext{}, err
+	}
+	mac := hmac.New(sha256.New, []byte(hmacSecret))
+	mac.Write([]byte(canonical))
+	sig := integratorID + ":" + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	out := ctx
+	out.Signature = &sig
+	return out, nil
 }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -314,13 +314,33 @@ export { ClaimManager, type ClaimState, type FaucetClaimClient } from './claimMa
 export { StatusPoller, type StatusState, type FaucetStatusClient } from './statusPoller.js';
 export { StreamManager, type FaucetStreamClient } from './streamManager.js';
 
+/**
+ * Audit finding #018 / issue #98: the integrator HMAC nonce is anti-replay
+ * protection — the server rejects nonces it has seen before, so an
+ * attacker who can predict the next nonce can pre-register it and
+ * deny-of-service the legitimate request, or replay an in-flight one.
+ * `Math.random` is not cryptographically random; the previous fallback
+ * preserved request shape on legacy embedded runtimes but quietly
+ * weakened the security property. Refuse to mint a nonce when WebCrypto
+ * is unavailable so the integrator gets a clear error at the call site
+ * rather than a silent downgrade.
+ *
+ * Every supported runtime — Node 22+, modern browsers, Cloudflare
+ * Workers, Deno, Bun — exposes `globalThis.crypto.getRandomValues`. If
+ * a deployment hits this throw, the runtime is older than the SDK's
+ * stated support floor (see packages/sdk-ts/package.json#engines).
+ */
 function randomNonce(): string {
-  const buf = new Uint8Array(16);
   const c = globalThis.crypto;
-  if (c && typeof c.getRandomValues === 'function') {
-    c.getRandomValues(buf);
-  } else {
-    for (let i = 0; i < buf.length; i++) buf[i] = Math.floor(Math.random() * 256);
+  if (!c || typeof c.getRandomValues !== 'function') {
+    throw new Error(
+      'sdk-ts: WebCrypto getRandomValues is unavailable. The integrator ' +
+        'HMAC nonce must be cryptographically random; refusing to fall ' +
+        'back to Math.random. Use Node 22+, a recent browser, or a ' +
+        'WebCrypto-capable Worker runtime.',
+    );
   }
+  const buf = new Uint8Array(16);
+  c.getRandomValues(buf);
   return toHex(buf);
 }


### PR DESCRIPTION
## Summary

Tranche 4 — three independent fixes with shared SDK touchpoints. Closes audit finding #018 / issue #98, pre-existing #84, and audit Improvement #104.

### #98 — sdk-ts randomNonce hardening

The integrator HMAC nonce is anti-replay protection: the server rejects nonces it has seen, so a predictable nonce lets an attacker pre-register the next one (DoS) or replay an in-flight request. The previous fallback to Math.random when WebCrypto was missing preserved request shape on legacy embedded runtimes but quietly weakened the property.

randomNonce() now throws when globalThis.crypto.getRandomValues is unavailable instead of falling back.

### #84 — confirmation timeout alignment with Nimiq tx validity

Default waitForConfirmation(tx) timeout was 60 s in both drivers, shorter than Albatross's 120-block validity window (~120 s @ 1 s blocks). Bumped driver defaults to 180 s (validity window + finality buffer); server passes the timeout via the new FAUCET_CONFIRMATION_TIMEOUT_MS env var.

### #104 — sdk-go + sdk-flutter hostContext HMAC parity

The TS SDK has had FaucetClient.signHostContext since the trust-boundary work landed; the Go and Dart SDKs were the only laggards. Both SDKs now expose:
- sdk-go: faucet.SignHostContext(ctx, integratorID, hmacSecret)
- sdk-flutter: nimiq_faucet.signHostContext(ctx, integratorId, hmacSecret)

Cross-SDK fixture parity is CI-enforced. Fixture canonical bytes + signature generated from packages/core/dist/index.js#canonicalizeHostContext (server source-of-truth) and replayed in TestSignHostContextMatchesServerFixture (Go) and 'signHostContext matches the server fixture' (Dart).

## Test plan

- [x] pnpm typecheck clean across 32 tasks
- [x] pnpm test clean across 24 tasks
- [x] dart test in packages/sdk-flutter — 7/7 (including new fixture-replay test)
- [ ] CI green on this PR