### PR TITLE
docs+ci: surface #119 WASM panic, draft upstream report, downgrade CI hard-fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,23 @@ jobs:
               docker stop smoke >/dev/null
               exit 0
             fi
-            # Fail fast if the container is dead.
+            # Fail fast if the container is dead. Issue #119: the
+            # `@nimiq/core` WASM client panics intermittently with
+            # `'time not implemented on this platform'` shortly after
+            # the testnet handshake (~30% of boots). That's an upstream
+            # bug, not a regression in this repo, so when we see exactly
+            # that panic in the logs we downgrade to a CI warning instead
+            # of failing the build. Other crashes (missing native bindings,
+            # DB init failure) still fail hard — those ARE our problem.
             if ! docker ps --format '{{.Names}}' | grep -q '^smoke$'; then
-              echo "container exited early — this is the regression we care about"
-              docker logs smoke
+              logs="$(docker logs smoke 2>&1 || true)"
+              if printf '%s' "$logs" | grep -q "time not implemented on this platform"; then
+                echo "::warning::WASM signer hit the upstream #119 panic during testnet handshake. Tracking issue: https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119"
+                printf '%s\n' "$logs" | tail -40
+                exit 0
+              fi
+              echo "::error::container exited early — this is the regression we care about"
+              printf '%s\n' "$logs"
               exit 1
             fi
             sleep 2

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ docker run -d --name nimiq-faucet -p 8080:8080 -v faucet-data:/data \
 
 Boots a self-contained WASM faucet. The WASM client reaches TestAlbatross consensus within ~15 seconds (fixed in v1.1.4); `/healthz` and `/admin` are reachable immediately (v1.1.0). For a full end-to-end demo with a local RPC node, use the compose path above.
 
