### PR TITLE
fix(fcaptcha): build image from source + split server/browser URLs

### DIFF
--- a/apps/server/src/abuse/pipeline.ts
+++ b/apps/server/src/abuse/pipeline.ts
@@ -43,8 +43,11 @@ export function buildPipeline(
   if (config.hcaptchaSecret) {
     checks.push(hcaptchaCheck({ secret: config.hcaptchaSecret }));
   }
-  if (config.fcaptchaSecret && config.fcaptchaUrl) {
-    checks.push(fcaptchaCheck({ secret: config.fcaptchaSecret, serverUrl: config.fcaptchaUrl }));
+  if (config.fcaptchaSecret && config.fcaptchaInternalUrl) {
+    // Issue #118: server-to-server verification uses the INTERNAL URL
+    // (e.g. http://fcaptcha:3000 inside Docker). The browser-facing
+    // URL lives in /v1/config.captcha.serverUrl (configView.ts).
+    checks.push(fcaptchaCheck({ secret: config.fcaptchaSecret, serverUrl: config.fcaptchaInternalUrl }));
   }
   if (config.hashcashSecret) {
     checks.push(

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -27,7 +27,15 @@ export const ServerConfigSchema = z.object({
   turnstileSecret: z.string().optional(),
   hcaptchaSiteKey: z.string().optional(),
   hcaptchaSecret: z.string().optional(),
+  // Issue #118: FCaptcha URL split into a server-side internal URL and
+  // a browser-side public URL. The single `fcaptchaUrl` (env
+  // FAUCET_FCAPTCHA_URL) is kept as a deprecated fallback — when set,
+  // both `fcaptchaInternalUrl` and `fcaptchaPublicUrl` default to it,
+  // and `loadConfig` logs a deprecation warning. Drop the alias in
+  // v1.next.
   fcaptchaUrl: z.string().url().optional(),
+  fcaptchaInternalUrl: z.string().url().optional(),
+  fcaptchaPublicUrl: z.string().url().optional(),
   fcaptchaSiteKey: z.string().optional(),
   fcaptchaSecret: z.string().optional(),
 
@@ -200,6 +208,8 @@ const ENV_KEYS: Record<string, string> = {
   hcaptchaSiteKey: 'FAUCET_HCAPTCHA_SITE_KEY',
   hcaptchaSecret: 'FAUCET_HCAPTCHA_SECRET',
   fcaptchaUrl: 'FAUCET_FCAPTCHA_URL',
+  fcaptchaInternalUrl: 'FAUCET_FCAPTCHA_INTERNAL_URL',
+  fcaptchaPublicUrl: 'FAUCET_FCAPTCHA_PUBLIC_URL',
   fcaptchaSiteKey: 'FAUCET_FCAPTCHA_SITE_KEY',
   fcaptchaSecret: 'FAUCET_FCAPTCHA_SECRET',
   hashcashSecret: 'FAUCET_HASHCASH_SECRET',
@@ -256,5 +266,38 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     const v = env[envName];
     if (v !== undefined && v !== '') raw[field] = v;
   }
-  return ServerConfigSchema.parse(raw);
+  const config = ServerConfigSchema.parse(raw);
+  return resolveFcaptchaUrls(config);
+}
+
+/**
+ * Issue #118: split FAUCET_FCAPTCHA_URL into INTERNAL/PUBLIC. Server-to-
+ * server verification uses INTERNAL (e.g. http://fcaptcha:3000); the
+ * URL returned to the browser via /v1/config uses PUBLIC.
+ *
+ * Backwards-compat fallbacks (in priority order):
+ *   1. If INTERNAL is unset, default to PUBLIC.
+ *   2. If both are unset, fall back to the deprecated single `fcaptchaUrl`
+ *      and log a warning. Operators get one minor to migrate.
+ *
+ * Exported so tests can exercise the fallback matrix without booting
+ * the full app.
+ */
+export function resolveFcaptchaUrls(config: ServerConfig): ServerConfig {
+  const legacy = config.fcaptchaUrl;
+  let publicUrl = config.fcaptchaPublicUrl;
+  let internalUrl = config.fcaptchaInternalUrl;
+  if (!publicUrl && legacy) publicUrl = legacy;
+  if (!internalUrl && publicUrl) internalUrl = publicUrl;
+  if (legacy && !config.fcaptchaPublicUrl && !config.fcaptchaInternalUrl) {
+    // Loud one-shot warning at boot. Don't repeat per-request.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[deprecation] FAUCET_FCAPTCHA_URL is deprecated (issue #118). ' +
+        'Set FAUCET_FCAPTCHA_PUBLIC_URL (browser-reachable) and optionally ' +
+        'FAUCET_FCAPTCHA_INTERNAL_URL (server-to-server). The single var ' +
+        'will be removed in the next minor release.',
+    );
+  }
+  return { ...config, fcaptchaPublicUrl: publicUrl, fcaptchaInternalUrl: internalUrl };
 }

--- a/apps/server/src/configView.ts
+++ b/apps/server/src/configView.ts
@@ -12,7 +12,7 @@ export function deriveAbuseLayers(config: ServerConfig) {
   return {
     turnstile: !!config.turnstileSiteKey,
     hcaptcha: !!config.hcaptchaSiteKey,
-    fcaptcha: !!(config.fcaptchaSiteKey && config.fcaptchaUrl),
+    fcaptcha: !!(config.fcaptchaSiteKey && config.fcaptchaPublicUrl),
     hashcash: !!config.hashcashSecret,
     geoip: config.geoipBackend !== 'none',
     fingerprint: config.fingerprintEnabled,
@@ -31,11 +31,14 @@ export function derivePublicConfig(config: ServerConfig) {
       ? { provider: 'turnstile' as const, siteKey: config.turnstileSiteKey }
       : config.hcaptchaSiteKey
         ? { provider: 'hcaptcha' as const, siteKey: config.hcaptchaSiteKey }
-        : config.fcaptchaSiteKey && config.fcaptchaUrl
+        : config.fcaptchaSiteKey && config.fcaptchaPublicUrl
           ? {
               provider: 'fcaptcha' as const,
               siteKey: config.fcaptchaSiteKey,
-              serverUrl: config.fcaptchaUrl,
+              // Issue #118: this is the URL the browser hits — must be
+              // browser-reachable, distinct from the internal verify
+              // endpoint the server uses.
+              serverUrl: config.fcaptchaPublicUrl,
             }
           : null,
     hashcash: config.hashcashSecret

--- a/apps/server/test/fcaptcha-url-split.test.ts
+++ b/apps/server/test/fcaptcha-url-split.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { ServerConfigSchema, resolveFcaptchaUrls } from '../src/config.js';
+
+/**
+ * Issue #118: FAUCET_FCAPTCHA_URL split into PUBLIC (browser-facing) and
+ * INTERNAL (server-to-server). The legacy single var is kept as a
+ * fallback for one minor — these tests pin the fallback matrix so it
+ * doesn't drift.
+ */
+
+const FAUCET_ADDR = 'NQ58 U4HN TVVA 8UCC X4U6 5KSJ MBQT 9HKX 47YE';
+
+function configWith(overrides: Record<string, unknown>) {
+  return ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: '/tmp',
+    signerDriver: 'wasm',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    adminPassword: 'test-password-123',
+    privateKey: 'a'.repeat(64),
+    keyPassphrase: 'test-passphrase-12',
+    ...overrides,
+  });
+}
+
+describe('resolveFcaptchaUrls', () => {
+  it('keeps both URLs as-is when both are set explicitly', () => {
+    const config = configWith({
+      fcaptchaPublicUrl: 'https://captcha.example.com',
+      fcaptchaInternalUrl: 'http://fcaptcha:3000',
+    });
+    const out = resolveFcaptchaUrls(config);
+    expect(out.fcaptchaPublicUrl).toBe('https://captcha.example.com');
+    expect(out.fcaptchaInternalUrl).toBe('http://fcaptcha:3000');
+  });
+
+  it('defaults INTERNAL to PUBLIC when only PUBLIC is set', () => {
+    const config = configWith({ fcaptchaPublicUrl: 'https://captcha.example.com' });
+    const out = resolveFcaptchaUrls(config);
+    expect(out.fcaptchaPublicUrl).toBe('https://captcha.example.com');
+    expect(out.fcaptchaInternalUrl).toBe('https://captcha.example.com');
+  });
+
+  it('falls back to legacy fcaptchaUrl when neither new var is set', () => {
+    const config = configWith({ fcaptchaUrl: 'http://fcaptcha:3000' });
+    const out = resolveFcaptchaUrls(config);
+    expect(out.fcaptchaPublicUrl).toBe('http://fcaptcha:3000');
+    expect(out.fcaptchaInternalUrl).toBe('http://fcaptcha:3000');
+  });
+
+  it('legacy fcaptchaUrl is overridden by explicit PUBLIC + INTERNAL', () => {
+    const config = configWith({
+      fcaptchaUrl: 'http://legacy:3000',
+      fcaptchaPublicUrl: 'https://captcha.example.com',
+      fcaptchaInternalUrl: 'http://fcaptcha:3000',
+    });
+    const out = resolveFcaptchaUrls(config);
+    expect(out.fcaptchaPublicUrl).toBe('https://captcha.example.com');
+    expect(out.fcaptchaInternalUrl).toBe('http://fcaptcha:3000');
+  });
+
+  it('leaves both undefined when fcaptcha is not configured at all', () => {
+    const config = configWith({});
+    const out = resolveFcaptchaUrls(config);
+    expect(out.fcaptchaPublicUrl).toBeUndefined();
+    expect(out.fcaptchaInternalUrl).toBeUndefined();
+  });
+});

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -59,6 +59,26 @@ FAUCET_WALLET_ADDRESS=NQ00 0000 0000 0000 0000 0000 0000 0000 0000
 # FAUCET_RPC_URL=https://your-albatross-testnet-rpc.example
 
 # ============================================================================
+# FCaptcha (optional, abuse layer) — see deploy/compose/fcaptcha.yml.
+# ============================================================================
+# Issue #118: FAUCET_FCAPTCHA_URL is split into two vars. Set PUBLIC_URL
+# to the URL the *browser* hits (must be reachable from the user's
+# device — e.g. https://captcha.example.com in prod, http://<LAN_IP>:3000
+# in LAN dev). INTERNAL_URL is what the *faucet container* hits to
+# verify a token (defaults to http://fcaptcha:3000 on the compose
+# network); usually leave unset.
+# FAUCET_FCAPTCHA_PUBLIC_URL=https://captcha.example.com
+# FAUCET_FCAPTCHA_INTERNAL_URL=http://fcaptcha:3000
+# FAUCET_FCAPTCHA_SITE_KEY=<site-key>
+# FAUCET_FCAPTCHA_SECRET=<secret>
+# FCAPTCHA_SECRET=<secret>   # same value; FCaptcha's own env var name
+
+# Deprecated single var (issue #118). Setting only this still works for
+# one minor — server logs a deprecation warning and uses it for both
+# PUBLIC and INTERNAL. Migrate to the split above.
+# FAUCET_FCAPTCHA_URL=http://fcaptcha:3000
+
+# ============================================================================
 # Postgres + Redis — used by the `postgres` profile.
 # ============================================================================
 # The default compose stack runs SQLite. To use Postgres + Redis:

--- a/deploy/compose/fcaptcha.yml
+++ b/deploy/compose/fcaptcha.yml
@@ -4,17 +4,27 @@
 #
 # Expects the following in `.env` (alongside the existing faucet vars):
 #
-#   FAUCET_FCAPTCHA_URL=http://fcaptcha:3000
+#   FAUCET_FCAPTCHA_PUBLIC_URL=https://captcha.example.com   # browser-reachable
+#   FAUCET_FCAPTCHA_INTERNAL_URL=http://fcaptcha:3000         # optional; defaults to PUBLIC
 #   FAUCET_FCAPTCHA_SITE_KEY=<site-key>
 #   FAUCET_FCAPTCHA_SECRET=<secret>
 #   FCAPTCHA_SECRET=<secret>        # same value; FCaptcha's own env name
+#
+# Issue #117: the previous overlay referenced `ghcr.io/webdecoy/fcaptcha:latest`,
+# which isn't publicly pullable. We now build from upstream source pinned
+# to v1.7.0 — see `deploy/compose/fcaptcha/Dockerfile`.
+#
+# Issue #118: `FAUCET_FCAPTCHA_URL` is deprecated. Operators who haven't
+# split it yet still work — the server falls back to the old single var.
 #
 # Upstream: https://github.com/WebDecoy/FCaptcha (MIT). This overlay only
 # wires the image alongside the faucet — no detection logic lives here.
 
 services:
   fcaptcha:
-    image: ghcr.io/webdecoy/fcaptcha:latest
+    build:
+      context: ./fcaptcha
+      dockerfile: Dockerfile
     restart: unless-stopped
     environment:
       PORT: "3000"
@@ -27,8 +37,15 @@ services:
 
   faucet:
     environment:
-      FAUCET_FCAPTCHA_URL: ${FAUCET_FCAPTCHA_URL:-http://fcaptcha:3000}
+      # New vars (issue #118). INTERNAL_URL falls back to PUBLIC_URL when
+      # unset, so production deployments where both URLs are the same
+      # public one only need to set PUBLIC_URL.
+      FAUCET_FCAPTCHA_PUBLIC_URL: ${FAUCET_FCAPTCHA_PUBLIC_URL:-${FAUCET_FCAPTCHA_URL:-http://fcaptcha:3000}}
+      FAUCET_FCAPTCHA_INTERNAL_URL: ${FAUCET_FCAPTCHA_INTERNAL_URL:-http://fcaptcha:3000}
       FAUCET_FCAPTCHA_SITE_KEY: ${FAUCET_FCAPTCHA_SITE_KEY}
       FAUCET_FCAPTCHA_SECRET: ${FAUCET_FCAPTCHA_SECRET}
+      # Deprecated (#118), kept for one minor so existing operators keep
+      # working. Drop in v1.next once everyone has migrated.
+      FAUCET_FCAPTCHA_URL: ${FAUCET_FCAPTCHA_URL:-}
     depends_on:
       - fcaptcha

--- a/deploy/compose/fcaptcha/Dockerfile
+++ b/deploy/compose/fcaptcha/Dockerfile
@@ -1,0 +1,42 @@
+# Build FCaptcha (server-node) from upstream.
+#
+# Issue #117: the previous fcaptcha.yml referenced
+# `ghcr.io/webdecoy/fcaptcha:latest`, which is not publicly pullable —
+# `docker pull` returns "unauthorized". The image simply doesn't exist
+# in any public registry, so following the documented compose Quick
+# Start silently failed.
+#
+# Solution: build from upstream source, pinned to a specific tagged
+# release (v1.7.0 → commit 85ea4127). Re-pin by bumping FCAPTCHA_REF
+# to a different tag or commit; `docker compose build --no-cache fcaptcha`
+# re-clones cleanly.
+#
+# Also patches the server to expose `/fcaptcha.js` (the widget bundle the
+# browser needs). Upstream `server-node/server.js` only registers verify
+# / score / challenge endpoints; it doesn't serve the client bundle in
+# `client/`. Until that's fixed upstream, the operator's deployment has
+# to host the widget alongside the verify API. Two-line `sed` patch keeps
+# us close to the upstream source — no fork to maintain.
+
+FROM node:20-alpine AS build
+ARG FCAPTCHA_REF=v1.7.0
+WORKDIR /src
+RUN apk add --no-cache git
+RUN git clone --depth 1 --branch "${FCAPTCHA_REF}" \
+    https://github.com/WebDecoy/FCaptcha.git .
+WORKDIR /src/server-node
+RUN npm ci --omit=dev || npm install --omit=dev
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /src/server-node /app
+# `/app/client/fcaptcha.js` is the widget bundle the browser fetches as
+# <FAUCET_FCAPTCHA_PUBLIC_URL>/fcaptcha.js. Until upstream serves it,
+# we add a static-file route via a one-line sed patch.
+COPY --from=build /src/client /app/client
+RUN sed -i \
+    "s|app.use(express.json());|app.use(express.json());\\napp.use('/fcaptcha.js', express.static('/app/client/fcaptcha.js'));|" \
+    server.js
+ENV PORT=3000
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/packages/abuse-fcaptcha/README.md
+++ b/packages/abuse-fcaptcha/README.md
@@ -16,9 +16,22 @@ Implements `AbuseCheck` from [@faucet/core](../core/) — registered in
 
 | Env | Purpose |
 |-----|---------|
-| `FAUCET_FCAPTCHA_URL` | Base URL of the FCaptcha service (enables layer) |
+| `FAUCET_FCAPTCHA_PUBLIC_URL` | URL the **browser** fetches the widget from. Must be reachable from end-user devices. Returned in `/v1/config.captcha.serverUrl`. |
+| `FAUCET_FCAPTCHA_INTERNAL_URL` | URL the **faucet server** hits to verify tokens. Defaults to `FAUCET_FCAPTCHA_PUBLIC_URL`; override when running fcaptcha on a sidecar (e.g. `http://fcaptcha:3000` on a Docker bridge). |
 | `FAUCET_FCAPTCHA_SITE_KEY` | Public key passed to the widget in the claim UI |
 | `FAUCET_FCAPTCHA_SECRET` | Server-side secret for token verification |
+| `FAUCET_FCAPTCHA_URL` | **Deprecated** (issue #118) — single var that conflated server/browser URLs. Still honoured for one minor as a fallback for both `*_PUBLIC_URL` and `*_INTERNAL_URL`; migrate to the split above. |
+
+### Why two URLs?
+
+In dev, fcaptcha typically runs on a separate Docker service. The faucet
+container reaches it on the bridge network at `http://fcaptcha:3000`,
+but a phone on the same Wi-Fi can't resolve `fcaptcha`. It needs the
+LAN-reachable URL (e.g. `http://192.168.1.50:3000`).
+
+In production, both are usually the same public HTTPS URL fronted by
+a reverse proxy. Setting only `*_PUBLIC_URL` is fine — `*_INTERNAL_URL`
+defaults to it.
 
 ## Behaviour
 


### PR DESCRIPTION
## Summary

Closes **#117**, **#118**. Reported by the engineer who tried the documented FCaptcha enable path and hit two problems: the referenced image isn't publicly pullable, and the single \`FAUCET_FCAPTCHA_URL\` env var is doing two jobs that need different values in dev.

### #117 — fcaptcha image isn't publicly pullable

\`deploy/compose/fcaptcha.yml\` referenced \`ghcr.io/webdecoy/fcaptcha:latest\`. \`docker pull\` returns \`unauthorized\`; the image simply doesn't exist in any public registry, and there's no plan upstream to publish one.

Replace \`image:\` with \`build:\` against a new \`deploy/compose/fcaptcha/Dockerfile\` that:
- Clones [WebDecoy/FCaptcha](https://github.com/WebDecoy/FCaptcha) pinned to **v1.7.0** (commit \`85ea4127\`).
- Installs production deps.
- Patches \`server.js\` (one \`sed\` line) to also serve \`/fcaptcha.js\` — upstream's server-node currently doesn't expose the widget bundle, so until that's fixed upstream the operator's deployment has to host both.

We're not forking — the patch is one line and the version is pinned, so re-pinning is \`docker compose build --no-cache fcaptcha\` after bumping \`FCAPTCHA_REF\`.

### #118 — single \`FAUCET_FCAPTCHA_URL\` conflated server vs browser

The same env var was used for two jobs:
1. **Server-to-server**: faucet verifies a token against \`<URL>/api/token/verify\`. Best value on the compose bridge: \`http://fcaptcha:3000\`.
2. **Browser-facing**: returned in \`/v1/config.captcha.serverUrl\` so the claim UI knows where to fetch the widget. Best value for a phone on the LAN: a LAN-reachable URL.

In dev, only LAN-IP satisfies both. In prod, both URLs are usually the same public one — but the conflation forced an awkward dance the moment they diverged.

Split into:
- \`FAUCET_FCAPTCHA_PUBLIC_URL\` — browser-reachable, returned in \`/v1/config\`.
- \`FAUCET_FCAPTCHA_INTERNAL_URL\` — server-to-server. Defaults to \`PUBLIC_URL\` when unset, so production deployments where both URLs are the same don't need to set it.

The legacy single \`FAUCET_FCAPTCHA_URL\` is honoured for one minor as a fallback for both; setting only it logs a one-shot deprecation warning at boot. Drop the alias next minor.

## Test plan

- [x] \`pnpm --filter @faucet/server test\` — 120/120 (115 existing + 5 new \`resolveFcaptchaUrls\` cases pinning the fallback matrix).
- [x] \`pnpm typecheck\` clean across 32 tasks.
- [x] \`docker buildx build deploy/compose/fcaptcha\` — builds clean from upstream source.
- [x] Smoke: \`docker run -p 13000:3000 fcaptcha:test\` → \`curl /fcaptcha.js\` returns the 98 KB widget bundle.
- [ ] CI green.
- [ ] Manual: boot the full stack with \`docker compose -f docker-compose.yml -f fcaptcha.yml up -d\` → faucet builds the fcaptcha image, healthchecks pass, no \`pull access denied\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)