### PR TITLE
fix(compose): make faucet + nimiq host ports overridable

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -30,6 +30,15 @@ FAUCET_KEY_PASSPHRASE=change-me-too
 FAUCET_DEV=1
 
 # ============================================================================
+# Host port overrides (issue #120) — avoid collisions across stacks
+# ============================================================================
+# Defaults match the documented Quick Start; override to run multiple
+# faucet stacks on the same machine.
+# FAUCET_HOST_PORT=8080
+# NIMIQ_P2P_HOST_PORT=8443
+# FCAPTCHA_HOST_PORT=3000   # only relevant with the fcaptcha overlay
+
+# ============================================================================
 # Wallet setup — pick ONE of the two flows below
 # ============================================================================
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -10,8 +10,11 @@ services:
       dockerfile: deploy/docker/Dockerfile
     image: nimiq-faucet:dev
     restart: unless-stopped
+    # Issue #120: host port is overridable so contributors running multiple
+    # stacks side-by-side don't collide on 8080. Default still binds 8080
+    # for the documented Quick Start.
     ports:
-      - "8080:8080"
+      - "${FAUCET_HOST_PORT:-8080}:8080"
     # `.env` is optional so the `nimiq` service can be started on its own
     # (e.g. for smoke testing) without first copying `.env.example`.
     env_file:
@@ -78,9 +81,10 @@ services:
     # Uncomment to expose for local debugging (e.g. curl from the host):
     # ports:
     #   - "127.0.0.1:8648:8648"
-    # P2P port must be reachable for the node to sync:
+    # P2P port must be reachable for the node to sync. Issue #120: host
+    # port is overridable to avoid collisions across stacks.
     ports:
-      - "8443:8443"
+      - "${NIMIQ_P2P_HOST_PORT:-8443}:8443"
 
 volumes:
   faucet-data:


### PR DESCRIPTION
## Summary

Closes **#120**. Reported by the engineer who tried to run two stacks side by side and got \`bind: address already in use\` because 8080 (faucet) and 8443 (nimiq P2P) were hardcoded.

Replace the hardcoded host-port halves with \`\${VAR:-default}\`:

\`\`\`yaml
ports:
  - "\${FAUCET_HOST_PORT:-8080}:8080"
  ...
  - "\${NIMIQ_P2P_HOST_PORT:-8443}:8443"
\`\`\`

The container-side ports stay fixed (the faucet still listens on 8080 internally, the nimiq node still on 8443) but operators can rebind the host side without touching the compose file:

\`\`\`bash
FAUCET_HOST_PORT=28080 NIMIQ_P2P_HOST_PORT=28443 docker compose up
\`\`\`

Defaults match the documented Quick Start, so existing one-stack users see no change. \`.env.example\` gains a small section pointing at the overrides.

PR #137 (Tranche B) already added the same pattern for \`FCAPTCHA_HOST_PORT\` in \`fcaptcha.yml\`, so this PR only touches the main compose stack.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` validates the compose YAML.
- [ ] CI green (existing compose-smoke job exercises the default ports).
- [ ] Manual: \`FAUCET_HOST_PORT=28080 docker compose up -d\` → \`docker ps\` shows \`0.0.0.0:28080->8080/tcp\`.
- [ ] Manual: default \`docker compose up -d\` still binds 8080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)