### PR TITLE
feat(examples): demonstrate abuse layers in every example app (§3.0.7)

### DIFF
--- a/examples/capacitor-mobile-app/.env.example
+++ b/examples/capacitor-mobile-app/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env` and adjust as needed.
+
+# The faucet URL the WebView hits. On a phone this needs to be reachable
+# from the device — use your LAN IP rather than localhost.
+VITE_FAUCET_URL=http://localhost:8080
+
+# Identifier emitted in hostContext.uid. In production a backend signs
+# the hostContext (FaucetClient.signHostContext + integrator HMAC secret)
+# and hands the signed value to the app — the device should NEVER hold
+# the HMAC secret. The demo passes a plain uid for runnability.
+VITE_INTEGRATOR_ID=capacitor-example

--- a/examples/capacitor-mobile-app/README.md
+++ b/examples/capacitor-mobile-app/README.md
@@ -1,20 +1,25 @@
 # Capacitor Mobile App Example
 
-Vite + React + Capacitor app demonstrating `@nimiq-faucet/capacitor` integration. In Docker, this runs as a web preview. For real mobile, add native platforms on the host.
+Vite + React + Capacitor app demonstrating `@nimiq-faucet/capacitor` integration **with full abuse-layer support**: device fingerprint (auto-injected), captcha widget, hashcash, and `hostContext`.
+
+In Docker this runs as a web preview. For real iOS/Android, add native platforms on the host.
 
 ## What this demonstrates
 
-- `CapacitorFaucetClient` which auto-injects device fingerprint on native
-- `useFaucetClaim` hook from `@nimiq-faucet/react` for claim lifecycle
-- Graceful fallback in web mode (no device fingerprint, but claim still works)
-- Address input, claim submission, and live status updates
+- `CapacitorFaucetClient` — auto-injects `fingerprint.visitorId` from `@capacitor/device`'s `Device.getId()` on every claim
+- Device info surfacing in the UI (platform, model, visitorId) so testers can see what the faucet receives
+- `/v1/config` discovery — captcha + hashcash rendered conditionally
+- Cloudflare Turnstile + hCaptcha widget integration in the WebView
+- Hashcash via `client.solveAndClaim()` (works whether or not the server requires PoW)
+- `hostContext` shape (uid + signed-context pattern documented in code comments)
 
 ## Run locally (web preview)
 
 ```bash
 # From repo root
 pnpm install
-VITE_FAUCET_URL=http://localhost:8080 pnpm --filter @nimiq-faucet/example-capacitor dev
+cp examples/capacitor-mobile-app/.env.example examples/capacitor-mobile-app/.env
+pnpm --filter @nimiq-faucet/example-capacitor dev
 ```
 
 ## Run with Docker (web preview)
@@ -25,6 +30,13 @@ docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.y
 # Open http://localhost:3003
 ```
 
+## Configuration
+
+| Env var                    | Default                       | Notes |
+|----------------------------|-------------------------------|-------|
+| `VITE_FAUCET_URL`          | `http://localhost:8080`       | Faucet base URL the WebView hits |
+| `VITE_INTEGRATOR_ID`       | `capacitor-example`           | Identifier embedded in `hostContext.uid` |
+
 ## For real mobile
 
 ```bash
@@ -32,3 +44,22 @@ cd examples/capacitor-mobile-app
 npx cap add ios      # or android
 npx cap open ios     # opens Xcode
 ```
+
+On native iOS/Android the `@capacitor/device` `Device.getId()` returns:
+- **iOS**: a vendor-stable UUID (`identifierForVendor`)
+- **Android 8+**: a 64-bit hex string keyed by `(app-signing-key, user, device)`
+- **Web**: a per-browser localStorage UUID (regenerated if storage is cleared)
+
+The faucet receives this as `fingerprint.visitorId` and uses it in the abuse pipeline (e.g. fingerprint-velocity layer).
+
+## Abuse layers
+
+| Layer | How this example demonstrates it |
+|-------|----------------------------------|
+| **Device fingerprint** | `CapacitorFaucetClient` auto-populates `fingerprint.visitorId` from `Device.getId()`. The UI surfaces the value so you can verify what the faucet sees. |
+| **Cloudflare Turnstile / hCaptcha** | Loaded from `/v1/config.captcha.provider`. Widget renders in the WebView; token sent on `claim` as `captchaToken`. |
+| **Hashcash** | `client.solveAndClaim()` calls `requestChallenge()` → `solveHashcash()` → `claim()` with the solution. On servers without hashcash configured this is identical to a plain `claim()`. |
+| **`hostContext` (signed)** | Production mobile apps receive a backend-signed context as part of authenticated session state — the device should NEVER hold the HMAC secret. The demo sends a plain uid for runnability. |
+| **GeoIP / On-chain / AI** | Server-side only — invisible to the app. |
+
+Server-side details: [`docs/abuse-prevention.md`](../../docs/abuse-prevention.md).

--- a/examples/capacitor-mobile-app/src/App.tsx
+++ b/examples/capacitor-mobile-app/src/App.tsx
@@ -1,44 +1,194 @@
-import { useCallback, useMemo, useState } from 'react';
-import { CapacitorFaucetClient } from '@nimiq-faucet/capacitor';
-import { useFaucetClaim } from '@nimiq-faucet/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Device, type DeviceInfo } from '@capacitor/device';
+import { CapacitorFaucetClient, type ClaimResponse, type FaucetConfig } from '@nimiq-faucet/capacitor';
 
-const faucetUrl = (import.meta as any).env?.VITE_FAUCET_URL || 'http://localhost:8080';
+/**
+ * §3.0.7 abuse-layer demo — Capacitor mobile app (React + Vite).
+ *
+ * Demonstrates the four abuse-layer surfaces that apply on mobile:
+ *   1. Device fingerprint — `CapacitorFaucetClient` automatically injects
+ *      `fingerprint.visitorId` from `@capacitor/device`'s `Device.getId()`
+ *      on every claim. The example also surfaces the platform/model in the
+ *      UI so testers can confirm the value the faucet receives.
+ *   2. Captcha widget (Turnstile/hCaptcha) — driven by `/v1/config`. Loads
+ *      the provider's script in the WebView.
+ *   3. Hashcash proof-of-work — `client.solveAndClaim()` does the round trip.
+ *   4. `hostContext` — uid + KYC level + accountAgeDays. Production apps
+ *      receive a backend-signed context as part of authenticated session
+ *      state; this demo sends an unsigned uid for runnability.
+ */
 
