### PR TITLE
fix(docker): make example builds work from a plain `docker build`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,23 +1,32 @@
+## Universal excludes only — never useful in any image.
+##
+## Per-Dockerfile build-context shrinkage (e.g. exclude `examples/`
+## from the server image) lives in `<dockerfile>.dockerignore` files
+## next to each Dockerfile. BuildKit picks the dockerfile-specific
+## file when present and falls back to this one otherwise.
+##
+## Issue #115: previously this file excluded `examples/` and most
+## SDK packages, so `docker build -f examples/<any>/Dockerfile .`
+## from the repo root failed with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.
+
 **/node_modules
 **/dist
 **/.turbo
 **/.output
 **/coverage
+**/.next
+**/.dart_tool
+**/build
+**/target
 .git
-.github
-deploy/helm
-deploy/compose
-examples
-apps/dashboard/node_modules
-apps/docs/node_modules
-packages/sdk-flutter
-packages/sdk-go
-packages/sdk-react-native
-packages/sdk-capacitor
-packages/sdk-react
-packages/sdk-vue
 *.log
 .DS_Store
 .env
 .env.*
 data/
+**/*.db
+**/*.db-journal
+test-results/
+playwright-report/
+blob-report/
+.e2e-state.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,36 @@ jobs:
           echo "WARN: image boots but did not reach healthz in 120s (likely flaky seed-peer sync)."
           exit 0
 
+  examples-build:
+    # Issue #115 / #116: prove that `docker build` against each example
+    # Dockerfile actually completes from the repo root. The two original
+    # examples used a deps-only-cache pattern that silently broke against
+    # the workspace lockfile, and the root .dockerignore excluded
+    # `examples/` so plain builds couldn't find their own context.
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Build vue-claim-page example image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: examples/vue-claim-page/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          tags: example-vue-claim:ci
+      - name: Build nextjs-claim-page example image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: examples/nextjs-claim-page/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          tags: example-nextjs-claim:ci
+
   compose-smoke:
     runs-on: ubuntu-latest
     needs: docker

--- a/deploy/docker/Dockerfile.dockerignore
+++ b/deploy/docker/Dockerfile.dockerignore
@@ -1,0 +1,49 @@
+## Build-context excludes scoped to the server image only.
+##
+## BuildKit honours `<dockerfile>.dockerignore` when present, so this
+## file shrinks the context for `docker build -f deploy/docker/Dockerfile`
+## without affecting `docker build -f examples/<any>/Dockerfile .` —
+## those contexts intentionally need the full workspace (issue #115).
+##
+## Inherits the universal excludes from `.dockerignore` in the repo root;
+## add ONLY the things the server image specifically doesn't need.
+
+# Universal excludes (mirrored from root .dockerignore).
+**/node_modules
+**/dist
+**/.turbo
+**/.output
+**/coverage
+**/.next
+**/.dart_tool
+**/build
+**/target
+.git
+*.log
+.DS_Store
+.env
+.env.*
+data/
+**/*.db
+**/*.db-journal
+test-results/
+playwright-report/
+blob-report/
+.e2e-state.json
+
+# Server-image-specific: the public API server doesn't need example apps,
+# the dashboard / claim-ui dev sources (the Dockerfile builds them in a
+# dedicated stage), or the non-TS SDK ports.
+.github
+deploy/helm
+deploy/compose
+examples
+apps/dashboard/node_modules
+apps/docs
+apps/playground
+packages/sdk-flutter
+packages/sdk-go
+packages/sdk-react-native
+packages/sdk-capacitor
+packages/sdk-react
+packages/sdk-vue

--- a/examples/nextjs-claim-page/Dockerfile
+++ b/examples/nextjs-claim-page/Dockerfile
@@ -1,6 +1,14 @@
 ## syntax=docker/dockerfile:1.7
 # Next.js claim page example — multi-stage build.
-# Build context must be the repo root.
+#
+# Build context = repo root, e.g.
+#   docker buildx build -f examples/nextjs-claim-page/Dockerfile -t nextjs-claim:test .
+#
+# Issue #116: see the matching note in examples/vue-claim-page/Dockerfile —
+# the deps-only-cache pattern was broken because the root package.json
+# devDependency on @faucet/abuse-hashcash makes pnpm require every
+# workspace package.json at install time. Copy the full workspace and
+# filter at install time instead.
 
 FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm
@@ -8,26 +16,20 @@ ENV PATH="${PNPM_HOME}:${PATH}"
 RUN corepack enable
 WORKDIR /app
 
-FROM base AS deps
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml turbo.json tsconfig.base.json ./
-COPY packages/sdk-ts/package.json packages/sdk-ts/
-COPY packages/sdk-react/package.json packages/sdk-react/
-COPY examples/nextjs-claim-page/package.json examples/nextjs-claim-page/
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile=false
-
-FROM deps AS build
-COPY packages/sdk-ts packages/sdk-ts
-COPY packages/sdk-react packages/sdk-react
-COPY examples/nextjs-claim-page examples/nextjs-claim-page
+FROM base AS build
+COPY . .
 ARG NEXT_PUBLIC_FAUCET_URL=http://localhost:8080
 ENV NEXT_PUBLIC_FAUCET_URL=${NEXT_PUBLIC_FAUCET_URL}
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-nextjs...
 RUN pnpm turbo run build --filter=@nimiq-faucet/example-nextjs
 
 FROM base AS runtime
 ENV NODE_ENV=production
 COPY --from=build /app/examples/nextjs-claim-page/.next/standalone ./
 COPY --from=build /app/examples/nextjs-claim-page/.next/static ./examples/nextjs-claim-page/.next/static
