### PR TITLE
docs(security): trust-model, GHSA channel, GeoIP staleness in /readyz, signer memory hygiene

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,16 @@ Please report suspected vulnerabilities privately. Do **not** open a public
 GitHub issue, a pull request, or a discussion thread for undisclosed
 vulnerabilities.
 
-- Email: `richy@nimiq.com`
+Two private channels — pick whichever fits:
+
+- **GitHub Security Advisory** (preferred for technical reports). Open a
+  draft advisory at
+  [`/security/advisories/new`](https://github.com/PanoramicRum/nimiq-simple-faucet/security/advisories/new).
+  GHSAs let us coordinate the fix and CVE on the same thread, and the
+  finder is automatically credited on the published advisory.
+- **Email**: `richy@nimiq.com` for cases where GHSA isn't a fit
+  (operator-side incidents, bulk forwarding, follow-up on a previously
+  reported issue).
 - If you fork or deploy your own instance, update this contact address in
   your copy of the file.
 
@@ -79,6 +88,75 @@ We will not pursue legal action against researchers who:
 - Do not exploit findings beyond what is necessary to demonstrate the issue.
 
 If in doubt, ask first — we would rather coordinate than surprise each other.
+
+## Trust-boundary model
+
+The audit reports under [`audits/`](./audits/) and several findings in our
+issue tracker pivot on this question: which inputs does the server trust,
+and which does it have to defend against? Document it once, here.
+
+### Network metadata (auto-trusted only when proxied)
+
+| Input              | Trust by default | Trust path |
+|--------------------|------------------|------------|
+| Socket peer IP     | Yes              | Bound by the OS — can't be forged on a TCP connection. |
+| `X-Forwarded-For`  | **No**           | Honoured only when the upstream proxy IP matches `FAUCET_TRUSTED_PROXY_CIDRS` (audit #001 / issue #87). Empty by default → unproxied direct deployments are safe out of the box. |
+| `Origin`           | Yes (filtered)   | Cross-checked against `FAUCET_CORS_ORIGINS`. Browser-only mode also rejects unknown origins. |
+| `Sec-Fetch-Site`   | Hint-only        | Used only to gate browser-only mode. Treat as advisory: a non-browser caller can omit it. |
+| User-Agent         | Hint-only        | Stored in audit log; not used for any access decision. |
+
+### Client-supplied claim payload (untrusted by default)
+
+Every field on `POST /v1/claim` is attacker-controlled — assume the
+attacker is choosing the worst possible value at each layer.
+
+| Field                    | Trusted? | Why / how validated |
+|--------------------------|----------|---------------------|
+| `address`                | No       | Validated against the Nimiq address checksum + normalised. Invalid addresses 400. |
+| `captchaToken`           | No       | Verified against the configured captcha provider's `verify` endpoint per request. The provider is the source of trust, not the token. |
+| `hashcashSolution`       | No       | Re-checked server-side against the same secret + difficulty + TTL the challenge was minted with; replay cache rejects already-seen solutions (#015 / issue #95). |
+| `fingerprint.*`          | No       | Stored for correlation only; never directly used as an access decision. |
+| `idempotencyKey`         | No       | Scoped by `(integratorId, key)` for authenticated callers; by `(key, address)` for the unauth path (#86). Cross-tenant collisions are not possible. |
+| `hostContext.{trust-claims}` | **Cryptographically required** | `kycLevel`, `accountAgeDays`, `emailDomainHash`, `tags`, `verifiedIdentities` are honoured only when an integrator HMAC signature on the canonical bytes verifies. Unsigned claim → those fields are stripped before the abuse pipeline ever sees them (#016 / issue #96). |
+| `hostContext.{uid, cookieHash, sessionHash}` | Correlation-only | Always preserved. Lying about a UID either evades correlation (no worse than not sending one) or trips correlation against the fingerprint visitor-id; either way the attacker doesn't gain trust. |
+
+### Integrator-authenticated calls
+
+Integrator HMAC auth (`X-Faucet-Api-Key` + signature over canonical
+request bytes) does NOT extend trust to the request body unless the
+relevant field also carries an in-band signature. The signed envelope
+proves the integrator endorsed *the network call*, not the truthfulness
+of every field inside.
+
+The one exception is the `hostContext` per-field signature, which is
+checked against `canonicalizeHostContext` (see
+[`packages/core/src/hostContext.ts`](./packages/core/src/hostContext.ts)).
+
+### Storage and at-rest
+
+| Datum                      | At-rest protection |
+|---------------------------|--------------------|
+| Admin password             | Argon2id via `@node-rs/argon2`, salted per row. |
+| Admin sessions             | Hashed token in DB; `__Host-`-prefixed cookie ferries the plaintext (#017 / issue #97). |
+| Admin TOTP secret          | Argon2id-derived KEK + XChaCha20-Poly1305 encryption when `FAUCET_KEY_PASSPHRASE` is set; otherwise plaintext in the local SQLite (acceptable on a single-tenant volume, not on shared infra). |
+| Integrator API keys        | SHA-256 hash only; the plaintext is returned **once** at create/rotate. |
+| Integrator HMAC secrets    | Plaintext in DB — needed for symmetric verification. The DB is a sensitive-grade artefact; restrict filesystem access. |
+| Wallet private key         | XChaCha20-Poly1305 keyring blob when `FAUCET_KEY_PASSPHRASE` is set. RPC-driver deployments hold the key in the Nimiq node, not in the faucet's data dir. |
+
+### What we don't defend against
+
+- **Compromised integrator**. If an integrator's HMAC secret leaks, the
+  attacker can forge `hostContext` claims and replay HMAC-signed
+  requests indefinitely. Rotate the secret via the admin dashboard
+  (TOTP step-up required, audit-logged).
+- **Compromised admin**. An admin with a valid session + TOTP can drain
+  the wallet, rotate keys, mint integrator credentials. Audit log
+  records every such action; the dashboard is gated behind password +
+  TOTP + per-route rate-limit.
+- **Compromised infrastructure**. We do not encrypt at-rest claim history
+  or the audit log against an attacker who has shell access to the
+  faucet container. Operators should restrict cluster access and run
+  the chart with the bundled NetworkPolicy + PDB (#019, #021 / issue #101).
 
 ## Acknowledgements
 

--- a/apps/server/src/abuse/pipeline.ts
+++ b/apps/server/src/abuse/pipeline.ts
@@ -114,7 +114,7 @@ export function buildPipeline(
   return new AbusePipeline(checks);
 }
 
-function buildGeoipResolver(config: ServerConfig): GeoIpResolver | undefined {
+export function buildGeoipResolver(config: ServerConfig): GeoIpResolver | undefined {
   if (config.geoipBackend === 'dbip') {
     return new DbipResolver();
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -9,7 +9,7 @@ import { sql } from 'drizzle-orm';
 import type { ServerConfig } from './config.js';
 import { openDb } from './db/index.js';
 import { buildDriver } from './drivers.js';
-import { buildPipeline } from './abuse/pipeline.js';
+import { buildPipeline, buildGeoipResolver } from './abuse/pipeline.js';
 import { migrateBlocklistNormalization } from './abuse/blocklistMigrate.js';
 import { EventStream, streamRoute } from './stream.js';
 import { claimRoutes } from './routes/claim.js';
@@ -84,11 +84,17 @@ export async function buildApp(
     );
   }
   const driver = opts.driverOverride ?? (await buildDriver(config));
+  // Build the GeoIP resolver once at boot so /readyz can surface its
+  // staleness — see audit Improvement (Tranche 5). Pass the same
+  // instance into the pipeline rather than letting it build a separate
+  // one, otherwise we'd double the in-memory MMDB cost.
+  const geoipResolver: GeoIpResolver | undefined =
+    opts.geoipResolverOverride ?? buildGeoipResolver(config);
   const pipeline = buildPipeline(
     db,
     config,
     driver,
-    opts.geoipResolverOverride ? { geoipResolver: opts.geoipResolverOverride } : {},
+    geoipResolver ? { geoipResolver } : {},
   );
   const stream = new EventStream();
 
@@ -160,6 +166,26 @@ export async function buildApp(
       }
     } else {
       checks.balance = 'unknown';
+    }
+
+    // Audit Improvement (Tranche 5): surface GeoIP DB staleness so a
+    // forgotten MaxMind / DB-IP refresh shows up as a degraded readyz
+    // signal instead of silently mis-classifying VPN/hosting traffic.
+    // Stale data does NOT flip readyz to 503 — that would cause Kubernetes
+    // to stop routing traffic to a faucet that's still functional, just
+    // with degraded geo accuracy. Operators wire the `checks.geoip` field
+    // into their alerting if they want a louder signal.
+    if (geoipResolver?.healthSnapshot) {
+      const snap = geoipResolver.healthSnapshot();
+      if (snap) {
+        const ageDays =
+          snap.ageMs != null ? Math.floor(snap.ageMs / (24 * 60 * 60 * 1_000)) : null;
+        checks.geoip = snap.stale
+          ? `stale (${snap.resolver}, ${ageDays}d old)`
+          : ageDays != null
+            ? `ok (${snap.resolver}, ${ageDays}d old)`
+            : `ok (${snap.resolver})`;
+      }
     }
 
     if (!allOk) {

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -325,6 +325,45 @@ a clear error message).
 - [ ] Backup job cronned and tested (restore-from-backup actually works)
 - [ ] Alerting wired — see [health-observability.md](./health-observability.md)
 - [ ] Secret rotation schedule documented (TOTP, admin password, HMAC secrets, wallet key)
+- [ ] Memory-hygiene mitigations applied (see §6.1) for mainnet deployments holding the signing key in-process
+
+### 6.1 Signer-key memory hygiene
+
+The WASM signer driver decrypts the operator's private key into the
+faucet process's heap and keeps it resident for the lifetime of the
+container. This is operationally simple — no external HSM, no per-tx
+unlock — but it widens the blast radius of a process-level compromise:
+a core dump, a `ptrace`-capable adversary, or a reachable
+`/proc/<pid>/mem` reads the key directly.
+
+The audit's recommended mitigations, in order of cost:
+
+1. **Disable core dumps.** In Compose, `ulimits: { core: { soft: 0,
+   hard: 0 } }` on the `faucet` service. In Kubernetes, set
+   `securityContext.allowPrivilegeEscalation: false` (already on by
+   default in our Helm chart) AND ensure your kernel's
+   `kernel.core_pattern` doesn't pipe core dumps to a writable location.
+2. **Restrict `ptrace`.** Run with the
+   `prevent_privilege_escalation` Pod Security Standard (default in
+   recent Kubernetes) AND `securityContext.seccompProfile.type:
+   RuntimeDefault` (already on by default in our chart) which blocks
+   `ptrace`/`process_vm_readv` from inside the container.
+3. **Read-only root filesystem.** Already on by default
+   (`containerSecurityContext.readOnlyRootFilesystem: true`). Prevents
+   an attacker who gains code execution from staging a debugger binary.
+4. **Switch to the RPC driver for production.** When `FAUCET_SIGNER_DRIVER=rpc`,
+   the private key never enters the faucet process. The Nimiq node
+   holds it (you can additionally run that node in a dedicated namespace
+   with stricter Pod Security). This is the recommended path for
+   non-trivial mainnet balances.
+5. **Rotate the key on a known schedule.** A leaked-but-unused key has
+   a fixed window of validity. Pair this with the audit-log alerting
+   on `account.send` so an unexpected withdrawal is noticed within
+   minutes, not days.
+
+The chart's defaults (read-only rootfs, `runAsNonRoot`, RuntimeDefault
+seccomp, no `allowPrivilegeEscalation`) cover items 1–3 for most
+clusters. Item 4 is a deploy-time choice; item 5 is operational.
 
 ---
 

--- a/packages/abuse-geoip/src/dbip.ts
+++ b/packages/abuse-geoip/src/dbip.ts
@@ -1,6 +1,7 @@
+import { statSync } from 'node:fs';
 import { open as openMmdb } from 'maxmind';
 import { createRequire } from 'node:module';
-import type { GeoIpResolver, GeoIpResult } from './types.js';
+import type { GeoIpHealthSnapshot, GeoIpResolver, GeoIpResult } from './types.js';
 
 /** DB-IP Lite country MMDB record shape. */
 interface DbipCountryRecord {
@@ -27,11 +28,19 @@ type AnyReader = Awaited<ReturnType<typeof openMmdb<any>>>;
  * Works out of the box — no license key, no download step, no configuration.
  * Data is CC BY 4.0 (https://db-ip.com/db/lite.php).
  */
+// DB-IP Lite ships monthly. The bundled package version pins a specific
+// snapshot, so the right "max age" check is "is the package itself
+// recent enough", which an operator updates via dependabot. We surface
+// the file mtime anyway so /readyz shows something concrete; flag stale
+// at 90 days since DB-IP updates monthly and we want a generous buffer.
+const DBIP_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1_000;
+
 export class DbipResolver implements GeoIpResolver {
   readonly id = 'dbip';
   #countryReader: AnyReader | null = null;
   #asnReader: AnyReader | null = null;
   #ready: Promise<void>;
+  #countryDbPath: string | null = null;
 
   constructor() {
     this.#ready = this.#load();
@@ -45,6 +54,7 @@ export class DbipResolver implements GeoIpResolver {
     const asnDbPath = require.resolve(
       '@ip-location-db/dbip-asn-mmdb/dbip-asn.mmdb',
     );
+    this.#countryDbPath = countryDbPath;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.#countryReader = await openMmdb<any>(countryDbPath, {
       cache: { max: 6000 },
@@ -53,6 +63,26 @@ export class DbipResolver implements GeoIpResolver {
     this.#asnReader = await openMmdb<any>(asnDbPath, {
       cache: { max: 6000 },
     });
+  }
+
+  // See MaxMind resolver; same intent.
+  healthSnapshot(): GeoIpHealthSnapshot {
+    if (!this.#countryDbPath) {
+      return { resolver: this.id, stale: true };
+    }
+    let dbBuildTimeMs: number | null = null;
+    try {
+      dbBuildTimeMs = statSync(this.#countryDbPath).mtimeMs;
+    } catch {
+      return { resolver: this.id, stale: true };
+    }
+    const ageMs = Date.now() - dbBuildTimeMs;
+    return {
+      resolver: this.id,
+      dbBuildTimeMs,
+      ageMs,
+      stale: ageMs > DBIP_MAX_AGE_MS,
+    };
   }
 
   async lookup(ip: string): Promise<GeoIpResult> {

--- a/packages/abuse-geoip/src/maxmind.ts
+++ b/packages/abuse-geoip/src/maxmind.ts
@@ -1,10 +1,11 @@
+import { statSync } from 'node:fs';
 import {
   open as openMmdb,
   type AsnResponse,
   type CountryResponse,
   type Reader,
 } from 'maxmind';
-import type { GeoIpResolver, GeoIpResult } from './types.js';
+import type { GeoIpHealthSnapshot, GeoIpResolver, GeoIpResult } from './types.js';
 
 export interface MaxMindResolverOptions {
   /** Path to GeoLite2-Country.mmdb. Required. */
@@ -13,7 +14,15 @@ export interface MaxMindResolverOptions {
   asnDbPath?: string;
   /** Cache size. Default 6000 entries per DB. */
   cacheSize?: number;
+  /**
+   * Maximum tolerated age of the country DB before `healthSnapshot()`
+   * reports it as stale. Default 45 days — MaxMind ships GeoLite2 weekly,
+   * so anything older is well past the operator's normal refresh window.
+   */
+  maxAgeMs?: number;
 }
+
+const DEFAULT_MAX_AGE_MS = 45 * 24 * 60 * 60 * 1_000;
 
 export class MaxMindResolver implements GeoIpResolver {
   readonly id = 'maxmind';
@@ -47,6 +56,31 @@ export class MaxMindResolver implements GeoIpResolver {
       country: iso ? iso.toUpperCase() : null,
       asn: asn?.autonomous_system_number ?? null,
       asnOrg: asn?.autonomous_system_organization ?? null,
+    };
+  }
+
+  // Audit Improvement: surface DB staleness in /readyz so operators get
+  // a loud signal when their MaxMind DB hasn't been refreshed in months.
+  // Stale country/ASN data silently mis-classifies VPN/hosting ranges,
+  // letting attackers around country/ASN allow- or deny-lists.
+  healthSnapshot(): GeoIpHealthSnapshot {
+    const maxAgeMs = this.options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    let dbBuildTimeMs: number | null = null;
+    try {
+      // The .mmdb file's mtime is the closest proxy to "build time"
+      // without parsing the metadata block — close enough for staleness.
+      dbBuildTimeMs = statSync(this.options.countryDbPath).mtimeMs;
+    } catch {
+      // File missing / unreadable. Report stale=true so the operator
+      // notices; the resolver itself would have failed to open earlier.
+      return { resolver: this.id, stale: true };
+    }
+    const ageMs = Date.now() - dbBuildTimeMs;
+    return {
+      resolver: this.id,
+      dbBuildTimeMs,
+      ageMs,
+      stale: ageMs > maxAgeMs,
     };
   }
 }

--- a/packages/abuse-geoip/src/types.ts
+++ b/packages/abuse-geoip/src/types.ts
@@ -16,6 +16,25 @@ export interface GeoIpResult {
 export interface GeoIpResolver {
   readonly id: string;
   lookup(ip: string): Promise<GeoIpResult>;
+  /**
+   * Optional health snapshot of the underlying GeoIP data. Used by the
+   * server's `/readyz` to surface staleness — a faucet running with a
+   * year-old MaxMind DB silently mis-classifies VPN/hosting ranges.
+   * Returns `null` when the resolver doesn't have a meaningful concept
+   * of "data age" (e.g. an online API like ipinfo).
+   */
+  healthSnapshot?(): GeoIpHealthSnapshot | null;
+}
+
+export interface GeoIpHealthSnapshot {
+  /** Resolver id (matches GeoIpResolver.id). */
+  resolver: string;
+  /** Wall-clock timestamp the local DB file was last modified, ms since epoch. `null` for online resolvers. */
+  dbBuildTimeMs?: number | null;
+  /** Age of the data in milliseconds, computed against `Date.now()`. */
+  ageMs?: number | null;
+  /** True when the resolver considers the data old enough to be inaccurate. */
+  stale: boolean;
 }
 
 export interface GeoIpPolicy {


### PR DESCRIPTION
## Summary

Tranche 5 — auditor's non-issue Improvements lifted into docs + one small runtime signal.

### SECURITY.md

- **Trust-boundary model** section names which inputs the server trusts vs. defends against, broken down by network metadata, claim payload, integrator-authenticated calls, and at-rest storage. Explicitly names what we DON'T defend against (compromised integrator/admin/infra) so operators choose their own controls.
- **Reporting a vulnerability** now lists GitHub Security Advisory as the preferred private channel alongside email. GHSAs coordinate the fix + CVE on one thread and auto-credit the finder.

### GeoIP staleness in /readyz

- New optional \`GeoIpResolver.healthSnapshot()\` returning DB build time + age + a \`stale\` flag. MaxMind defaults to 45 days (provider ships weekly); DB-IP defaults to 90 days (provider ships monthly).
- \`app.ts\` surfaces the snapshot under \`checks.geoip\` on /readyz. Stale data does **not** flip readyz to 503 — that would cause Kubernetes to stop routing to a still-functional faucet over a degraded data signal. Operators wire \`checks.geoip\` into their own alerting if they want louder.
- Side effect: the resolver is now built once in \`buildApp\` and shared with the pipeline, so /readyz and the abuse pipeline use the same MMDB cache instead of doubling it.

### deployment-production.md §6.1 — signer key memory hygiene

The audit's recommended mitigations against process-level disclosure of the in-process WASM signer key:
1. Disable core dumps
2. Restrict ptrace via Pod Security + seccomp
3. Read-only rootfs
4. Switch to the RPC driver for production (key never enters the faucet)
5. Scheduled rotation

The default Helm chart already covers items 1–3. Items 4–5 are deploy-time/operational choices.

## Test plan

- [x] \`pnpm typecheck\` clean across 32 tasks
- [x] \`pnpm test\` clean across 24 tasks
- [ ] CI green
- [ ] Manual: hit /readyz on a deployment with the bundled DB-IP package — confirm \`checks.geoip\` shows \`ok (dbip, Nd old)\` with a sensible age
- [ ] Manual: temporarily set MaxMind \`maxAgeMs\` low and confirm \`stale (...)\` shows up

🤖 Generated with [Claude Code](https://claude.com/claude-code)