-function statusLabel(status: string): string {
-  switch (status) {
-    case 'idle': return '';
-    case 'pending': return 'Submitting claim...';
-    case 'queued': return 'Queued — waiting for broadcast...';
-    case 'broadcast': return 'Broadcast — waiting for confirmation...';
+const faucetUrl = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_FAUCET_URL || 'http://localhost:8080';
+const integratorId = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_INTEGRATOR_ID || 'capacitor-example';
+
+type Phase = 'idle' | 'loading-config' | 'awaiting-captcha' | 'solving-hashcash' | 'submitting' | 'broadcast' | 'confirmed' | 'rejected' | 'error';
+
+function phaseLabel(phase: Phase, attempts: number): string {
+  switch (phase) {
+    case 'loading-config': return 'Reading server config…';
+    case 'solving-hashcash': return `Proof-of-work: ${attempts.toLocaleString()} attempts…`;
+    case 'submitting': return 'Submitting claim…';
+    case 'broadcast': return 'Broadcast — waiting for confirmation…';
     case 'confirmed': return 'Confirmed!';
     case 'rejected': return 'Rejected';
-    case 'challenged': return 'Challenge required';
-    default: return status;
+    case 'error': return 'Something went wrong.';
+    default: return '';
   }
 }
 
 export default function App() {
   const client = useMemo(() => new CapacitorFaucetClient({ url: faucetUrl }), []);
+
+  const [phase, setPhase] = useState<Phase>('loading-config');
   const [address, setAddress] = useState('');
+  const [config, setConfig] = useState<FaucetConfig | null>(null);
+  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null);
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const [hashcashAttempts, setHashcashAttempts] = useState(0);
+  const [txId, setTxId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const captchaToken = useRef<string | null>(null);
+  const captchaRendered = useRef(false);
 
-  const { claim, reset, status, txId, error } = useFaucetClaim({
-    client,
-    address,
-    hostContext: { uid: 'capacitor-example' },
-  });
+  const isPending = ['loading-config', 'solving-hashcash', 'submitting', 'broadcast'].includes(phase);
+  const captchaRequired = Boolean(config?.captcha) && config?.captcha?.provider !== 'fcaptcha';
+  const captchaSatisfied = !captchaRequired || captchaToken.current !== null;
+  const canSubmit = !isPending && address.trim().length > 0 && captchaSatisfied;
 
-  const pending = status === 'pending';
-  const label = statusLabel(status);
+  // Device info + faucet config + captcha widget on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [info, id] = await Promise.all([
+          Device.getInfo().catch(() => null),
+          Device.getId().then((r) => r.identifier).catch(() => null),
+        ]);
+        if (cancelled) return;
+        setDeviceInfo(info);
+        setDeviceId(id);
 
-  const handleSubmit = useCallback((e: React.FormEvent) => {
+        const cfg = await client.config();
+        if (cancelled) return;
+        setConfig(cfg);
+        setPhase(cfg.captcha ? 'awaiting-captcha' : 'idle');
+        if (cfg.captcha && !captchaRendered.current) {
+          await loadCaptchaWidget(cfg);
+          captchaRendered.current = true;
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setPhase('error');
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [client]);
+
+  async function loadCaptchaWidget(cfg: FaucetConfig) {
+    if (!cfg.captcha) return;
+    const provider = cfg.captcha.provider;
+    if (provider === 'fcaptcha') {
+      // FCaptcha is the WebView/mini-app fcaptcha pattern; this example
+      // targets Turnstile/hCaptcha. fcaptcha would work here too — see
+      // examples/mini-app-claim-* for that pattern.
+      setErrorMessage('This example renders Turnstile/hCaptcha; the faucet returned fcaptcha.');
+      return;
+    }
+    const src = provider === 'turnstile'
+      ? 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+      : 'https://js.hcaptcha.com/1/api.js?render=explicit';
+    await injectScript(src, `data-${provider}`);
+    type CaptchaLib = { render: (el: HTMLElement, o: Record<string, unknown>) => unknown };
+    const w = window as Window & { turnstile?: CaptchaLib; hcaptcha?: CaptchaLib };
+    const lib = provider === 'turnstile' ? w.turnstile : w.hcaptcha;
+    const host = document.getElementById('captcha-host');
+    if (!lib || !host) return;
+    lib.render(host, {
+      sitekey: cfg.captcha.siteKey,
+      callback: (token: string) => { captchaToken.current = token; },
+      'error-callback': () => { captchaToken.current = null; setErrorMessage('Captcha widget reported an error'); },
+      'expired-callback': () => { captchaToken.current = null; },
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (address.trim()) claim();
-  }, [address, claim]);
+    if (!canSubmit) return;
+    setErrorMessage(null);
+    setTxId(null);
+
+    // hostContext: production frontends receive a SIGNED context minted
+    // by their backend as part of authenticated session state. This demo
+    // sends a plain uid so it runs without a backend.
+    const hostContext = { uid: integratorId };
+
+    try {
+      let result: ClaimResponse;
+      if (config?.hashcash) {
+        setPhase('solving-hashcash');
+        setHashcashAttempts(0);
+        result = await client.solveAndClaim(address.trim(), {
+          uid: integratorId,
+          hostContext,
+          captchaToken: captchaToken.current ?? undefined,
+          onProgress: (n) => setHashcashAttempts(n),
+        });
+      } else {
+        setPhase('submitting');
+        result = await client.claim(address.trim(), {
+          hostContext,
+          captchaToken: captchaToken.current ?? undefined,
+        });
+      }
+      // Either path auto-injected fingerprint.visitorId via the
+      // CapacitorFaucetClient wrapper — the faucet logs include the
+      // device id in `request.fingerprint`.
+      setPhase('submitting');
+      setTxId(result.txId ?? null);
+      if (result.status === 'rejected') {
+        setPhase('rejected');
+        setErrorMessage(result.reason ?? 'Claim rejected');
+        return;
+      }
+      if (result.status === 'challenged') {
+        setPhase('rejected');
+        setErrorMessage(result.reason ?? 'Captcha challenge required');
+        return;
+      }
+      setPhase('broadcast');
+      const final = await client.waitForConfirmation(result.id);
+      setTxId((prev) => final.txId ?? prev);
+      setPhase(final.status === 'confirmed' ? 'confirmed' : 'rejected');
+      if (final.status === 'rejected' && final.reason) setErrorMessage(final.reason);
+    } catch (err) {
+      setPhase('error');
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  function handleReset() {
+    setPhase(config?.captcha ? 'awaiting-captcha' : 'idle');
+    setTxId(null);
+    setErrorMessage(null);
+    setHashcashAttempts(0);
+    captchaToken.current = null;
+  }
+
+  const label = phaseLabel(phase, hashcashAttempts);
 
   return (
     <main style={styles.container}>
       <h1 style={styles.heading}>Nimiq Faucet</h1>
-      <p style={styles.subtitle}>Capacitor mobile app — claim free NIM</p>
+      <p style={styles.subtitle}>Capacitor mobile app — claim free NIM (with abuse-layer demo)</p>
+
+      <div style={styles.deviceCard}>
+        <div style={styles.deviceLabel}>Device fingerprint (auto-injected)</div>
+        <div style={styles.deviceLine}>
+          <strong>{deviceInfo ? `${deviceInfo.platform} ${deviceInfo.model}` : 'detecting…'}</strong>
+        </div>
+        <div style={styles.deviceLine}><code>visitorId: {deviceId ?? 'unavailable'}</code></div>
+      </div>
 
       <form onSubmit={handleSubmit} style={styles.form}>
         <label htmlFor="address" style={styles.label}>Nimiq Address</label>
@@ -47,48 +197,86 @@ export default function App() {
           value={address}
           onChange={(e) => setAddress(e.target.value)}
           placeholder="NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
-          disabled={pending}
+          disabled={isPending}
           autoComplete="off"
           spellCheck={false}
           style={styles.input}
         />
-        <button type="submit" disabled={pending || !address.trim()} style={styles.button}>
-          {pending ? 'Claiming...' : 'Claim NIM'}
+
+        {captchaRequired && (
+          <div style={styles.captchaBlock}>
+            <div style={styles.captchaLabel}>{config!.captcha!.provider === 'turnstile' ? 'Cloudflare Turnstile' : 'hCaptcha'}</div>
+            <div id="captcha-host" />
+          </div>
+        )}
+
+        {config?.hashcash && (
+          <p style={styles.hashcashNote}>
+            Hashcash difficulty {config.hashcash.difficulty} bits — solved on this device.
+          </p>
+        )}
+
+        <button type="submit" disabled={!canSubmit} style={styles.button}>
+          {isPending ? 'Claiming…' : 'Claim NIM'}
         </button>
       </form>
 
       {label && (
         <div style={{
           ...styles.status,
-          ...(status === 'confirmed' ? styles.confirmed : {}),
-          ...(status === 'rejected' ? styles.rejected : {}),
+          ...(phase === 'confirmed' ? styles.confirmed : {}),
+          ...(phase === 'rejected' ? styles.rejected : {}),
+          ...(phase === 'solving-hashcash' ? styles.hashcash : {}),
         }}>
           <p>{label}</p>
           {txId && <p style={styles.tx}>TX: <code>{txId}</code></p>}
         </div>
       )}
 
-      {error && (
+      {errorMessage && (
         <div style={styles.error}>
-          <p>{error.message}</p>
-          <button onClick={reset} style={{ ...styles.button, ...styles.retry }}>Try again</button>
+          <p>{errorMessage}</p>
+          <button onClick={handleReset} style={{ ...styles.button, ...styles.retry }}>Try again</button>
         </div>
       )}
     </main>
   );
 }
 
+function injectScript(src: string, marker: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[${marker}]`);
+    if (existing) { resolve(); return; }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.defer = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute(marker, 'true');
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
 const styles: Record<string, React.CSSProperties> = {
   container: { maxWidth: 480, margin: '0 auto', padding: '2rem', fontFamily: 'system-ui, sans-serif' },
   heading: { fontSize: '1.75rem', marginBottom: '0.25rem', color: '#1f2348' },
-  subtitle: { color: '#6b7280', marginBottom: '2rem' },
-  form: { display: 'flex', flexDirection: 'column', gap: '0.75rem' },
+  subtitle: { color: '#6b7280', marginBottom: '1.5rem' },
+  deviceCard: { padding: '0.75rem', background: '#f0f1f9', borderRadius: 8, marginBottom: '1.5rem', fontSize: '0.8rem' },
+  deviceLabel: { fontSize: '0.7rem', color: '#6b7280', textTransform: 'uppercase' as const, letterSpacing: 0.5, marginBottom: '0.25rem' },
+  deviceLine: { wordBreak: 'break-all' as const, lineHeight: 1.4 },
+  form: { display: 'flex', flexDirection: 'column' as const, gap: '0.75rem' },
   label: { fontWeight: 600, fontSize: '0.875rem' },
   input: { padding: '0.75rem', border: '1px solid #d1d5db', borderRadius: 8, fontFamily: 'monospace', fontSize: '0.875rem' },
   button: { padding: '0.75rem', border: 'none', borderRadius: 8, background: '#1f2348', color: '#fff', fontSize: '1rem', fontWeight: 600, cursor: 'pointer' },
+  captchaBlock: { padding: '0.75rem', background: '#f0f1f9', borderRadius: 8 },
+  captchaLabel: { fontSize: '0.75rem', color: '#6b7280', marginBottom: '0.5rem' },
+  hashcashNote: { fontSize: '0.75rem', color: '#6b7280', fontStyle: 'italic' as const, marginTop: '-0.25rem' },
   status: { marginTop: '1.5rem', padding: '1rem', borderRadius: 8, background: '#e8eaf6' },
   confirmed: { background: '#d1fae5', color: '#065f46' },
   rejected: { background: '#fee2e2', color: '#991b1b' },
+  hashcash: { background: '#fef3c7', color: '#78350f' },
   tx: { marginTop: '0.5rem', fontSize: '0.8rem', wordBreak: 'break-all' as const },
   error: { marginTop: '1.5rem', padding: '1rem', borderRadius: 8, background: '#fee2e2', color: '#991b1b' },
   retry: { marginTop: '0.75rem', background: '#991b1b', fontSize: '0.875rem', padding: '0.5rem 1rem' },

--- a/examples/flutter-mobile-app/README.md
+++ b/examples/flutter-mobile-app/README.md
@@ -1,21 +1,39 @@
 # Flutter / Dart SDK Demo
 
-CLI app demonstrating the `nimiq_faucet` Dart SDK. Runs as a compiled binary in Docker.
+CLI app demonstrating the `nimiq_faucet` Dart SDK **with full abuse-layer support**: HMAC-signed `hostContext` and automatic hashcash via `solveAndClaim()`.
+
+Runs as a compiled binary in Docker.
 
 ## What this demonstrates
 
 - `FaucetClient` instantiation
-- `config()` to fetch faucet configuration
-- `claim()` submission with `HostContext`
+- `config()` to fetch faucet configuration (captcha provider, hashcash difficulty)
+- **`signHostContext(...)` — HMAC-signed user-state assertions** (load-bearing in the faucet's abuse pipeline)
+- **`solveAndClaim(...)` — automatic hashcash challenge round-trip** (works whether or not the server requires PoW)
 - `waitForConfirmation()` polling
 - Error handling via `FaucetException`
+
+## Configuration
+
+| Env var                       | Required | Default                         | Notes |
+|-------------------------------|----------|---------------------------------|-------|
+| `FAUCET_URL`                  | no       | `http://localhost:8080`         | Faucet base URL |
+| `FAUCET_INTEGRATOR_ID`        | no       | `dart-cli-example`              | Identifier embedded in `hostContext.uid` and HMAC signature prefix |
+| `FAUCET_HMAC_SECRET`          | **prod** | unset                           | Server-only HMAC secret. With it set, the demo signs hostContext. Without it the asserted fields aren't load-bearing. |
+| `CLAIM_ADDRESS`               | no       | placeholder                     | Recipient address (also accepted as positional CLI arg) |
+| `CLAIM_USER_ID`               | no       | `FAUCET_INTEGRATOR_ID`          | uid attached to hostContext |
+| `CLAIM_KYC_LEVEL`             | no       | unset                           | `none` / `email` / `phone` / `id` |
+| `CLAIM_ACCOUNT_AGE_DAYS`      | no       | unset                           | integer; only meaningful when signed |
 
 ## Run locally
 
 ```bash
 cd examples/flutter-mobile-app
 dart pub get
-FAUCET_URL=http://localhost:8080 dart run bin/main.dart "NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
+FAUCET_URL=http://localhost:8080 \
+  FAUCET_HMAC_SECRET="$(openssl rand -hex 32)" \
+  CLAIM_KYC_LEVEL=email CLAIM_ACCOUNT_AGE_DAYS=180 \
+  dart run bin/main.dart "NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
 ```
 
 ## Run with Docker
@@ -23,14 +41,26 @@ FAUCET_URL=http://localhost:8080 dart run bin/main.dart "NQ00 0000 0000 0000 000
 ```bash
 # From repo root — starts faucet + runs this demo
 docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.yml up --build example-flutter
-# The container runs the claim and exits. Check logs:
 docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.yml logs example-flutter
 ```
 
+## Abuse layers
+
+| Layer | How this example demonstrates it |
+|-------|----------------------------------|
+| **Hashcash** | `client.solveAndClaim(...)` calls `requestChallenge()` → solves the SHA-256 PoW → posts the solution. On servers without hashcash configured, this is identical to a plain `claim()`. |
+| **`hostContext` (HMAC-signed)** | `signHostContext(ctx, integratorId, hmacSecret)` — the faucet verifies the HMAC and treats `uid`, `kycLevel`, `accountAgeDays`, `tags` as load-bearing. **Without a signature, asserted fields are ignored.** |
+| **Captcha** | Not applicable to a CLI — captcha tokens come from a user's browser/device. A Flutter mobile app would render the widget in a `WebView` and forward the token via `ClaimOptions.captchaToken`. |
+| **Fingerprint** | A Flutter mobile app can capture device info via `device_info_plus` and pass it via `ClaimOptions.fingerprint` (out of scope for this CLI demo). |
+
 ## For a real Flutter mobile app
 
-This example is a Dart CLI to prove the SDK works in Docker. For a real Flutter mobile app:
+This example is a Dart CLI to prove the SDK works in Docker. For a real Flutter app:
 
 1. `flutter create my_app && cd my_app`
 2. Add `nimiq_faucet` to `pubspec.yaml`
 3. Use `FaucetClient` in your widgets (see `packages/sdk-flutter/example/main.dart`)
+4. For abuse-layer integration:
+   - **hostContext signing happens on YOUR backend**, not in the app — the app receives a pre-signed context as part of authenticated session state
+   - **Captcha** — render in a `WebView` widget, intercept the token callback
+   - **Fingerprint** — `device_info_plus` for stable device IDs; pass to `FaucetClient.claim()` via `ClaimOptions.fingerprint`

--- a/examples/flutter-mobile-app/bin/main.dart
+++ b/examples/flutter-mobile-app/bin/main.dart
@@ -1,42 +1,84 @@
+// Nimiq Faucet Dart CLI demo with full abuse-layer support:
+// HMAC-signed hostContext + automatic hashcash via solveAndClaim.
+//
+// Usage:
+//   dart run bin/main.dart [<address>]
+//
+// Env vars:
+//   FAUCET_URL              — faucet base URL (default http://localhost:8080)
+//   FAUCET_INTEGRATOR_ID    — integrator identifier (default 'dart-cli-example')
+//   FAUCET_HMAC_SECRET      — server-only HMAC secret. With this set, the
+//                             demo signs hostContext so the faucet treats
+//                             asserted user-state fields as load-bearing.
+//                             Without it the claim still works but the
+//                             asserted fields don't carry weight.
+//   CLAIM_ADDRESS           — claim recipient (also positional arg)
+//   CLAIM_USER_ID           — uid for hostContext.uid (default INTEGRATOR_ID)
+//   CLAIM_KYC_LEVEL         — 'none' | 'email' | 'phone' | 'id'
+//   CLAIM_ACCOUNT_AGE_DAYS  — integer
+
 import 'dart:io';
 import 'package:nimiq_faucet/nimiq_faucet.dart';
 
 Future<void> main(List<String> args) async {
   final url = Platform.environment['FAUCET_URL'] ?? 'http://localhost:8080';
+  final integratorId = Platform.environment['FAUCET_INTEGRATOR_ID'] ?? 'dart-cli-example';
+  final hmacSecret = Platform.environment['FAUCET_HMAC_SECRET'];
+  final userId = Platform.environment['CLAIM_USER_ID'] ?? integratorId;
+  final kycLevel = Platform.environment['CLAIM_KYC_LEVEL'];
+  final accountAgeDays = int.tryParse(Platform.environment['CLAIM_ACCOUNT_AGE_DAYS'] ?? '');
   final address = args.isNotEmpty
       ? args.first
-      : Platform.environment['CLAIM_ADDRESS'] ??
-          'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
+      : Platform.environment['CLAIM_ADDRESS'] ?? 'NQ00 0000 0000 0000 0000 0000 0000 0000 0000';
 
-  print('Faucet URL: $url');
-  print('Address:    $address');
+  print('Faucet URL:    $url');
+  print('Address:       $address');
+  print('Integrator:    $integratorId');
+  print('Signed ctx:    ${hmacSecret != null}');
   print('');
 
   final client = FaucetClient(url: url);
   try {
-    // Fetch config
     final cfg = await client.config();
-    print('Network: ${cfg.network}');
-    print('Claim amount: ${cfg.claimAmountLuna} luna');
+    print('Network:       ${cfg.network}');
+    print('Claim amount:  ${cfg.claimAmountLuna} luna');
+    print('Captcha:       ${cfg.captcha?.provider ?? 'disabled'}');
+    print('Hashcash:      ${cfg.hashcash != null ? '${cfg.hashcash!.difficulty} bits' : 'disabled'}');
     print('');
 
-    // Submit claim
-    print('Submitting claim...');
-    final resp = await client.claim(
-      address,
-      const ClaimOptions(hostContext: HostContext(uid: 'dart-cli-example')),
+    // Build a hostContext from the values you (the integrator) attest to.
+    var hc = HostContext(
+      uid: userId,
+      kycLevel: kycLevel,
+      accountAgeDays: accountAgeDays,
     );
-    print('Claim ID: ${resp.id}');
-    print('Status:   ${resp.status}');
-    if (resp.txId != null) print('TX:       ${resp.txId}');
+    // Sign hostContext if a secret is configured. Without a signature
+    // the faucet IGNORES the asserted fields (claim still works, but
+    // falls back to default abuse scoring on the unsigned-context path).
+    if (hmacSecret != null) {
+      hc = signHostContext(hc, integratorId, hmacSecret);
+    }
+
+    // solveAndClaim auto-handles the hashcash round-trip when the
+    // server requires it; it's a plain claim() otherwise.
+    print('Submitting claim...');
+    final resp = await client.solveAndClaim(
+      address,
+      ClaimOptions(hostContext: hc),
+    );
+    print('Claim ID:      ${resp.id}');
+    print('Status:        ${resp.status}');
+    if (resp.txId != null) print('TX:            ${resp.txId}');
     print('');
 
-    // Wait for confirmation
     if (resp.status == 'queued' || resp.status == 'broadcast') {
       print('Waiting for confirmation...');
       final confirmed = await client.waitForConfirmation(resp.id);
-      print('Final status: ${confirmed.status}');
-      if (confirmed.txId != null) print('TX: ${confirmed.txId}');
+      print('Final status:  ${confirmed.status}');
+      if (confirmed.txId != null) print('TX:            ${confirmed.txId}');
+      if (confirmed.status == 'rejected' && confirmed.reason != null) {
+        print('Reason:        ${confirmed.reason}');
+      }
     }
 
     print('');

--- a/examples/flutter-mobile-app/pubspec.lock
+++ b/examples/flutter-mobile-app/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: "../../packages/sdk-flutter"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:

--- a/examples/go-backend-integration/.env.example
+++ b/examples/go-backend-integration/.env.example
@@ -1,0 +1,17 @@
+# Copy to `.env` and adjust as needed.
+#
+# The faucet URL the proxy hits (server-to-server, doesn't need to be
+# browser-reachable; can be a private DNS name in production).
+FAUCET_URL=http://localhost:8080
+
+# Identifier embedded in hostContext.uid AND in the HMAC signature prefix
+# (`<integratorId>:<base64-hmac>`). Pick a stable string per integrator.
+FAUCET_INTEGRATOR_ID=go-backend-example
+
+# Server-only HMAC secret. With this set, the proxy signs hostContext on
+# every claim so the faucet treats the asserted fields (uid, kycLevel,
+# accountAgeDays, tags) as load-bearing. Generate once with:
+#   openssl rand -hex 32
+# and store in your secret manager. NEVER expose to clients.
+# Without this var, the proxy still works but asserted fields are ignored.
+# FAUCET_HMAC_SECRET=

--- a/examples/go-backend-integration/README.md
+++ b/examples/go-backend-integration/README.md
@@ -1,30 +1,49 @@
 # Go Backend Integration Example
 
-Minimal Go HTTP server demonstrating server-side faucet integration using `github.com/PanoramicRum/nimiq-simple-faucet/packages/sdk-go`.
+Go HTTP server demonstrating server-side faucet integration using `github.com/PanoramicRum/nimiq-simple-faucet/packages/sdk-go`, **with full abuse-layer support**: HMAC-signed `hostContext` and hashcash via `SolveAndClaim`.
 
 ## What this demonstrates
 
 - `faucet.New()` client construction
 - `Config()` to fetch faucet configuration
-- `SolveAndClaim()` with hashcash challenge solving
+- **`SignHostContext()` — HMAC-signed user-state assertions** (load-bearing in the faucet's abuse pipeline)
+- **`SolveAndClaim()` — automatic hashcash challenge round-trip** (works whether or not the server requires PoW)
 - `WaitForConfirmation()` polling
 - A backend proxy pattern where your server claims on behalf of users
 
 ## Endpoints
 
-| Method | Path       | Description                              |
-|--------|------------|------------------------------------------|
-| GET    | /healthz   | Health check                             |
-| GET    | /config    | Fetch and return faucet config           |
-| POST   | /claim     | `{"address":"NQ..."}` — claim and wait   |
+| Method | Path       | Body                                         | Description |
+|--------|------------|----------------------------------------------|-------------|
+| GET    | /healthz   | —                                            | Health check |
+| GET    | /config    | —                                            | Fetch and return faucet config |
+| POST   | /claim     | `{"address":"NQ...","userId":"u-1","kyc":"email"}` | Sign hostContext + solve hashcash + claim |
+
+`userId` and `kyc` are optional. With `FAUCET_HMAC_SECRET` set, the server signs the resulting hostContext so the faucet trusts the asserted user-state fields.
+
+## Configuration
+
+| Env var                  | Required | Default                   | Notes |
+|--------------------------|----------|---------------------------|-------|
+| `FAUCET_URL`             | no       | `http://localhost:8080`   | Faucet base URL |
+| `FAUCET_INTEGRATOR_ID`   | no       | `go-backend-example`      | Identifier embedded in `hostContext.uid` and HMAC signature prefix |
+| `FAUCET_HMAC_SECRET`     | **prod** | unset                     | Server-only HMAC secret. With it set, claims carry signed `hostContext`. Without it the demo still works (uid is sent unsigned) but asserted fields are not load-bearing. |
+
+Copy [`.env.example`](./.env.example) to `.env` and adjust.
 
 ## Run locally
 
 ```bash
 cd examples/go-backend-integration
-FAUCET_URL=http://localhost:8080 go run .
+cp .env.example .env  # edit FAUCET_HMAC_SECRET
+FAUCET_URL=http://localhost:8080 \
+  FAUCET_HMAC_SECRET="$(openssl rand -hex 32)" \
+  go run .
+
 # In another terminal:
-curl -X POST http://localhost:8081/claim -d '{"address":"NQ00 0000 0000 0000 0000 0000 0000 0000 0000"}'
+curl -X POST http://localhost:8081/claim \
+  -H 'content-type: application/json' \
+  -d '{"address":"NQ00 0000 0000 0000 0000 0000 0000 0000 0000","userId":"alice","kyc":"email"}'
 ```
 
 ## Run with Docker
@@ -32,7 +51,18 @@ curl -X POST http://localhost:8081/claim -d '{"address":"NQ00 0000 0000 0000 000
 ```bash
 # From repo root
 docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.yml up --build example-go
-# Test:
 curl http://localhost:3005/config
 curl -X POST http://localhost:3005/claim -d '{"address":"NQ00 0000 0000 0000 0000 0000 0000 0000 0000"}'
 ```
+
+## Abuse layers
+
+| Layer | How this example demonstrates it |
+|-------|----------------------------------|
+| **Hashcash** | `SolveAndClaim()` calls `Config()` → `RequestChallenge()` → solves the SHA-256 PoW → posts the solution. If the server has no hashcash configured, this is identical to a plain `Claim()`. |
+| **`hostContext` (HMAC-signed)** | `SignHostContext(ctx, integratorID, hmacSecret)` — the faucet verifies the HMAC and treats `uid`, `kycLevel`, `accountAgeDays`, `tags` as load-bearing. **Without a signature, asserted fields are ignored.** |
+| **Captcha (Turnstile/hCaptcha)** | Not applicable to a backend proxy — captcha tokens come from the *user's* browser and would be forwarded by the frontend. The proxy passes whatever `captchaToken` the frontend supplied. |
+| **Fingerprint** | Same — fingerprints come from the user's device; the proxy forwards `fingerprint` as supplied. |
+| **GeoIP / On-chain / AI** | Server-side only — invisible to the integrator. |
+
+Server-side details: [`docs/abuse-prevention.md`](../../docs/abuse-prevention.md) and [`packages/abuse-hostcontext/README.md`](../../packages/abuse-hostcontext/README.md).

--- a/examples/go-backend-integration/main.go
+++ b/examples/go-backend-integration/main.go
@@ -1,5 +1,12 @@
-// Minimal Go backend that proxies faucet claims.
+// Minimal Go backend that proxies faucet claims with full abuse-layer
+// integration: hashcash via SolveAndClaim and HMAC-signed hostContext.
+//
 // Exposes GET /healthz, GET /config, and POST /claim on :8081.
+//
+// In production, the integrator's user-state fields (uid, accountAgeDays,
+// kycLevel, tags) are signed with FAUCET_HMAC_SECRET so the faucet can
+// trust them in its abuse pipeline. Without a signature the asserted
+// fields are ignored.
 package main
 
 import (
@@ -15,10 +22,12 @@ import (
 )
 
 func main() {
-	url := os.Getenv("FAUCET_URL")
-	if url == "" {
-		url = "http://localhost:8080"
-	}
+	url := envOr("FAUCET_URL", "http://localhost:8080")
+	integratorID := envOr("FAUCET_INTEGRATOR_ID", "go-backend-example")
+	// HMAC secret is OPTIONAL — without it the example sends an unsigned
+	// uid (still useful, but the asserted fields don't carry weight in
+	// the faucet's abuse score). Set it in production.
+	hmacSecret := os.Getenv("FAUCET_HMAC_SECRET")
 
 	client := faucet.New(faucet.Config{URL: url})
 	mux := http.NewServeMux()
@@ -35,26 +44,52 @@ func main() {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(cfg)
+		_ = json.NewEncoder(w).Encode(cfg)
 	})
 
 	mux.HandleFunc("POST /claim", func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			Address string `json:"address"`
+			UserID  string `json:"userId"`
+			KYC     string `json:"kyc"` // "none" | "email" | "phone" | "id"
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Address == "" {
 			http.Error(w, `{"error":"address is required"}`, http.StatusBadRequest)
 			return
 		}
 
-		uid := "go-backend-example"
+		// Build a host context. In a real integrator's backend, these
+		// fields come from your authenticated user record — they are
+		// values you VOUCH for to the faucet. The HMAC binds them to
+		// you so the faucet can apply the asserted-trust bonus.
+		uid := userIDOr(body.UserID, integratorID)
+		hc := faucet.HostContext{UID: &uid}
+		if body.KYC != "" {
+			hc.KYCLevel = &body.KYC
+		}
+		// Sign hostContext if a secret is configured. Production
+		// deployments should require this; the demo allows unsigned for
+		// quick start (the faucet still accepts the claim, but the
+		// hostContext fields aren't load-bearing without a signature).
+		if hmacSecret != "" {
+			signed, err := faucet.SignHostContext(hc, integratorID, hmacSecret)
+			if err != nil {
+				http.Error(w, fmt.Sprintf(`{"error":"sign hostContext: %s"}`, err.Error()), http.StatusInternalServerError)
+				return
+			}
+			hc = signed
+		}
+
+		// SolveAndClaim handles the hashcash round-trip if the server
+		// requires it (Config().Hashcash != nil). On servers without
+		// hashcash configured this falls through to a plain Claim.
 		resp, err := client.SolveAndClaim(r.Context(), body.Address, faucet.ClaimOptions{
-			HostContext: &faucet.HostContext{UID: &uid},
+			HostContext: &hc,
 		})
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
-			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return
 		}
 
@@ -65,7 +100,7 @@ func main() {
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusGatewayTimeout)
-			json.NewEncoder(w).Encode(map[string]string{
+			_ = json.NewEncoder(w).Encode(map[string]string{
 				"error":   err.Error(),
 				"claimId": resp.ID,
 				"status":  resp.Status,
@@ -74,12 +109,26 @@ func main() {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(confirmed)
+		_ = json.NewEncoder(w).Encode(confirmed)
 	})
 
 	addr := ":8081"
-	log.Printf("go-backend-integration listening on %s (faucet: %s)", addr, url)
+	log.Printf("go-backend-integration listening on %s (faucet: %s, signed-hostContext: %t)", addr, url, hmacSecret != "")
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func userIDOr(userID, fallback string) string {
+	if userID != "" {
+		return userID
+	}
+	return fallback
 }

--- a/examples/nextjs-claim-page/.env.example
+++ b/examples/nextjs-claim-page/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env.local` and adjust as needed.
+# Next.js exposes only `NEXT_PUBLIC_*` vars to the browser bundle.
+#
+# The faucet URL the browser hits. Must be reachable from where you load
+# the page (CORS-allowed by the faucet's FAUCET_CORS_ORIGINS env var).
+NEXT_PUBLIC_FAUCET_URL=http://localhost:8080
+
+# Identifier emitted in hostContext.uid. In production a backend signs
+# the hostContext (FaucetClient.signHostContext + integrator HMAC secret);
+# the demo passes a plain uid for simplicity. See README §"Abuse layers".
+NEXT_PUBLIC_INTEGRATOR_ID=nextjs-example

--- a/examples/nextjs-claim-page/README.md
+++ b/examples/nextjs-claim-page/README.md
@@ -1,21 +1,28 @@
 # Next.js Claim Page Example
 
-Minimal Next.js 14 app demonstrating `@nimiq-faucet/react` integration.
+Next.js 16 (App Router) app demonstrating `@nimiq-faucet/react` integration **with full abuse-layer support**: captcha widget, hashcash proof-of-work, and signed `hostContext`. Mirror of [`../vue-claim-page/`](../vue-claim-page/).
 
 ## What this demonstrates
 
 - `FaucetClient` instantiation from `@nimiq-faucet/react`
-- `useFaucetClaim` hook for claim lifecycle management
-- Address input, claim submission, and live status updates
-- Error handling with retry
+- `/v1/config` discovery — the page renders the captcha widget the server is configured for, and runs hashcash if the server requires it
+- Cloudflare Turnstile + hCaptcha widget integration (script loaded conditionally)
+- Hashcash via `client.solveAndClaim()` with progress reporting
+- `hostContext` shape (uid + the docs path for HMAC-signed contexts)
+- Address input, claim submission, live status updates, error handling with retry
 
 ## Run locally
 
 ```bash
 # From repo root
 pnpm install
-NEXT_PUBLIC_FAUCET_URL=http://localhost:8080 pnpm --filter @nimiq-faucet/example-nextjs dev
+cp examples/nextjs-claim-page/.env.example examples/nextjs-claim-page/.env.local
+# edit .env.local if your faucet isn't on http://localhost:8080
+pnpm --filter @nimiq-faucet/example-nextjs dev
+# Open http://localhost:3001
 ```
+
+The faucet itself (compose stack, `local-node` profile) is described in [`deploy/compose/README.md`](../../deploy/compose/README.md).
 
 ## Run with Docker
 
@@ -25,14 +32,57 @@ docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.y
 # Open http://localhost:3001
 ```
 
+## Abuse layers
+
+Which layers actually run is decided by the faucet operator, not the page. The page reads `/v1/config` on mount and renders only the surfaces the server requires:
+
+| Layer | Server enables via | Page shows |
+|-------|-------------------|------------|
+| **Cloudflare Turnstile** | `FAUCET_TURNSTILE_SITE_KEY` + `FAUCET_TURNSTILE_SECRET` | Cloudflare widget; token sent on `claim` as `captchaToken` |
+| **hCaptcha** | `FAUCET_HCAPTCHA_SITE_KEY` + `FAUCET_HCAPTCHA_SECRET` | hCaptcha widget; token sent on `claim` as `captchaToken` |
+| **Hashcash** | `FAUCET_HASHCASH_SECRET` (+ `FAUCET_HASHCASH_DIFFICULTY`) | "Proof-of-work: N attempts" progress text; `client.solveAndClaim()` does the round-trip |
+| **`hostContext`** | always accepted (no env required) | uid demonstrated; signed-context pattern shown in code comments |
+| **GeoIP / Fingerprint / On-chain / AI** | server-side only | invisible — no page changes needed |
+
+Server-side details: [`docs/abuse-prevention.md`](../../docs/abuse-prevention.md) and the per-layer READMEs under [`packages/abuse-*`](../../packages/).
+
+### Captcha provider
+
+The page renders **either** Turnstile **or** hCaptcha — whichever the server returns from `/v1/config.captcha.provider`. Don't enable both server-side; the faucet picks one.
+
+### Hashcash difficulty
+
+`config.hashcash.difficulty` is read from `/v1/config`; the page surfaces it ("Hashcash difficulty 18 bits — solved in your browser"). 16 bits ≈ 65k hashes (~0.1s on a laptop), 20 bits ≈ 1M hashes (~1s), 24 bits ≈ 16M hashes (~15s). Tune for your bot/human ratio.
+
+### `hostContext` signing — production deployments
+
+The example sends a plain `{ uid: 'nextjs-example' }`. **In production**, every claim should carry a backend-signed hostContext so the faucet can trust the user-state fields (account age, KYC level, tags) you assert. With Next.js you can sign in a route handler and pass the result to the client component:
+
+```ts
+// app/api/host-context/route.ts (server-only)
+import { FaucetClient } from '@nimiq-faucet/sdk';
+
+export async function GET() {
+  const signed = FaucetClient.signHostContext(
+    { uid: 'user-123', accountAgeDays: 90, kycLevel: 'verified' },
+    process.env.INTEGRATOR_ID!,
+    process.env.FAUCET_HMAC_SECRET!,
+  );
+  return Response.json(signed);
+}
+```
+
+The client component fetches `/api/host-context` and passes the result to `client.claim({ hostContext })`. The faucet verifies the HMAC and treats the asserted fields as load-bearing in the abuse pipeline. Without a signature, asserted fields are ignored. See [`packages/abuse-hostcontext/README.md`](../../packages/abuse-hostcontext/README.md).
+
 ## Project structure
 
 ```
 nextjs-claim-page/
   app/
     layout.tsx     — root layout
-    page.tsx       — claim UI (client component)
+    page.tsx       — claim UI + abuse-layer orchestration (client component)
     globals.css    — styles
+  .env.example     — copy to .env.local
   package.json
   next.config.mjs
   tsconfig.json

--- a/examples/nextjs-claim-page/app/globals.css
+++ b/examples/nextjs-claim-page/app/globals.css
@@ -52,6 +52,21 @@ button {
 button:disabled { opacity: 0.5; cursor: not-allowed; }
 button:not(:disabled):hover { opacity: 0.85; }
 
+.captcha-block {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #f0f1f9;
+  border-radius: 8px;
+}
+.captcha-label { font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem; }
+
+.hashcash-note {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: -0.25rem;
+  font-style: italic;
+}
+
 .status {
   margin-top: 1.5rem;
   padding: 1rem;
@@ -60,6 +75,7 @@ button:not(:disabled):hover { opacity: 0.85; }
 }
 .status.confirmed { background: #d1fae5; color: #065f46; }
 .status.rejected { background: #fee2e2; color: #991b1b; }
+.status.solving-hashcash { background: #fef3c7; color: #78350f; }
 
 .tx { margin-top: 0.5rem; font-size: 0.8rem; word-break: break-all; }
 

--- a/examples/nextjs-claim-page/app/page.tsx
+++ b/examples/nextjs-claim-page/app/page.tsx
@@ -1,73 +1,239 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import { FaucetClient, useFaucetClaim } from '@nimiq-faucet/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FaucetClient, type ClaimResponse } from '@nimiq-faucet/react';
+import type { FaucetConfig } from '@nimiq-faucet/sdk';
+
+/**
+ * §3.0.7 abuse-layer demo — Next.js (App Router).
+ *
+ * Demonstrates the four abuse-layer surfaces the faucet supports:
+ *   1. Captcha widget (Turnstile or hCaptcha) — driven by `/v1/config`.
+ *   2. Hashcash proof-of-work — `client.solveAndClaim()` does the round trip.
+ *   3. `hostContext` — passed on every claim. Production frontends should
+ *      send a *signed* hostContext minted by their backend (see README §
+ *      "Abuse layers" — `FaucetClient.signHostContext` is the helper).
+ *   4. Fingerprint — out of scope here; see the Capacitor/RN examples.
+ *
+ * `useFaucetClaim` from `@nimiq-faucet/react` is the simpler shape for
+ * uid-only flows; we bypass it here so we can interleave the captcha +
+ * hashcash steps before calling `client.claim`. The hook's source
+ * (packages/sdk-react/src/index.ts) is a 30-line wrapper over `client.claim`,
+ * so this manual path stays close in spirit and easy to compare.
+ */
 
 const faucetUrl = process.env.NEXT_PUBLIC_FAUCET_URL || 'http://localhost:8080';
+const integratorId = process.env.NEXT_PUBLIC_INTEGRATOR_ID || 'nextjs-example';
 
-function statusLabel(status: string): string {
-  switch (status) {
-    case 'idle': return '';
-    case 'pending': return 'Submitting claim...';
-    case 'queued': return 'Queued — waiting for broadcast...';
-    case 'broadcast': return 'Broadcast — waiting for confirmation...';
+type Phase = 'idle' | 'loading-config' | 'awaiting-captcha' | 'solving-hashcash' | 'submitting' | 'broadcast' | 'confirmed' | 'rejected' | 'error';
+
+function phaseLabel(phase: Phase, attempts: number): string {
+  switch (phase) {
+    case 'loading-config': return 'Reading server config…';
+    case 'solving-hashcash': return `Proof-of-work: ${attempts.toLocaleString()} attempts…`;
+    case 'submitting': return 'Submitting claim…';
+    case 'broadcast': return 'Broadcast — waiting for confirmation…';
     case 'confirmed': return 'Confirmed!';
     case 'rejected': return 'Rejected';
-    case 'challenged': return 'Challenge required';
-    default: return status;
+    case 'error': return 'Something went wrong.';
+    default: return '';
   }
 }
 
 export default function Home() {
   const client = useMemo(() => new FaucetClient({ url: faucetUrl }), []);
+
+  const [phase, setPhase] = useState<Phase>('loading-config');
   const [address, setAddress] = useState('');
+  const [config, setConfig] = useState<FaucetConfig | null>(null);
+  const [hashcashAttempts, setHashcashAttempts] = useState(0);
+  const [txId, setTxId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const captchaToken = useRef<string | null>(null);
+  const captchaRendered = useRef(false);
 
-  const { claim, reset, status, txId, error } = useFaucetClaim({
-    client,
-    address,
-    hostContext: { uid: 'nextjs-example' },
-  });
+  const isPending = ['loading-config', 'solving-hashcash', 'submitting', 'broadcast'].includes(phase);
+  const captchaRequired = Boolean(config?.captcha);
+  const captchaSatisfied = !captchaRequired || captchaToken.current !== null;
+  const canSubmit = !isPending && address.trim().length > 0 && captchaSatisfied;
 
-  const pending = status === 'pending';
-  const label = statusLabel(status);
+  // Load `/v1/config` + captcha widget once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cfg = await client.config();
+        if (cancelled) return;
+        setConfig(cfg);
+        setPhase(cfg.captcha ? 'awaiting-captcha' : 'idle');
+        if (cfg.captcha && !captchaRendered.current) {
+          await loadCaptchaWidget(cfg, () => {
+            // No-op on success: token is captured via window callback below.
+          });
+          captchaRendered.current = true;
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setPhase('error');
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [client]);
+
+  async function loadCaptchaWidget(cfg: FaucetConfig, onLoaded: () => void) {
+    if (!cfg.captcha) return;
+    const provider = cfg.captcha.provider;
+    if (provider === 'fcaptcha') {
+      // FCaptcha is the WebView/mini-app path; the standalone web example
+      // doesn't render its widget — see examples/mini-app-claim-* for that.
+      setErrorMessage('This example renders Turnstile/hCaptcha; the faucet returned fcaptcha. See examples/mini-app-claim-* instead.');
+      return;
+    }
+    const src = provider === 'turnstile'
+      ? 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+      : 'https://js.hcaptcha.com/1/api.js?render=explicit';
+    await injectScript(src, `data-${provider}`);
+    onLoaded();
+    type CaptchaLib = { render: (el: HTMLElement, o: Record<string, unknown>) => unknown };
+    const w = window as Window & { turnstile?: CaptchaLib; hcaptcha?: CaptchaLib };
+    const lib = provider === 'turnstile' ? w.turnstile : w.hcaptcha;
+    const host = document.getElementById('captcha-host');
+    if (!lib || !host) return;
+    lib.render(host, {
+      sitekey: cfg.captcha.siteKey,
+      callback: (token: string) => { captchaToken.current = token; },
+      'error-callback': () => { captchaToken.current = null; setErrorMessage('Captcha widget reported an error'); },
+      'expired-callback': () => { captchaToken.current = null; },
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setErrorMessage(null);
+    setTxId(null);
+
+    // hostContext: production frontends should send a SIGNED context minted
+    // by their backend (FaucetClient.signHostContext + integrator HMAC secret).
+    // The example sends a plain uid to keep the demo runnable without a backend.
+    const hostContext = { uid: integratorId };
+
+    try {
+      let result: ClaimResponse;
+      if (config?.hashcash) {
+        setPhase('solving-hashcash');
+        setHashcashAttempts(0);
+        result = await client.solveAndClaim(address.trim(), {
+          uid: integratorId,
+          hostContext,
+          captchaToken: captchaToken.current ?? undefined,
+          onProgress: (n) => setHashcashAttempts(n),
+        });
+      } else {
+        setPhase('submitting');
+        result = await client.claim(address.trim(), {
+          hostContext,
+          captchaToken: captchaToken.current ?? undefined,
+        });
+      }
+      setPhase('submitting');
+      setTxId(result.txId ?? null);
+      if (result.status === 'rejected') {
+        setPhase('rejected');
+        setErrorMessage(result.reason ?? 'Claim rejected');
+        return;
+      }
+      if (result.status === 'challenged') {
+        setPhase('rejected');
+        setErrorMessage(result.reason ?? 'Captcha challenge required');
+        return;
+      }
+      setPhase('broadcast');
+      const final = await client.waitForConfirmation(result.id);
+      setTxId((prev) => final.txId ?? prev);
+      setPhase(final.status === 'confirmed' ? 'confirmed' : 'rejected');
+      if (final.status === 'rejected' && final.reason) setErrorMessage(final.reason);
+    } catch (err) {
+      setPhase('error');
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  function handleReset() {
+    setPhase(config?.captcha ? 'awaiting-captcha' : 'idle');
+    setTxId(null);
+    setErrorMessage(null);
+    setHashcashAttempts(0);
+    captchaToken.current = null;
+  }
+
+  const label = phaseLabel(phase, hashcashAttempts);
 
   return (
     <main className="container">
       <h1>Nimiq Faucet</h1>
-      <p className="subtitle">Claim free NIM on testnet</p>
+      <p className="subtitle">Claim free NIM on testnet (with abuse-layer demo)</p>
 
-      <form
-        className="claim-form"
-        onSubmit={(e) => { e.preventDefault(); if (address.trim()) claim(); }}
-      >
+      <form className="claim-form" onSubmit={handleSubmit}>
         <label htmlFor="address">Nimiq Address</label>
         <input
           id="address"
           value={address}
           onChange={(e) => setAddress(e.target.value)}
           placeholder="NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
-          disabled={pending}
+          disabled={isPending}
           autoComplete="off"
           spellCheck={false}
         />
-        <button type="submit" disabled={pending || !address.trim()}>
-          {pending ? 'Claiming...' : 'Claim NIM'}
+
+        {config?.captcha && config.captcha.provider !== 'fcaptcha' && (
+          <div className="captcha-block">
+            <p className="captcha-label">{config.captcha.provider === 'turnstile' ? 'Cloudflare Turnstile' : 'hCaptcha'}</p>
+            <div id="captcha-host" />
+          </div>
+        )}
+
+        {config?.hashcash && (
+          <p className="hashcash-note">
+            Hashcash difficulty {config.hashcash.difficulty} bits — solved in your browser.
+          </p>
+        )}
+
+        <button type="submit" disabled={!canSubmit}>
+          {isPending ? 'Claiming…' : 'Claim NIM'}
         </button>
       </form>
 
       {label && (
-        <div className={`status ${status}`}>
+        <div className={`status ${phase}`}>
           <p>{label}</p>
           {txId && <p className="tx">TX: <code>{txId}</code></p>}
         </div>
       )}
 
-      {error && (
+      {errorMessage && (
         <div className="error">
-          <p>{error.message}</p>
-          <button className="retry" onClick={reset}>Try again</button>
+          <p>{errorMessage}</p>
+          <button className="retry" onClick={handleReset}>Try again</button>
         </div>
       )}
     </main>
   );
+}
+
+function injectScript(src: string, marker: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[${marker}]`);
+    if (existing) { resolve(); return; }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.defer = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute(marker, 'true');
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+    document.head.appendChild(script);
+  });
 }

--- a/examples/nextjs-claim-page/package.json
+++ b/examples/nextjs-claim-page/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@nimiq-faucet/react": "workspace:*",
+    "@nimiq-faucet/sdk": "workspace:*",
     "next": "^16.2.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/python-backend-integration/.env.example
+++ b/examples/python-backend-integration/.env.example
@@ -1,0 +1,20 @@
+# Copy to `.env` and adjust as needed.
+
+# The faucet URL the proxy hits (server-to-server, doesn't need to be
+# browser-reachable; can be a private DNS name in production).
+FAUCET_URL=http://localhost:8080
+
+# Identifier embedded in hostContext.uid AND in the HMAC signature prefix
+# (`<integratorId>:<base64-hmac>`). Pick a stable string per integrator.
+FAUCET_INTEGRATOR_ID=python-backend-example
+
+# Server-only HMAC secret. With this set, the proxy signs hostContext on
+# every claim so the faucet treats the asserted fields as load-bearing.
+# Generate once with:
+#   openssl rand -hex 32
+# Without this var, the proxy still works but asserted fields are ignored.
+# FAUCET_HMAC_SECRET=
+
+# Optional: integrator API key for whole-request HMAC (separate from
+# hostContext signing — used for S2S auth on faucets behind FAUCET_REQUIRE_API_KEY).
+# FAUCET_API_KEY=

--- a/examples/python-backend-integration/README.md
+++ b/examples/python-backend-integration/README.md
@@ -1,17 +1,93 @@
-# Python backend integration example
+# Python Backend Integration Example
 
-Minimal example showing how to use the `nimiq-faucet` Python SDK from a backend service.
+Python backend example showing the `nimiq-faucet` Python SDK with **full abuse-layer support**: HMAC-signed `hostContext` and automatic hashcash via `solve_and_claim()`.
+
+## What this demonstrates
+
+- `FaucetClient` instantiation
+- `solve_and_claim(...)` — automatic hashcash challenge round-trip
+- `FaucetClient.sign_host_context(...)` — HMAC-signed user-state assertions
+- Backend pattern: authenticate the user → vouch for their state → faucet trusts asserted fields
+- `wait_for_confirmation()` polling
+
+## Configuration
+
+| Env var                  | Required | Default                           | Notes |
+|--------------------------|----------|-----------------------------------|-------|
+| `FAUCET_URL`             | no       | `http://localhost:8080`           | Faucet base URL (S2S, doesn't need to be browser-reachable) |
+| `FAUCET_INTEGRATOR_ID`   | no       | `python-backend-example`          | Identifier embedded in `hostContext.uid` and HMAC signature prefix |
+| `FAUCET_HMAC_SECRET`     | **prod** | unset                             | Server-only HMAC secret. With it set, claims carry signed `hostContext`. Without it the demo still works (uid is sent unsigned) but asserted fields are not load-bearing. Generate: `openssl rand -hex 32`. |
+| `FAUCET_API_KEY`         | no       | unset                             | Optional whole-request HMAC for S2S auth (separate from hostContext signing) |
+
+Copy [`.env.example`](./.env.example) to `.env` and adjust.
 
 ## Run locally
 
 ```bash
 pip install nimiq-faucet
-FAUCET_URL=http://localhost:8080 python app.py
+cp examples/python-backend-integration/.env.example examples/python-backend-integration/.env
+# edit .env to set FAUCET_HMAC_SECRET
+export $(grep -v '^#' examples/python-backend-integration/.env | xargs)
+python examples/python-backend-integration/app.py
 ```
 
 ## With Docker
 
 ```bash
-docker build -t python-faucet-example .
-docker run --rm -e FAUCET_URL=http://host.docker.internal:8080 python-faucet-example
+docker build -t python-faucet-example examples/python-backend-integration
+docker run --rm \
+  -e FAUCET_URL=http://host.docker.internal:8080 \
+  -e FAUCET_HMAC_SECRET="$(openssl rand -hex 32)" \
+  python-faucet-example
 ```
+
+## Use from Flask / FastAPI / Django
+
+The example exposes a single function `handle_claim(address, user_id=..., kyc_level=..., account_age_days=..., tags=...)`. Drop it behind any framework:
+
+```python
+# FastAPI
+from fastapi import FastAPI
+from app import handle_claim
+
+api = FastAPI()
+
+@api.post("/claim")
+def claim(req: ClaimRequest, user = Depends(authenticated_user)):
+    return handle_claim(
+        req.address,
+        user_id=user.id,
+        kyc_level=user.kyc_level,
+        account_age_days=user.account_age_days,
+        tags=user.feature_tags,
+    )
+```
+
+```python
+# Flask
+from flask import Flask, request, jsonify
+from app import handle_claim
+
+app = Flask(__name__)
+
+@app.post("/claim")
+def claim():
+    user = require_auth(request)
+    return jsonify(handle_claim(
+        request.json["address"],
+        user_id=user.id,
+        kyc_level=user.kyc_level,
+    ))
+```
+
+## Abuse layers
+
+| Layer | How this example demonstrates it |
+|-------|----------------------------------|
+| **Hashcash** | `solve_and_claim()` calls `request_challenge()` → `solve_hashcash()` → `claim()` with the solution. On servers without hashcash configured, this is identical to a plain `claim()`. |
+| **`hostContext` (HMAC-signed)** | `FaucetClient.sign_host_context(ctx, integrator_id, hmac_secret)` — the faucet verifies the HMAC and treats `uid`, `kyc_level`, `account_age_days`, `tags` as load-bearing. **Without a signature, asserted fields are ignored.** |
+| **Captcha (Turnstile/hCaptcha)** | Not applicable to a backend — captcha tokens come from the *user's* browser. The backend forwards `captcha_token` if the frontend supplied one. |
+| **Fingerprint** | Same — fingerprints come from the user's device; the backend forwards `fingerprint` as supplied. |
+| **GeoIP / On-chain / AI** | Server-side only — invisible to the integrator. |
+
+Server-side details: [`docs/abuse-prevention.md`](../../docs/abuse-prevention.md) and [`packages/abuse-hostcontext/README.md`](../../packages/abuse-hostcontext/README.md).

--- a/examples/python-backend-integration/app.py
+++ b/examples/python-backend-integration/app.py
@@ -1,45 +1,106 @@
-"""Minimal Flask/FastAPI example — Nimiq Faucet Python SDK."""
+"""Nimiq Faucet Python backend integration — full abuse-layer demo.
 
+Demonstrates HMAC-signed hostContext + automatic hashcash via
+`solve_and_claim()`. Drop into any Flask/FastAPI/Django route handler;
+the abuse-layer plumbing is identical regardless of the framework.
+"""
+
+import logging
 import os
-from nimiq_faucet import FaucetClient, ClaimOptions, HostContext, FaucetError
+
+from nimiq_faucet import (
+    ClaimOptions,
+    FaucetClient,
+    FaucetError,
+    HostContext,
+)
 
 FAUCET_URL = os.environ.get("FAUCET_URL", "http://localhost:8080")
-API_KEY = os.environ.get("FAUCET_API_KEY")
+INTEGRATOR_ID = os.environ.get("FAUCET_INTEGRATOR_ID", "python-backend-example")
+# HMAC secret is OPTIONAL — without it the example sends an unsigned uid
+# (still useful for traffic shaping, but the asserted fields don't carry
+# weight in the faucet's abuse score). Set it in production.
 HMAC_SECRET = os.environ.get("FAUCET_HMAC_SECRET")
+# Optional: integrator API key for whole-request HMAC (S2S auth, not
+# hostContext signing). Independent of FAUCET_HMAC_SECRET below.
+API_KEY = os.environ.get("FAUCET_API_KEY")
 
-client = FaucetClient(FAUCET_URL, api_key=API_KEY, hmac_secret=HMAC_SECRET)
+client = FaucetClient(FAUCET_URL, api_key=API_KEY, hmac_secret=HMAC_SECRET if API_KEY else None)
+
+logger = logging.getLogger(__name__)
 
 
-def handle_claim(address: str, user_id: str | None = None) -> dict:
+def handle_claim(
+    address: str,
+    *,
+    user_id: str | None = None,
+    kyc_level: str | None = None,
+    account_age_days: int | None = None,
+    tags: list[str] | None = None,
+) -> dict:
     """Process a faucet claim on behalf of a user.
 
-    In production, call this from your Flask/FastAPI route handler after
-    authenticating the user. The host context (user ID, KYC level, etc.)
-    feeds into the faucet's abuse scoring — signed contexts receive a
-    trust bonus.
+    In production, call this from your route handler AFTER authenticating
+    the user. The host-context fields below are values you VOUCH for to
+    the faucet — your auth system has already verified them. Signing the
+    context with FAUCET_HMAC_SECRET binds them to your integrator
+    identity so the faucet can treat them as load-bearing.
     """
     options = ClaimOptions()
 
-    if user_id and HMAC_SECRET:
-        ctx = HostContext(uid=user_id, kyc_level="email")
-        # Sign the context so the faucet trusts it without whole-request HMAC
+    # Build a hostContext from your authenticated user's state. Only
+    # fill in fields you can actually attest to — empty fields don't
+    # earn trust bonuses.
+    ctx = HostContext(
+        uid=user_id or INTEGRATOR_ID,
+        kyc_level=kyc_level,
+        account_age_days=account_age_days,
+        tags=tags,
+    )
+
+    # Sign hostContext if a secret is configured. Without it the faucet
+    # IGNORES the asserted fields (the claim still works — it just falls
+    # back to default abuse scoring on the unsigned-context path).
+    if HMAC_SECRET:
         options.host_context = FaucetClient.sign_host_context(
-            ctx, API_KEY or "default", HMAC_SECRET
+            ctx, INTEGRATOR_ID, HMAC_SECRET,
         )
+    else:
+        options.host_context = ctx
 
     try:
-        response = client.claim(address, options)
-        confirmed = client.wait_for_confirmation(response.id, timeout_s=30)
+        # solve_and_claim handles the hashcash round-trip when the
+        # server requires it; on servers without hashcash configured
+        # this falls through to a plain claim().
+        attempts = 0
+
+        def on_progress(n: int) -> None:
+            nonlocal attempts
+            attempts = n
+
+        response = client.solve_and_claim(address, options, on_progress=on_progress)
+        if attempts:
+            logger.info("hashcash solved in %d attempts", attempts)
+        confirmed = client.wait_for_confirmation(response.id, timeout_s=60)
         return {
             "id": confirmed.id,
             "status": confirmed.status,
             "tx_id": confirmed.tx_id,
+            "signed_hostcontext": HMAC_SECRET is not None,
         }
     except FaucetError as e:
         return {"error": e.message, "status": e.status}
 
 
 if __name__ == "__main__":
-    # Quick test: claim to a testnet address
-    result = handle_claim("NQ02 STQX XESU 2E4S N9X7 GEXD 0VGL Y8PT BQ05")
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    # Quick test: claim to a testnet address. In a real backend this
+    # would come from the authenticated user's request body.
+    result = handle_claim(
+        "NQ02 STQX XESU 2E4S N9X7 GEXD 0VGL Y8PT BQ05",
+        user_id="alice",
+        kyc_level="email",
+        account_age_days=180,
+        tags=["beta-tester"],
+    )
     print(result)

--- a/examples/vue-claim-page/.env.example
+++ b/examples/vue-claim-page/.env.example
@@ -1,0 +1,10 @@
+# Copy to `.env` and adjust as needed.
+#
+# The faucet URL the browser hits. Must be reachable from where you load
+# the page (CORS-allowed by the faucet's FAUCET_CORS_ORIGINS env var).
+VITE_FAUCET_URL=http://localhost:8080
+
+# Identifier emitted in hostContext.uid. In production a backend signs
+# the hostContext (FaucetClient.signHostContext + integrator HMAC secret);
+# the demo passes a plain uid for simplicity. See README §"Abuse layers".
+VITE_INTEGRATOR_ID=vue-example

--- a/examples/vue-claim-page/README.md
+++ b/examples/vue-claim-page/README.md
@@ -1,21 +1,27 @@
 # Vue Claim Page Example
 
-Minimal Vue 3 + Vite app demonstrating `@nimiq-faucet/vue` integration.
+Vue 3 + Vite app demonstrating `@nimiq-faucet/vue` integration **with full abuse-layer support**: captcha widget, hashcash proof-of-work, and signed `hostContext`.
 
 ## What this demonstrates
 
 - `FaucetClient` instantiation from `@nimiq-faucet/vue`
-- `useFaucetClaim` composable for reactive claim state
-- Address input, claim submission, and live status updates
-- Error handling with retry
+- `/v1/config` discovery — the page renders the captcha widget the server is configured for, and runs hashcash if the server requires it
+- Cloudflare Turnstile + hCaptcha widget integration (script loaded conditionally)
+- Hashcash via `client.solveAndClaim()` with progress reporting
+- `hostContext` shape (uid + the docs path for HMAC-signed contexts)
+- Address input, claim submission, live status updates, error handling with retry
 
 ## Run locally
 
 ```bash
 # From repo root
 pnpm install
-VITE_FAUCET_URL=http://localhost:8080 pnpm --filter @nimiq-faucet/example-vue dev
+cp examples/vue-claim-page/.env.example examples/vue-claim-page/.env
+# edit .env if your faucet isn't on http://localhost:8080
+pnpm --filter @nimiq-faucet/example-vue dev
 ```
+
+The faucet itself (compose stack, `local-node` profile) is described in [`deploy/compose/README.md`](../../deploy/compose/README.md).
 
 ## Run with Docker
 
@@ -25,15 +31,56 @@ docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.y
 # Open http://localhost:3002
 ```
 
+## Abuse layers
+
+Which layers actually run is decided by the faucet operator, not the page. The page reads `/v1/config` on mount and renders only the surfaces the server requires:
+
+| Layer | Server enables via | Page shows |
+|-------|-------------------|------------|
+| **Cloudflare Turnstile** | `FAUCET_TURNSTILE_SITE_KEY` + `FAUCET_TURNSTILE_SECRET` | Cloudflare widget; token sent on `claim` as `captchaToken` |
+| **hCaptcha** | `FAUCET_HCAPTCHA_SITE_KEY` + `FAUCET_HCAPTCHA_SECRET` | hCaptcha widget; token sent on `claim` as `captchaToken` |
+| **Hashcash** | `FAUCET_HASHCASH_SECRET` (+ `FAUCET_HASHCASH_DIFFICULTY`) | "Proof-of-work: N attempts" progress text; `client.solveAndClaim()` does the round-trip |
+| **`hostContext`** | always accepted (no env required) | uid demonstrated; signed-context pattern shown in code comments |
+| **GeoIP / Fingerprint / On-chain / AI** | server-side only | invisible — no page changes needed |
+
+Server-side details: [`docs/abuse-prevention.md`](../../docs/abuse-prevention.md) and the per-layer READMEs under [`packages/abuse-*`](../../packages/).
+
+### Captcha provider
+
+The page renders **either** Turnstile **or** hCaptcha — whichever the server returns from `/v1/config.captcha.provider`. Don't enable both server-side; the faucet picks one.
+
+### Hashcash difficulty
+
+`config.hashcash.difficulty` is read from `/v1/config`; the page surfaces it ("Hashcash difficulty 18 bits — solved in your browser"). 16 bits ≈ 65k hashes (~0.1s on a laptop), 20 bits ≈ 1M hashes (~1s), 24 bits ≈ 16M hashes (~15s). Tune for your bot/human ratio.
+
+### `hostContext` signing — production deployments
+
+The example sends a plain `{ uid: 'vue-example' }`. **In production**, every claim should carry a backend-signed hostContext so the faucet can trust the user-state fields (account age, KYC level, tags) you assert:
+
+```ts
+// On YOUR backend (Node.js):
+import { FaucetClient } from '@nimiq-faucet/sdk';
+
+const signed = FaucetClient.signHostContext(
+  { uid: user.id, accountAgeDays: user.ageDays, kycLevel: 'verified' },
+  process.env.INTEGRATOR_ID!,
+  process.env.FAUCET_HMAC_SECRET!, // server-only
+);
+// Send `signed` to the browser; browser passes it to client.claim().
+```
+
+The faucet verifies the HMAC and treats the asserted fields as load-bearing in the abuse pipeline. Without a signature, asserted fields are ignored. See [`packages/abuse-hostcontext/README.md`](../../packages/abuse-hostcontext/README.md).
+
 ## Project structure
 
 ```
 vue-claim-page/
   src/
-    App.vue        — claim UI component
+    App.vue        — claim UI + abuse-layer orchestration
     main.ts        — app entry
     env.d.ts       — Vite env types
   index.html       — Vite HTML entry
+  .env.example     — copy to .env
   package.json
   vite.config.ts
   tsconfig.json

--- a/examples/vue-claim-page/package.json
+++ b/examples/vue-claim-page/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@nimiq-faucet/sdk": "workspace:*",
     "@nimiq-faucet/vue": "workspace:*",
     "vue": "^3.5.33"
   },

--- a/examples/vue-claim-page/src/App.vue
+++ b/examples/vue-claim-page/src/App.vue
@@ -1,41 +1,189 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
-import { FaucetClient, useFaucetClaim } from '@nimiq-faucet/vue';
+import { computed, onMounted, ref } from 'vue';
+import { FaucetClient, type ClaimResponse } from '@nimiq-faucet/vue';
+import type { FaucetConfig } from '@nimiq-faucet/sdk';
+
+/**
+ * §3.0.7 abuse-layer demo — Vue 3.
+ *
+ * Demonstrates the four abuse-layer surfaces the faucet supports:
+ *   1. Captcha widget (Turnstile or hCaptcha) — driven by `/v1/config`.
+ *   2. Hashcash proof-of-work — `client.solveAndClaim()` does the round trip.
+ *   3. `hostContext` — passed on every claim. Production frontends should
+ *      send a *signed* hostContext minted by their backend (see README §
+ *      "Abuse layers" — `FaucetClient.signHostContext` is the helper).
+ *   4. Fingerprint — out of scope here; see the Capacitor/RN examples.
+ *
+ * `useFaucetClaim` from `@nimiq-faucet/vue` is the simpler shape for
+ * uid-only flows; we bypass it here so we can interleave the captcha +
+ * hashcash steps before calling `client.claim`. The composable's source
+ * (packages/sdk-vue/src/index.ts) is a 30-line wrapper over `client.claim`,
+ * so this manual path stays close in spirit and easy to compare.
+ */
 
 const faucetUrl = import.meta.env.VITE_FAUCET_URL || 'http://localhost:8080';
+const integratorId = import.meta.env.VITE_INTEGRATOR_ID || 'vue-example';
 const client = new FaucetClient({ url: faucetUrl });
 
-const address = ref('');
+type Phase = 'idle' | 'loading-config' | 'awaiting-captcha' | 'solving-hashcash' | 'submitting' | 'broadcast' | 'confirmed' | 'rejected' | 'error';
 
-const { claim, reset, status, txId, error, isPending } = useFaucetClaim({
-  client,
-  get address() { return address.value; },
-  hostContext: { uid: 'vue-example' },
-});
+const phase = ref<Phase>('loading-config');
+const address = ref('');
+const config = ref<FaucetConfig | null>(null);
+const captchaToken = ref<string | null>(null);
+const hashcashAttempts = ref(0);
+const txId = ref<string | null>(null);
+const errorMessage = ref<string | null>(null);
+
+const isPending = computed(() => ['loading-config', 'solving-hashcash', 'submitting', 'broadcast'].includes(phase.value));
+const captchaRequired = computed(() => Boolean(config.value?.captcha));
+const captchaSatisfied = computed(() => !captchaRequired.value || captchaToken.value !== null);
+const canSubmit = computed(() => phase.value !== 'submitting' && phase.value !== 'broadcast' && phase.value !== 'solving-hashcash' && address.value.trim().length > 0 && captchaSatisfied.value);
 
 const statusLabel = computed(() => {
-  switch (status.value) {
-    case 'idle': return '';
-    case 'pending': return 'Submitting claim...';
-    case 'queued': return 'Queued — waiting for broadcast...';
-    case 'broadcast': return 'Broadcast — waiting for confirmation...';
+  switch (phase.value) {
+    case 'loading-config': return 'Reading server config…';
+    case 'awaiting-captcha': return captchaRequired.value && !captchaToken.value ? 'Solve the captcha to continue.' : '';
+    case 'solving-hashcash': return `Proof-of-work: ${hashcashAttempts.value.toLocaleString()} attempts…`;
+    case 'submitting': return 'Submitting claim…';
+    case 'broadcast': return 'Broadcast — waiting for confirmation…';
     case 'confirmed': return 'Confirmed!';
     case 'rejected': return 'Rejected';
-    case 'challenged': return 'Challenge required';
-    default: return status.value;
+    case 'error': return 'Something went wrong.';
+    default: return '';
   }
 });
 
-function handleSubmit() {
-  if (!address.value.trim()) return;
-  claim();
+onMounted(async () => {
+  try {
+    const cfg = await client.config();
+    config.value = cfg;
+    phase.value = cfg.captcha ? 'awaiting-captcha' : 'idle';
+    if (cfg.captcha) await loadCaptchaWidget(cfg);
+  } catch (err) {
+    phase.value = 'error';
+    errorMessage.value = err instanceof Error ? err.message : String(err);
+  }
+});
+
+type CaptchaProvider = 'turnstile' | 'hcaptcha';
+
+interface CaptchaLib {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => unknown;
+}
+type CaptchaWindow = Window & { turnstile?: CaptchaLib; hcaptcha?: CaptchaLib };
+
+async function loadCaptchaWidget(cfg: FaucetConfig) {
+  if (!cfg.captcha) return;
+  const provider = cfg.captcha.provider;
+  if (provider === 'fcaptcha') {
+    // FCaptcha is the WebView/mini-app path; the standalone web example
+    // doesn't render its widget — see examples/mini-app-claim-* for that.
+    errorMessage.value = 'This example renders Turnstile/hCaptcha; the faucet returned fcaptcha. See examples/mini-app-claim-* instead.';
+    return;
+  }
+  const src = provider === 'turnstile'
+    ? 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+    : 'https://js.hcaptcha.com/1/api.js?render=explicit';
+  await injectScript(src, `data-${provider}`);
+  renderCaptchaWidget(provider, cfg.captcha.siteKey);
+}
+
+function renderCaptchaWidget(provider: CaptchaProvider, siteKey: string) {
+  const host = document.getElementById('captcha-host');
+  if (!host) return;
+  const w = window as CaptchaWindow;
+  const lib = provider === 'turnstile' ? w.turnstile : w.hcaptcha;
+  if (!lib) return;
+  lib.render(host, {
+    sitekey: siteKey,
+    callback: (token: string) => { captchaToken.value = token; },
+    'error-callback': () => { captchaToken.value = null; errorMessage.value = 'Captcha widget reported an error'; },
+    'expired-callback': () => { captchaToken.value = null; },
+  });
+}
+
+function injectScript(src: string, marker: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[${marker}]`);
+    if (existing) { resolve(); return; }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.defer = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute(marker, 'true');
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+async function handleSubmit() {
+  if (!canSubmit.value) return;
+  errorMessage.value = null;
+  txId.value = null;
+
+  // hostContext: production frontends should send a SIGNED context minted
+  // by their backend (FaucetClient.signHostContext + integrator HMAC secret).
+  // The example sends a plain uid to keep the demo runnable without a backend.
+  const hostContext = { uid: integratorId };
+
+  try {
+    let result: ClaimResponse;
+    if (config.value?.hashcash) {
+      phase.value = 'solving-hashcash';
+      hashcashAttempts.value = 0;
+      result = await client.solveAndClaim(address.value.trim(), {
+        uid: integratorId,
+        hostContext,
+        captchaToken: captchaToken.value ?? undefined,
+        onProgress: (n) => { hashcashAttempts.value = n; },
+      });
+    } else {
+      phase.value = 'submitting';
+      result = await client.claim(address.value.trim(), {
+        hostContext,
+        captchaToken: captchaToken.value ?? undefined,
+      });
+    }
+    phase.value = 'submitting';
+    txId.value = result.txId ?? null;
+    if (result.status === 'rejected') {
+      phase.value = 'rejected';
+      errorMessage.value = result.reason ?? 'Claim rejected';
+      return;
+    }
+    if (result.status === 'challenged') {
+      phase.value = 'rejected';
+      errorMessage.value = result.reason ?? 'Captcha challenge required';
+      return;
+    }
+    phase.value = 'broadcast';
+    const final = await client.waitForConfirmation(result.id);
+    txId.value = final.txId ?? txId.value;
+    phase.value = final.status === 'confirmed' ? 'confirmed' : 'rejected';
+    if (final.status === 'rejected' && final.reason) errorMessage.value = final.reason;
+  } catch (err) {
+    phase.value = 'error';
+    errorMessage.value = err instanceof Error ? err.message : String(err);
+  }
+}
+
+function reset() {
+  phase.value = config.value?.captcha ? 'awaiting-captcha' : 'idle';
+  txId.value = null;
+  errorMessage.value = null;
+  hashcashAttempts.value = 0;
+  // Captcha tokens are single-shot — clearing forces re-solve on retry.
+  captchaToken.value = null;
 }
 </script>
 
 <template>
   <main class="container">
     <h1>Nimiq Faucet</h1>
-    <p class="subtitle">Claim free NIM on testnet</p>
+    <p class="subtitle">Claim free NIM on testnet (with abuse-layer demo)</p>
 
     <form @submit.prevent="handleSubmit" class="claim-form">
       <label for="address">Nimiq Address</label>
@@ -49,20 +197,27 @@ function handleSubmit() {
         spellcheck="false"
       />
 
-      <button type="submit" :disabled="isPending || !address.trim()">
-        {{ isPending ? 'Claiming...' : 'Claim NIM' }}
+      <div v-if="config?.captcha && config.captcha.provider !== 'fcaptcha'" class="captcha-block">
+        <p class="captcha-label">{{ config.captcha.provider === 'turnstile' ? 'Cloudflare Turnstile' : 'hCaptcha' }}</p>
+        <div id="captcha-host" />
+      </div>
+
+      <p v-if="config?.hashcash" class="hashcash-note">
+        Hashcash difficulty {{ config.hashcash.difficulty }} bits — solved in your browser.
+      </p>
+
+      <button type="submit" :disabled="!canSubmit">
+        {{ isPending ? 'Claiming…' : 'Claim NIM' }}
       </button>
     </form>
 
-    <div v-if="statusLabel" class="status" :class="status">
+    <div v-if="statusLabel" class="status" :class="phase">
       <p>{{ statusLabel }}</p>
-      <p v-if="txId" class="tx">
-        TX: <code>{{ txId }}</code>
-      </p>
+      <p v-if="txId" class="tx">TX: <code>{{ txId }}</code></p>
     </div>
 
-    <div v-if="error" class="error">
-      <p>{{ error.message }}</p>
+    <div v-if="errorMessage" class="error">
+      <p>{{ errorMessage }}</p>
       <button @click="reset" class="retry">Try again</button>
     </div>
   </main>
@@ -81,32 +236,15 @@ body {
   justify-content: center;
 }
 
-.container {
-  max-width: 480px;
-  width: 100%;
-  padding: 2rem;
-}
+.container { max-width: 480px; width: 100%; padding: 2rem; }
 
-h1 {
-  font-size: 1.75rem;
-  margin-bottom: 0.25rem;
-}
+h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
 
-.subtitle {
-  color: #6b7280;
-  margin-bottom: 2rem;
-}
+.subtitle { color: #6b7280; margin-bottom: 2rem; }
 
-.claim-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
+.claim-form { display: flex; flex-direction: column; gap: 0.75rem; }
 
-label {
-  font-weight: 600;
-  font-size: 0.875rem;
-}
+label { font-weight: 600; font-size: 0.875rem; }
 
 input {
   padding: 0.75rem;
@@ -135,15 +273,26 @@ button {
 button:disabled { opacity: 0.5; cursor: not-allowed; }
 button:not(:disabled):hover { opacity: 0.85; }
 
-.status {
-  margin-top: 1.5rem;
-  padding: 1rem;
+.captcha-block {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #f0f1f9;
   border-radius: 8px;
-  background: #e8eaf6;
 }
 
+.captcha-label { font-size: 0.75rem; color: #6b7280; margin-bottom: 0.5rem; }
+
+.hashcash-note {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: -0.25rem;
+  font-style: italic;
+}
+
+.status { margin-top: 1.5rem; padding: 1rem; border-radius: 8px; background: #e8eaf6; }
 .status.confirmed { background: #d1fae5; color: #065f46; }
 .status.rejected { background: #fee2e2; color: #991b1b; }
+.status.solving-hashcash { background: #fef3c7; color: #78350f; }
 
 .tx { margin-top: 0.5rem; font-size: 0.8rem; word-break: break-all; }
 
@@ -155,10 +304,5 @@ button:not(:disabled):hover { opacity: 0.85; }
   color: #991b1b;
 }
 
-.retry {
-  margin-top: 0.75rem;
-  background: #991b1b;
-  font-size: 0.875rem;
-  padding: 0.5rem 1rem;
-}
+.retry { margin-top: 0.75rem; background: #991b1b; font-size: 0.875rem; padding: 0.5rem 1rem; }
 </style>

--- a/examples/vue-claim-page/src/env.d.ts
+++ b/examples/vue-claim-page/src/env.d.ts
@@ -2,6 +2,9 @@
 
 interface ImportMetaEnv {
   readonly VITE_FAUCET_URL: string;
+  /** Identifier sent in `hostContext.uid`. In production the backend signs
+   *  the hostContext; the example uses the literal value for the demo. */
+  readonly VITE_INTEGRATOR_ID?: string;
 }
 
 interface ImportMeta {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       '@nimiq-faucet/react':
         specifier: workspace:*
         version: link:../../packages/sdk-react
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
       next:
         specifier: ^16.2.4
         version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -411,6 +414,9 @@ importers:
 
   examples/vue-claim-page:
     dependencies:
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
       '@nimiq-faucet/vue':
         specifier: workspace:*
         version: link:../../packages/sdk-vue


### PR DESCRIPTION
Closes ROADMAP §3.0.7 (Example abuse-layer integration) — every example app now demonstrates how to wire the abuse layers that apply to its framework.

## What changed per example

| Example | Captcha widget | Hashcash | Signed `hostContext` | Fingerprint |
|---------|:--------------:|:--------:|:--------------------:|:-----------:|
| `vue-claim-page` | ✅ Turnstile / hCaptcha (driven by `/v1/config`) | ✅ `solveAndClaim` w/ progress | ✅ pattern documented | — |
| `nextjs-claim-page` | ✅ Turnstile / hCaptcha | ✅ `solveAndClaim` w/ progress | ✅ + route-handler example | — |
| `capacitor-mobile-app` | ✅ Turnstile / hCaptcha (in WebView) | ✅ `solveAndClaim` | ✅ pattern documented | ✅ auto-injected by `CapacitorFaucetClient` + visible in UI |
| `go-backend-integration` | n/a (backend) | ✅ `SolveAndClaim` | ✅ `SignHostContext(ctx, integratorID, hmacSecret)` | n/a |
| `python-backend-integration` | n/a (backend) | ✅ `solve_and_claim` | ✅ `FaucetClient.sign_host_context(...)` | n/a |
| `flutter-mobile-app` (Dart CLI) | n/a (CLI) | ✅ `solveAndClaim` | ✅ `signHostContext` from `nimiq_faucet` | n/a |

## Per-example deliverables

Each example now has:

- **An "Abuse layers" section** in its README listing the layers it demonstrates and the env vars/server config that enables others
- **An `.env.example`** documenting `FAUCET_URL` / `FAUCET_INTEGRATOR_ID` / `FAUCET_HMAC_SECRET` (or the `VITE_*` / `NEXT_PUBLIC_*` variants where appropriate)
- **Working code** that picks up the config from `/v1/config` and renders only what the operator has enabled

## Design choices

### Web examples bypass `useFaucetClaim`

`@nimiq-faucet/{vue,react}`'s `useFaucetClaim` is the right shape for uid-only flows. The new flows interleave captcha + hashcash prep before claiming, which is awkward to do through the hook's reactive arg shape. The examples bypass `useFaucetClaim` and call `client.solveAndClaim` / `client.claim` directly — the hook is unchanged.

### Captcha widgets only render Turnstile or hCaptcha

The fcaptcha integration lives in `examples/mini-app-claim-*` (it's a same-origin / WebView-specific pattern). When the faucet is configured for fcaptcha, these examples surface a friendly "see mini-app-claim-*" message rather than rendering a wrong widget.

### Backend examples make HMAC signing optional

`FAUCET_HMAC_SECRET` is **strongly recommended in production** but optional for the demo so it runs out of the box. With the secret unset, claims still work — they just don't get the asserted-trust bonus from the faucet's pipeline. Each backend README spells this out explicitly.

### Capacitor surfaces the device fingerprint in the UI

`CapacitorFaucetClient` already auto-injects `fingerprint.visitorId`. The example now shows the value (platform, model, visitorId) in a small device card so testers can verify what the faucet receives.

## Verification

```
✅ pnpm turbo run build --filter @nimiq-faucet/example-vue --filter @nimiq-faucet/example-nextjs --filter @nimiq-faucet/example-capacitor
   → vue 70 KB / 28 KB gz, next static prerender, capacitor 161 KB / 53 KB gz
✅ python3 -c "import ast; ast.parse(open('app.py').read())"  → OK
✅ dart analyze (flutter-mobile-app)                            → No issues found
✅ Go vet/build runs in CI; API calls cross-referenced against packages/sdk-go/{hmac,faucet}.go
```

## Out of scope (deliberate, file as follow-ups if needed)

- **React Native example** — doesn't yet exist (roadmap §1.5.1, separate item)
- **Mutation testing** — covered by the existing CI build/typecheck gates and the framework SDK tests merged in PR #143

## Diff size

23 files changed, **+1,217 / -207**. Mostly new code in app sources + READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)