-COPY --from=build /app/examples/nextjs-claim-page/public ./examples/nextjs-claim-page/public
+# This example has no `public/` dir today. If you add one (e.g. for
+# favicons), add `COPY --from=build /app/examples/nextjs-claim-page/public
+# ./examples/nextjs-claim-page/public` back in.
 EXPOSE 3000
 CMD ["node", "examples/nextjs-claim-page/server.js"]

--- a/examples/vue-claim-page/Dockerfile
+++ b/examples/vue-claim-page/Dockerfile
@@ -1,6 +1,17 @@
 ## syntax=docker/dockerfile:1.7
 # Vue claim page example — multi-stage build.
-# Build context must be the repo root.
+#
+# Build context = repo root, e.g.
+#   docker buildx build -f examples/vue-claim-page/Dockerfile -t vue-claim:test .
+#
+# Issue #116: the previous deps-only-cache pattern copied only a sliver
+# of `package.json` files and tried to `pnpm install --frozen-lockfile=false`.
+# pnpm validates the lockfile against every workspace member named in the
+# root devDependencies (e.g. @faucet/abuse-hashcash), so install failed
+# with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. The fix is to copy the full
+# workspace and let `pnpm install --filter <example>...` prune unused
+# graphs at install time. We trade per-layer cache granularity for
+# correctness; the BuildKit pnpm-store mount keeps cold installs fast.
 
 FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm
@@ -8,20 +19,12 @@ ENV PATH="${PNPM_HOME}:${PATH}"
 RUN corepack enable
 WORKDIR /app
 
-FROM base AS deps
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml turbo.json tsconfig.base.json ./
-COPY packages/sdk-ts/package.json packages/sdk-ts/
-COPY packages/sdk-vue/package.json packages/sdk-vue/
-COPY examples/vue-claim-page/package.json examples/vue-claim-page/
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile=false
-
-FROM deps AS build
-COPY packages/sdk-ts packages/sdk-ts
-COPY packages/sdk-vue packages/sdk-vue
-COPY examples/vue-claim-page examples/vue-claim-page
+FROM base AS build
+COPY . .
 ARG VITE_FAUCET_URL=http://localhost:8080
 ENV VITE_FAUCET_URL=${VITE_FAUCET_URL}
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-vue...
 RUN pnpm turbo run build --filter=@nimiq-faucet/example-vue
 
 FROM nginx:alpine AS runtime


### PR DESCRIPTION
## Summary

Closes **#115**, **#116**. Reported by the engineer who tried to integrate the faucet against a real Nimiq Pay Mini App and hit two blockers running `docker buildx build -f examples/<x>/Dockerfile .` from the repo root.

### #115 — root `.dockerignore` excluded `examples/`

The root `.dockerignore` had path-pattern excludes (`examples`, `deploy/compose`, `packages/sdk-vue`, etc.) that made sense for the **server image** but broke any plain `docker build` of an example — the example's own context disappeared, install failed with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.

Fix: trim the root `.dockerignore` to universal excludes only (`node_modules`, `dist`, `.turbo`, build artefacts, secrets, logs). Move the server-image-specific excludes into a new `deploy/docker/Dockerfile.dockerignore` — BuildKit honours `<dockerfile>.dockerignore` when present, so the server image keeps its lean context while every other Dockerfile sees the full workspace.

### #116 — example Dockerfile deps-cache pattern was broken

Both `examples/vue-claim-page/Dockerfile` and `examples/nextjs-claim-page/Dockerfile` copied only a sliver of `package.json` files (root + sdk-ts + sdk-vue/react + the example) and ran `pnpm install --frozen-lockfile=false`. But pnpm validates the lockfile against every workspace member named in the root `devDependencies` — including `@faucet/abuse-hashcash` — so install failed without the full workspace tree.

Fix: switch to "copy full workspace, filter install" (the pattern PR #113's mini-app examples use successfully), and reinstate `--frozen-lockfile` now that install actually works. Also drop the broken `COPY ... /public` line in the nextjs Dockerfile — the example has no `public/` dir.

### CI

New `examples-build` job in `ci.yml` that runs `docker buildx build` against both example Dockerfiles. The existing `docker` job only exercises `deploy/docker/Dockerfile`, so a regression in either example would have slipped past — that's why these have been broken since the examples landed.

## Test plan

- [x] `docker buildx build -f examples/vue-claim-page/Dockerfile -t test:vue .` → exits 0 locally.
- [x] `docker buildx build -f examples/nextjs-claim-page/Dockerfile -t test:nextjs .` → exits 0 locally.
- [x] `docker buildx build -f deploy/docker/Dockerfile -t nimiq-faucet:test .` → server image still builds (proves the new `deploy/docker/Dockerfile.dockerignore` keeps the lean context).
- [ ] CI green (the new `examples-build` job is the proof-of-life).

## Why this matters now

- A new contributor who copy-pastes the example as a starting point gets a confusing pnpm error on the first build.
- PR #113 shipped per-Dockerfile `.dockerignore` workarounds against this. Once this lands, those workarounds become redundant and the engineer can drop them on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)