### PR TITLE
docs(claim-ui): footer says "Built with love by Richy"

### DIFF
--- a/apps/claim-ui/src/components/FooterBar.vue
+++ b/apps/claim-ui/src/components/FooterBar.vue
@@ -2,7 +2,7 @@
   <footer class="py-12 bg-[#FAF9F7] border-t border-outline-variant/10 mt-auto">
     <div class="flex flex-col md:flex-row justify-between items-center px-12 w-full max-w-7xl mx-auto gap-8">
       <div class="text-sm font-medium text-[#1F2348]/70 font-body leading-relaxed text-center md:text-left">
-        Built with Porcelain Precision by <a class="hover:text-primary-container underline transition-colors" href="https://github.com/PanoramicRum/nimiq-simple-faucet" target="_blank" rel="noopener">Richy</a>.
+        Built with love by <a class="hover:text-primary-container underline transition-colors" href="https://github.com/PanoramicRum/nimiq-simple-faucet" target="_blank" rel="noopener">Richy</a>.
       </div>
       <nav class="flex items-center gap-6">
         <a class="text-[#1F2348]/70 text-sm font-medium font-body hover:text-primary-container transition-colors" href="https://github.com/PanoramicRum/nimiq-simple-faucet" target="_blank" rel="noopener">Developer Playground</a>


### PR DESCRIPTION
Single-line copy change in [\`apps/claim-ui/src/components/FooterBar.vue:5\`](apps/claim-ui/src/components/FooterBar.vue#L5):

> Built with ~~Porcelain Precision~~ **love** by [Richy](...).

\"Porcelain Precision\" was coined when the Porcelain Vault theme was the only theme; with the upcoming pluggable multi-theme system the phrase becomes theme-specific in a footer that all themes share. \"love\" is theme-agnostic and friendlier.

Pre-PR 2 in the four-PR rollout for ROADMAP §3.0 alt-themes; ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)