### PR TITLE
fix(auth): widen TOTP verification window to ±1 step (fixes admin-auth CI flake)

### DIFF
--- a/apps/server/src/auth/session.ts
+++ b/apps/server/src/auth/session.ts
@@ -141,6 +141,14 @@ export function totpUri(secret: string, account: string, issuer = 'NimiqFaucet')
   return authenticator.keyuri(account, issuer, secret);
 }
 
+// Accept the previous, current, and next 30-second TOTP step. Without this,
+// `authenticator.check()` defaults to `window: 0` — zero clock-drift
+// tolerance — which both flakes CI under load (the test generates a code in
+// step N, the server verifies in step N+1 → 401) and rejects legitimate
+// users whose phone clock is a few seconds off. ±1 step is the standard
+// otplib recommendation for real-world authenticator apps.
+authenticator.options = { window: 1 };
+
 /** Timing-safe TOTP code verification via otplib (accepts prev/next window). */
 export function verifyTotp(secret: string, code: string): boolean {
   const normalized = code.replace(/\s+/g, '');


### PR DESCRIPTION
## Summary

Fixes the post-#140 CI flake in \`test/admin-auth.e2e.test.ts:99\` ("login with valid password + TOTP succeeds"). Same fix also closes a real-user bug.

\`authenticator.check()\` from \`@otplib/preset-default\` defaults to \`window: 0\` — zero clock-drift tolerance. Two real consequences:

1. **CI flakes.** When a test generates a code with \`authenticator.generate()\` in step N and the server verifies in step N+1 (because the runner crossed a 30-second boundary between the two calls), verification returns \`false\` → the second-login test gets 401 instead of 200. Hit on the post-#140 main run; passes locally on every retry. Classic timing flake.
2. **Real users.** A phone whose clock is 5–30 seconds off would have its valid TOTP code rejected. otplib's own docs recommend \`window: 1\` for real-world authenticator apps — the per-step lookback and look-ahead matches what Google Authenticator / Authy / 1Password already do server-side.

Set \`authenticator.options = { window: 1 }\` once at module load (the preset is a singleton). All TOTP verifications go through \`verifyTotp\` which uses this configured authenticator, so step-up and login share the same tolerance.

## Test plan

- [x] \`pnpm --filter @faucet/server test\` — 128/128 (was 127, +1 because the formerly-flaky test now reliably passes; same total elsewhere).
- [x] All admin-auth, admin-first-login, admin-cookie-prefix tests pass.
- [ ] CI green on this PR.
- [ ] No retroactive flake on \`main\` for the next 24h of CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)