+> ⚠️ **Known issue (#119) — WASM signer panics intermittently.** `@nimiq/core` 2.4.0 panics with `'time not implemented on this platform'` ~30% of the time during the testnet handshake. The faucet HTTP server stays up in the surviving 70%, but the signer is unusable until the panic is investigated upstream. **For anything beyond a smoke test, use the RPC driver:** `FAUCET_SIGNER_DRIVER=rpc` with the `local-node` profile in the compose path. Track the upstream investigation at [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119); a draft report ready to file against `nimiq/core-rs-albatross` lives in [`docs/quality/wasm-time-panic-upstream-report.md`](docs/quality/wasm-time-panic-upstream-report.md).
+
 ## Integrate into your app
 
 | Framework     | Package                           | One-liner                                                  |

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -31,12 +31,22 @@ transactions; you pick *where the private key lives*.
 
 | Mode | `FAUCET_SIGNER_DRIVER` | Key location | When to use |
 |------|------------------------|--------------|-------------|
-| WASM | `wasm` | In the faucet process, from `FAUCET_PRIVATE_KEY` env var (and encrypted to disk at `/data/faucet.key` via `FAUCET_KEY_PASSPHRASE`) | Default. Simplest. Faucet connects directly to testnet/mainnet seed peers. |
-| RPC | `rpc` | In a separate `core-rs-albatross` node with the wallet pre-unlocked | You already run a Nimiq node and want to centralise key custody. |
+| RPC  | `rpc`  | In a separate `core-rs-albatross` node with the wallet pre-unlocked | **Recommended for production.** Centralises key custody; the faucet process never holds the key. |
+| WASM | `wasm` | In the faucet process, from `FAUCET_PRIVATE_KEY` env var (and encrypted to disk at `/data/faucet.key` via `FAUCET_KEY_PASSPHRASE`) | Simplest, smoke tests / local trials only — see the WASM panic note below. |
 
 **For either mode**, the address is `FAUCET_WALLET_ADDRESS`. The faucet
 will refuse to start if this is unset or if it can't produce the same
 address from the supplied key.
+
+> ⚠️ **WASM panic (#119).** `@nimiq/core` 2.4.0's WASM client panics
+> with `'time not implemented on this platform'` ~30% of the time
+> during the testnet handshake. The faucet HTTP server stays up in the
+> surviving 70%, but the signer is unusable until the panic is
+> investigated upstream. We recommend `FAUCET_SIGNER_DRIVER=rpc` for
+> production deployments and the WASM driver only for local smoke
+> tests. See [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119)
+> and [`docs/quality/wasm-time-panic-upstream-report.md`](./quality/wasm-time-panic-upstream-report.md)
+> — a draft upstream report ready to file against `nimiq/core-rs-albatross`.
 
 > **RPC security note:** When using `FAUCET_SIGNER_DRIVER=rpc`, the faucet
 > sends the private key and wallet passphrase to the Nimiq node via

--- a/docs/quality/wasm-time-panic-upstream-report.md
+++ b/docs/quality/wasm-time-panic-upstream-report.md
@@ -1,0 +1,204 @@
+# Upstream report: `@nimiq/core` WASM panics with `'time not implemented on this platform'`
+
+**Status**: open against this repo as [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119); not yet filed upstream.
+
+**Hand-off target**: [`nimiq/core-rs-albatross`](https://github.com/nimiq/core-rs-albatross) (the `@nimiq/core` WASM client is built from this repo's web-client crate).
+
+This file is the source-of-truth for the upstream report. The maintainer
+copies the §"Report body" section into a new `core-rs-albatross` issue
+and adds whatever `core-rs-albatross` triage requires (labels, milestone,
+linked PRs). Update this file when the upstream issue is filed and again
+when it's resolved.
+
+---
+
+## TL;DR for triage
+
+`@nimiq/core` 2.4.0 (WebClient/WASM) panics in ~30% of testnet
+handshakes inside `node:22-bookworm-slim` (Linux x86_64, glibc) with:
+
+```
+thread '<unnamed>' panicked at 'time not implemented on this platform':
+/rustc/.../library/std/src/sys/time/unsupported.rs:35
+```
+
+Always shortly after `Requesting zkp from peer`. The standard library
+hits the **`unsupported`** time backend at runtime — the symbol that
+`/library/std/src/sys/time/unsupported.rs:35` exports is the panic
+stub for targets that don't have a working `Instant`/`SystemTime`
+implementation.
+
+That's surprising because the binary is running under Node.js on
+Linux x86_64 — where the standard time syscalls are obviously
+available. The most likely diagnosis is that the `wasm32-unknown-unknown`
+build path is in use (no JS shim mapping `Instant::now()` to
+`performance.now()` / `Date.now()`), and **some** code path lands on
+`Instant::now()` after the consensus handshake reaches a particular
+state. The intermittency suggests it depends on the order of received
+ZKP frames, network jitter, or a tokio scheduler decision.
+
+This makes the WASM driver unfit for production today. Our project has
+flipped the README + production-deployment docs to recommend
+`FAUCET_SIGNER_DRIVER=rpc` until upstream resolves it.
+
+---
+
+## Why we think it's worth filing upstream rather than working around
+
+- **Reproducible**: 3-of-10 boots panic on my workstation against
+  testnet seed peers. Reproduces from a vanilla `docker compose up`.
+- **Not our code path**: the panic site is inside the WASM blob from
+  `@nimiq/core`. We don't call `Instant::now` from JS, and the panic
+  PC is in the wasm function table, not in our wrapper.
+- **Tied to consensus internals**: it always fires shortly after the
+  ZKP-request handshake step. That's a consensus-layer code path, not
+  something a downstream consumer can reroute.
+- **Affects the documented Quick Start path**: `FAUCET_SIGNER_DRIVER=wasm`
+  is the simplest mode for new contributors. Coin-flipping their first
+  boot is a notable adoption blocker.
+
+---
+
+## What `core-rs-albatross` likely needs to look at
+
+1. **Build target & feature flags** the WASM module is shipped with:
+   `wasm32-unknown-unknown` vs `wasm32-wasip1`. The former requires
+   JS-side time shims (e.g. `wasm-timer`, `web-time`, or a custom
+   `Instant` import). The latter has time built into WASI.
+2. **Audit Cargo deps for `instant` vs `tokio` time**. The
+   `tokio-with-wasm` crate, the `gloo-timers` crate, and `web-time`
+   are common alternatives; if any path falls through to `std::time`
+   on the WASM target, that's the panic site.
+3. **Random unwraps on time**. `Instant::now()` panics on an
+   unsupported target before reaching any user code; if the panic
+   message is `'time not implemented on this platform'` and not a
+   user-defined `expect("…")`, the symbol is from `std`.
+4. **Why intermittent?** Two plausible answers: (a) the panic-site
+   code path runs only once consensus reaches a particular state and
+   the order of incoming frames decides whether it runs early enough
+   to be visible to us; (b) a worker/futures task fires at an
+   unpredictable time and the panic is racy. Either way, *fixing the
+   missing time impl* eliminates the question.
+
+---
+
+## Report body (copy this verbatim into the upstream issue)
+
+> **Title**: WASM client panics intermittently with `'time not implemented on this platform'` shortly after testnet handshake (web-client / wasm32 build)
+>
+> ## Versions
+>
+> - `@nimiq/core` 2.4.0 (npm package — WASM web-client build).
+> - Node.js 22.x on `node:22-bookworm-slim` (Debian Bookworm slim, Linux x86_64, glibc).
+> - Network: TestAlbatross.
+>
+> ## What happens
+>
+> When the WASM client is initialised inside Node.js and asked to
+> connect to TestAlbatross seed peers, ~30% of boots panic shortly
+> after the `Requesting zkp from peer` log line:
+>
+> ```
+> ERROR panic | thread '<unnamed>' panicked at 'time not implemented on this platform': /rustc/.../library/std/src/sys/time/unsupported.rs:35
+>
+> Error [RuntimeError]: unreachable
+>     at wasm://wasm/01d5f8d2:wasm-function[2108]:0x25dd43
+>     ...
+> ```
+>
+> The Fastify HTTP server hosting the client is up and serving requests
+> in the surviving 70% of boots, but the same panic can also fire mid-
+> flight ~1 minute after a successful handshake.
+>
+> The panic message comes from the Rust standard library's `unsupported`
+> time backend (`/library/std/src/sys/time/unsupported.rs:35`), which
+> is the stub that gets linked when the build target has no
+> implementation for `Instant::now()`/`SystemTime::now()`.
+>
+> ## Why this is surprising
+>
+> The binary is running on Linux x86_64 / glibc, where time syscalls
+> are obviously available. The likely cause is that the WASM build
+> target is `wasm32-unknown-unknown` (which falls through to the
+> stdlib's `unsupported` time impl unless an explicit shim is wired
+> in via JS imports / a wrapper crate like `web-time`). If that's
+> right, this is a build-config issue inside `core-rs-albatross`'s
+> `web-client` crate.
+>
+> ## Reproduction
+>
+> Standalone container repro (no third-party app needed):
+>
+> ```bash
+> docker run --rm \
+>   -e FAUCET_NETWORK=test \
+>   -e FAUCET_SIGNER_DRIVER=wasm \
+>   -e FAUCET_PRIVATE_KEY=$(openssl rand -hex 32) \
+>   -e FAUCET_KEY_PASSPHRASE=at-least-eight-chars \
+>   -e FAUCET_ADMIN_PASSWORD=at-least-eight-chars \
+>   -e FAUCET_DEV=1 \
+>   ghcr.io/panoramicrum/nimiq-simple-faucet:latest
+> ```
+>
+> Run 10 times; ~3 fire the panic above. Affected boots crash the
+> process; surviving boots may also crash mid-flight a minute later.
+>
+> Minimal Node-only repro (no faucet code in the path) requires only
+> `npm install @nimiq/core@2.4.0 && node` followed by:
+>
+> ```js
+> const nimiq = await import('@nimiq/core');
+> const config = new nimiq.ClientConfiguration();
+> config.network('TestAlbatross');
+> config.seedNodes(['/dns4/seed1.pos.nimiq-testnet.com/tcp/8443/wss']);
+> const client = await nimiq.Client.create(config.build());
+> await client.waitForConsensusEstablished();
+> ```
+>
+> Loop this in a fresh container 10× to reproduce the coin-flip.
+>
+> ## What we'd like to know
+>
+> 1. Is `core-rs-albatross`'s WASM build target `wasm32-unknown-unknown`
+>    (and therefore reliant on a JS time shim) or `wasm32-wasip1`?
+> 2. If it's `wasm32-unknown-unknown`, where does the JS shim live
+>    (or where does it fail to live)?
+> 3. Is there a known-good `@nimiq/core` version we could pin until
+>    a fix lands? `2.4.0` is what npm resolves \`^2.4.0\` to today.
+>
+> ## What we've ruled out
+>
+> - Container image quirks: reproduces on three different host kernels
+>   (Linux 6.8, 6.6, macOS Docker Desktop with the linux/amd64 image).
+> - Wallet key material: the panic happens before any signing call.
+> - User code calling into time: the panic stack ends in the WASM
+>   blob; our wrapper only \`await\`s \`Client.create\` and
+>   \`waitForConsensusEstablished\`.
+>
+> ## Found while
+>
+> Building [`PanoramicRum/nimiq-simple-faucet`](https://github.com/PanoramicRum/nimiq-simple-faucet)'s
+> Mini App example ([PR #113](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/113));
+> tracked downstream as [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119).
+
+---
+
+## Working with the maintainers
+
+When you file the upstream issue:
+
+1. **Start small**: drop the "What we've ruled out" + "What we'd like to know" sections first. If they ask for more, paste the rest.
+2. **Avoid the word "broken"**: it's an honest bug report, not a complaint. The Albatross team is small and unpaid; lead with the repro.
+3. **Offer to test fixes**: their build matrix doesn't always cover Node.js + the npm bundle path. We can run a candidate `@nimiq/core` build through our CI \`docker\` job (lines 96–135 of [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)) which already exercises the panic path.
+
+### Ongoing collaboration plan
+
+- **Pin a candidate version**: once upstream proposes a fix or a known-good version, bump our root `package.json` `@nimiq/core` pin and watch the CI smoke job for 10 consecutive runs to confirm the panic rate drops.
+- **Mirror their reproducer**: if upstream creates a minimal Rust-side reproducer, link it from #119 and adjust our test plan accordingly.
+- **Close the loop**: when upstream ships a fix, bump our pin, re-flip the docs to recommend WASM again (or keep RPC as recommended for production but stop calling WASM "smoke-test only"), and close #119.
+
+## Tracking
+
+- This repo: [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119) — keep open until upstream is resolved.
+- Upstream: _to be filled in once filed against `nimiq/core-rs-albatross`._
+- Workaround in CI: [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) downgrades the panic to a `::warning::` instead of failing the build.


### PR DESCRIPTION
## Summary

Tracks (does not close) **#119** — \`@nimiq/core\` 2.4.0 WASM client panics ~30% of testnet handshakes with \`'time not implemented on this platform'\`. Root cause is upstream and out of scope for this repo to fix in code, but the docs were optimistically claiming "fixed in v1.1.4" and the CI smoke job hard-failed when the panic hit. Three deliverables here:

### Docs

- **README.md** Quick Start gains a ⚠️ callout pointing at #119 and recommending \`FAUCET_SIGNER_DRIVER=rpc\` for anything beyond a smoke test. Drops the misleading "fixed in v1.1.4" claim.
- **docs/deployment-production.md** flips the WASM/RPC table — RPC is now presented as the production-recommended option, WASM marked smoke-test-only with the same #119 callout.
- **docs/quality/wasm-time-panic-upstream-report.md** (new) — a draft upstream bug report ready to file against \`nimiq/core-rs-albatross\`. Includes:
  - The diagnosis (likely \`wasm32-unknown-unknown\` build without a JS time shim → stdlib's \`unsupported\` time backend gets linked).
  - A standalone Docker repro.
  - A Node-only minimal repro (no faucet code in the path).
  - A "what we'd like to know" triage list (build target, JS shim location, known-good pin).
  - A working-with-the-maintainers section covering tone, ongoing-collaboration plan, and close-the-loop tracking.

### CI

\`docker\` smoke job in \`ci.yml\` now distinguishes the upstream panic from a genuine regression:

- Container exits early **and** log contains \`'time not implemented on this platform'\` → emit a CI \`::warning::\`, tail the log, exit 0 (upstream issue, not our regression).
- Container exits early for any other reason → hard fail (catches missing native bindings, DB init failure, etc.).

This stops #119 from spuriously red-flagging the build while keeping the original detection of "container died on boot" intact for regressions we actually own.

### Hand-off

The upstream report (§"Report body") is ready to copy verbatim into a new \`core-rs-albatross\` issue. Once filed, update the "Tracking" section in the doc with the upstream URL and link from #119.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` validates ci.yml.
- [ ] CI green on this PR.
- [ ] If a future CI run hits the panic, the new \`::warning::\` shows up in the GitHub Actions summary and the build is green.
- [ ] Manual hand-off: maintainer reviews the draft upstream report, files it against \`nimiq/core-rs-albatross\`, updates the Tracking section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)