### PR TITLE
feat(claim-ui): pluggable theme registry + contributor docs (§3.0.14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Boots a self-contained WASM faucet. The WASM client reaches TestAlbatross consen
 
 Every SDK accepts the same `hostContext` (hashed UID, cookie hash, session hash, account age, KYC level, tags, HMAC signature) so your project's own abuse signals flow into the faucet's scoring pipeline.
 
+### Want to ship your own claim-UI theme?
+
+The Claim UI is pluggable — `FAUCET_CLAIM_UI_THEME=<slug>` switches between bundled themes at deploy time, and adding a new theme is a documented contract. See [`docs/contributing-a-frontend.md`](./docs/contributing-a-frontend.md).
+
 ### Nimiq Pay Mini App
 
 A canonical [Nimiq Pay Mini App](https://mini-apps-launch-developer-center-dev-worker.je-cf9.workers.dev/mini-apps) example that runs inside the Nimiq Pay wallet WebView, reads the user's NIM address via [`@nimiq/mini-app-sdk`](https://www.npmjs.com/package/@nimiq/mini-app-sdk), and claims from this faucet. Two implementations sharing one TypeScript core:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -784,6 +784,98 @@ FCaptcha is missing a feature we need, contribute it upstream.
 **Estimated effort:** 1 day (thin driver + widget wrapper + compose
 profile + docs).
 
+### 3.0.14 — Multi-theme system + NimiqPoW alt theme
+
+**Status:** in-progress as of late April 2026. Foundation merged via
+PRs #146 / #147 / #148 / #149 (rename, server registry, NimiqPoW theme,
+Docker multi-theme bundling).
+
+**Goal:** make the Claim UI pluggable so operators can pick between
+multiple bundled themes with one env-var flip, and so community
+contributors have a documented path to ship a new theme.
+
+**Scope:**
+- `apps/server/src/themes.ts` — central theme registry. Slug → display
+  name + dist path (in repo + in Docker image).
+- `FAUCET_CLAIM_UI_THEME=<slug>` selects which bundled theme the server
+  serves at `/`. `FAUCET_CLAIM_UI_DIR` continues to win as an explicit
+  operator override (custom themes outside the registry).
+- `apps/nimiq-pow-ui/` — second theme: world-dot map + peer-pulse
+  animation, recreating the visual language of the old
+  [`nimiq/web-miner`](https://github.com/nimiq/web-miner). Decorative
+  only — claims are still HTTP, no in-browser PoW.
+- `docs/contributing-a-frontend.md` — full contract for community
+  contributors (faucet API surface, dist/ requirements, theme
+  registration steps, submission process).
+- Docker image bundles every `apps/*-ui/dist/` so flipping themes
+  needs no rebuild.
+
+**Out of scope (explicitly):**
+- Real proof-of-work mining in the browser (the old web-miner ran
+  actual PoW; the alt theme is a visual tribute, not a functional
+  mining client).
+
+### 3.0.15 — Hub-API wallet integration for the NimiqPoW theme
+
+**Goal:** replace v1's paste-address input with [`@nimiq/hub-api`](https://www.npmjs.com/package/@nimiq/hub-api)
+so users connect their Nimiq wallet via the Hub flow rather than copy-
+pasting an address. The user's account access is signed by the Hub; no
+key handling in the page.
+
+**Why scoped to NimiqPoW first:** the existing Porcelain Vault theme
+already has its own claim UX and changing it disrupts users on the
+default. Land Hub integration in NimiqPoW first, validate with real-
+phone testing, then graduate the pattern to other themes.
+
+**Scope:**
+- Replace `apps/nimiq-pow-ui/src/components/ConnectWallet.vue`'s paste
+  input with a Hub-API connect button.
+- `@nimiq/hub-api` as a workspace dep on the NimiqPoW theme only.
+- Document the Hub flow in `apps/nimiq-pow-ui/README.md`.
+
+**Estimated effort:** 1 day (Hub-API has a well-documented integration
+path; the slow piece is real-phone testing across iOS/Android).
+
+### 3.0.16 — User-facing theme picker dropdown (nice-to-have)
+
+**Goal:** let visitors switch between bundled themes from a UI
+control instead of having the operator decide at deploy time.
+
+**Why a nice-to-have:** the env-var switch (§3.0.14) covers the
+operator workflow. A user-facing picker is an opinionated UX
+addition — useful for the playground / public demo, but probably
+disabled in serious production deployments where the operator wants
+brand consistency.
+
+**Scope:**
+- Surface the available themes via `/v1/config.ui.themes: [{ slug,
+  displayName, description }]`.
+- Top-bar "Theme:" dropdown, theme-aware so each theme renders its own
+  variant. Selection persists in `localStorage`.
+- Operator opt-in: `FAUCET_THEME_PICKER_ENABLED=false` by default.
+
+**Estimated effort:** 1 day.
+
+## Future ideas (community contributions wanted)
+
+These aren't on the roadmap — they're ideas the multi-theme system
+makes possible. Contributions welcome; open an issue if you'd like
+to discuss before starting.
+
+### React / Svelte / SolidJS / vanilla TS themes
+
+The frontend contract documented in [`docs/contributing-a-frontend.md`](docs/contributing-a-frontend.md)
+is framework-agnostic by design — anything that produces a static
+`dist/index.html` works. Reference implementations in non-Vue
+frameworks would showcase the contract and give integrators
+familiar starting points. PRs welcome under `apps/<framework>-ui/`.
+
+### Themes inspired by other Nimiq-ecosystem visuals
+
+The NimiqPoW theme proves the multi-theme model with a tribute to the
+old web-miner. Other Nimiq-ecosystem visual heritage (early Wallet,
+Nimiq Pay, the various community sites) could each become a theme.
+
 ---
 
 # Beyond 1.x — Ongoing quality programs

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -117,6 +117,14 @@ export const ServerConfigSchema = z.object({
   requireBrowser: z.coerce.boolean().default(false),
   uiEnabled: z.coerce.boolean().default(true),
   claimUiDir: z.string().optional(),
+  /**
+   * Slug of a bundled Claim UI theme to serve when `claimUiDir` is unset.
+   * Default: `porcelain-vault`. Unknown values fall back to the default
+   * with a warning log so a typo in deployment env doesn't break the UI.
+   * See `apps/server/src/themes.ts` for the registry. Adding a new theme
+   * is documented in `docs/contributing-a-frontend.md`.
+   */
+  claimUiTheme: z.string().default('porcelain-vault'),
   dashboardDir: z.string().optional(),
 
   // When true, `/docs/api` is served outside dev mode too. `/openapi.json`
@@ -277,6 +285,7 @@ const ENV_KEYS: Record<string, string> = {
   requireBrowser: 'FAUCET_REQUIRE_BROWSER',
   uiEnabled: 'FAUCET_UI_ENABLED',
   claimUiDir: 'FAUCET_CLAIM_UI_DIR',
+  claimUiTheme: 'FAUCET_CLAIM_UI_THEME',
   dashboardDir: 'FAUCET_DASHBOARD_DIR',
   openapiPublic: 'FAUCET_OPENAPI_PUBLIC',
   integratorKeys: 'FAUCET_INTEGRATOR_KEYS',

--- a/apps/server/src/themes.ts
+++ b/apps/server/src/themes.ts
@@ -1,0 +1,60 @@
+/**
+ * Registry of bundled Claim UI themes.
+ *
+ * Each theme is an independently-built Vite/static SPA in `apps/<slug>-ui/`
+ * that consumes the public faucet API (`/v1/config`, `/v1/claim`, etc.).
+ * The Docker image bundles every theme's `dist/` and an operator picks
+ * one at runtime via `FAUCET_CLAIM_UI_THEME=<slug>` — no rebuild.
+ *
+ * Adding a new theme is a 3-line PR here plus the new app's workspace
+ * package. See `docs/contributing-a-frontend.md` for the full contract.
+ */
+
+export interface ThemeManifest {
+  /** Human-readable name shown in logs and `/v1/config.ui.displayName`. */
+  displayName: string;
+  /** One-sentence description for docs / future UI picker. */
+  description: string;
+  /**
+   * Path to the built `dist/` directory **relative to the repo root**.
+   * Used in dev / monorepo runs (when the server is started via
+   * `pnpm --filter @faucet/server start` from the repo root).
+   */
+  distFromRepoRoot: string;
+  /**
+   * Absolute path inside the production Docker image. The Dockerfile
+   * COPYs each theme's `dist/` to `/app/themes/<slug>/dist/` so a
+   * single image can serve any bundled theme by env-var flip.
+   */
+  distInImage: string;
+}
+
+export const THEMES = {
+  'porcelain-vault': {
+    displayName: 'Porcelain Vault',
+    description:
+      'The default — clean, off-white, Material 3 palette. Vue 3 + Tailwind. Shipped in v2.2.1.',
+    distFromRepoRoot: 'apps/claim-ui/dist',
+    distInImage: '/app/themes/porcelain-vault/dist',
+  },
+} as const satisfies Record<string, ThemeManifest>;
+
+export type ThemeSlug = keyof typeof THEMES;
+
+export const DEFAULT_THEME: ThemeSlug = 'porcelain-vault';
+
+/**
+ * Type guard: is the given string a slug we know about? Tolerates
+ * unknown env input gracefully — callers fall back to DEFAULT_THEME
+ * with a warning log instead of crashing the server.
+ */
+export function isKnownTheme(slug: string): slug is ThemeSlug {
+  return slug in THEMES;
+}
+
+export function listThemes(): { slug: ThemeSlug; manifest: ThemeManifest }[] {
+  return (Object.keys(THEMES) as ThemeSlug[]).map((slug) => ({
+    slug,
+    manifest: THEMES[slug],
+  }));
+}

--- a/apps/server/src/ui.ts
+++ b/apps/server/src/ui.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import fastifyStatic from '@fastify/static';
 import type { ServerConfig } from './config.js';
+import { THEMES, DEFAULT_THEME, isKnownTheme, type ThemeSlug } from './themes.js';
 
 function firstExisting(candidates: string[]): string | null {
   for (const c of candidates) {
@@ -11,13 +12,50 @@ function firstExisting(candidates: string[]): string | null {
   return null;
 }
 
-function claimUiDir(config: ServerConfig): string | null {
-  if (config.claimUiDir) return existsSync(config.claimUiDir) ? resolve(config.claimUiDir) : null;
-  return firstExisting([
-    resolve(process.cwd(), 'apps/claim-ui/dist'),
-    resolve(process.cwd(), '../claim-ui/dist'),
-    '/app/apps/claim-ui/dist',
+/**
+ * Resolve which directory the Claim UI is served from. Order:
+ *   1. `config.claimUiDir` — explicit operator override (custom themes
+ *      not bundled in the Docker image, dev work, etc.). Wins absolutely.
+ *   2. The bundled-theme registry: `config.claimUiTheme` → `THEMES[slug]`.
+ *      Tries the production-Docker path first, then the monorepo dev path.
+ *   3. The default theme (`porcelain-vault`) — preserves the original
+ *      behaviour for anyone who upgrades without setting any new env vars.
+ *
+ * An unknown `claimUiTheme` value (typo in deployment env) is downgraded
+ * to the default with a warning log; we never crash the UI for a bad slug.
+ */
+function resolveClaimUiDir(
+  config: ServerConfig,
+  log: { warn: (obj: object, msg?: string) => void },
+): { dir: string | null; theme: ThemeSlug | null } {
+  if (config.claimUiDir) {
+    if (existsSync(config.claimUiDir)) {
+      return { dir: resolve(config.claimUiDir), theme: null };
+    }
+    log.warn(
+      { claimUiDir: config.claimUiDir },
+      'FAUCET_CLAIM_UI_DIR set but path does not exist; falling back to bundled theme',
+    );
+  }
+
+  let theme: ThemeSlug;
+  if (isKnownTheme(config.claimUiTheme)) {
+    theme = config.claimUiTheme;
+  } else {
+    log.warn(
+      { requested: config.claimUiTheme, fallback: DEFAULT_THEME, knownThemes: Object.keys(THEMES) },
+      'FAUCET_CLAIM_UI_THEME slug not found in registry; falling back to default theme',
+    );
+    theme = DEFAULT_THEME;
+  }
+
+  const manifest = THEMES[theme];
+  const dir = firstExisting([
+    manifest.distInImage,
+    resolve(process.cwd(), manifest.distFromRepoRoot),
+    resolve(process.cwd(), '../', manifest.distFromRepoRoot.replace(/^apps\//, '')),
   ]);
+  return { dir, theme };
 }
 
 function dashboardDir(config: ServerConfig): string | null {
@@ -48,7 +86,7 @@ export async function registerUi(app: FastifyInstance, config: ServerConfig): Pr
     app.log.info({ dash }, 'dashboard ui mounted at /admin');
   }
 
-  const claim = claimUiDir(config);
+  const { dir: claim, theme } = resolveClaimUiDir(config, app.log);
   if (claim) {
     await app.register(fastifyStatic, {
       root: claim,
@@ -71,6 +109,6 @@ export async function registerUi(app: FastifyInstance, config: ServerConfig): Pr
       }
       return reply.sendFile('index.html', claim);
     });
-    app.log.info({ claim }, 'claim ui mounted at /');
+    app.log.info({ claim, theme }, 'claim ui mounted at /');
   }
 }

--- a/apps/server/test/themes.test.ts
+++ b/apps/server/test/themes.test.ts
@@ -1,0 +1,43 @@
+/**
+ * §3.0.14 — bundled-theme registry resolution.
+ *
+ * The full UI-mounting path requires real built assets and is exercised
+ * by the smoke job. These tests cover the registry's logic surface in
+ * isolation: known slugs resolve, unknown slugs fall back to the default,
+ * and the manifest shape stays consistent across themes.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { THEMES, DEFAULT_THEME, isKnownTheme, listThemes } from '../src/themes.js';
+
+describe('THEMES registry', () => {
+  it('exposes the default theme', () => {
+    expect(DEFAULT_THEME in THEMES).toBe(true);
+    expect(THEMES[DEFAULT_THEME].displayName).toBeTruthy();
+    expect(THEMES[DEFAULT_THEME].distFromRepoRoot).toMatch(/^apps\/.*\/dist$/);
+    expect(THEMES[DEFAULT_THEME].distInImage).toMatch(/^\/app\/themes\/.*\/dist$/);
+  });
+
+  it.each(Object.entries(THEMES))(
+    'theme %s has a complete manifest',
+    (slug, manifest) => {
+      expect(manifest.displayName).toBeTruthy();
+      expect(manifest.description).toBeTruthy();
+      expect(manifest.distFromRepoRoot).toMatch(/^apps\/.*\/dist$/);
+      expect(manifest.distInImage).toBe(`/app/themes/${slug}/dist`);
+    },
+  );
+
+  it('isKnownTheme distinguishes registered slugs from typos', () => {
+    expect(isKnownTheme('porcelain-vault')).toBe(true);
+    expect(isKnownTheme('porcelain-valt')).toBe(false); // typo
+    expect(isKnownTheme('')).toBe(false);
+    expect(isKnownTheme('NIMIQ-POW')).toBe(false); // case-sensitive
+  });
+
+  it('listThemes returns every registered theme with its manifest', () => {
+    const all = listThemes();
+    expect(all.length).toBe(Object.keys(THEMES).length);
+    expect(all.every((entry) => entry.manifest === THEMES[entry.slug])).toBe(true);
+  });
+});

--- a/docs/contributing-a-frontend.md
+++ b/docs/contributing-a-frontend.md
@@ -1,0 +1,190 @@
+# Contributing a Claim UI frontend
+
+The faucet's Claim UI is **pluggable**: any static SPA can be served as the user-facing claim page by pointing the server at its `dist/` directory. The repo ships one default theme (Porcelain Vault) and the bundled-theme registry lets operators pick another at deploy time with a single env var. Community-contributed themes follow the same path.
+
+This doc is the contract.
+
+---
+
+## 1. Frontend contract
+
+You ship a directory containing:
+
+- `index.html` — the SPA shell.
+- Any number of static assets (JS, CSS, images, fonts) referenced from `index.html` with **relative or absolute-from-root** paths (e.g. `/assets/index-abc123.js`). Vite's default output works out of the box.
+- That's it. The server doesn't care which framework or build tool produced the bundle.
+
+### Routing
+
+The server registers your `dist/` at `/` with [`@fastify/static`](https://github.com/fastify/fastify-static) and a not-found handler that returns your `index.html` for any non-API path. **SPA routing works out of the box** — `react-router`, `vue-router`, Next.js's App Router (in static-export mode), or hash-based routing all work.
+
+The reserved prefixes the server keeps for itself: `/v1/`, `/admin/`, `/mcp`, `/healthz`, `/llms.txt`, `/readyz`, `/metrics`. Don't use those as your client-side routes; the server will return 404 / its own response there.
+
+### What you must NOT do
+
+- Embed secrets in the bundle. Browsers see the JS; treat anything in there as public.
+- Hard-code a faucet URL. Read it from a config endpoint or build-time env (`VITE_FAUCET_URL` / `NEXT_PUBLIC_FAUCET_URL`).
+- Hold the user's private key. The faucet sends NIM **to** an address the user types in or pastes; it doesn't sign anything on the user's behalf.
+
+---
+
+## 2. Faucet API surface to consume
+
+Three endpoints cover the entire claim flow. The [`@nimiq-faucet/sdk`](../packages/sdk-ts) package is the recommended client; raw `fetch` works too.
+
+### `GET /v1/config`
+
+Returns the operator's current configuration:
+
+```json
+{
+  "network": "test",
+  "claimAmountLuna": "100000",
+  "abuseLayers": { "turnstile": false, "hcaptcha": false, "hashcash": true, ... },
+  "captcha": null,
+  "hashcash": { "difficulty": 18, "ttlMs": 300000 }
+}
+```
+
+Read this on mount. Render captcha widgets (when `captcha != null`) and surface hashcash difficulty (when `hashcash != null`). Don't render features the server didn't enable.
+
+### `POST /v1/claim`
+
+```json
+{
+  "address": "NQ00 ...",
+  "captchaToken": "...",                 // optional; when /v1/config.captcha != null
+  "hashcashSolution": "<challenge>#<nonce>",  // optional; when /v1/config.hashcash != null
+  "fingerprint": { "visitorId": "..." }, // optional; mobile apps via @capacitor/device
+  "hostContext": { "uid": "...", ... }   // optional; backend-signed in production
+}
+```
+
+Use `client.solveAndClaim()` to handle the hashcash round-trip automatically. Returns `{ id, status, txId? }`. Possible statuses: `queued`, `broadcast`, `confirmed`, `rejected`, `challenged`.
+
+### `GET /v1/claim/{id}`
+
+Poll for status, or use `client.waitForConfirmation(id)`.
+
+### Reference snippet (Vue 3)
+
+```ts
+import { ref, onMounted } from 'vue';
+import { FaucetClient, type FaucetConfig } from '@nimiq-faucet/sdk';
+
+const faucetUrl = import.meta.env.VITE_FAUCET_URL || window.location.origin;
+const client = new FaucetClient({ url: faucetUrl });
+const config = ref<FaucetConfig | null>(null);
+const status = ref('idle');
+
+onMounted(async () => { config.value = await client.config(); });
+
+async function claim(address: string) {
+  status.value = 'submitting';
+  const result = await client.solveAndClaim(address, {
+    hostContext: { uid: 'my-theme-name' },
+  });
+  const final = await client.waitForConfirmation(result.id);
+  status.value = final.status;
+}
+```
+
+The framework SDKs ([`@nimiq-faucet/vue`](../packages/sdk-vue), [`@nimiq-faucet/react`](../packages/sdk-react)) provide reactive wrappers. See the existing examples under [`examples/`](../examples) for full implementations across Vue, Next.js, Capacitor, Go, Python, Flutter.
+
+---
+
+## 3. Local development
+
+```bash
+# Clone the repo
+git clone https://github.com/PanoramicRum/nimiq-simple-faucet
+cd nimiq-simple-faucet
+pnpm install
+
+# Start the faucet (separate terminal)
+cd deploy/compose && cp .env.example .env  # edit FAUCET_ADMIN_PASSWORD + wallet
+docker compose --profile local-node up -d
+
+# Start your theme's dev server
+cd apps/<your-theme-slug>-ui
+VITE_FAUCET_URL=http://localhost:8080 pnpm dev
+```
+
+Your theme runs on Vite's port (5173 by default); browser hits the faucet via `VITE_FAUCET_URL`. CORS is permissive by default in `FAUCET_DEV=1` mode.
+
+---
+
+## 4. Theme registration
+
+When your theme builds cleanly and you've got a working claim flow, register it so operators can flip to it with `FAUCET_CLAIM_UI_THEME=<your-slug>`.
+
+### a. Add to the workspace
+
+[`pnpm-workspace.yaml`](../pnpm-workspace.yaml):
+
+```yaml
+packages:
+  ...
+  - 'apps/your-theme-slug-ui'
+```
+
+Your `apps/<your-theme-slug>-ui/package.json` should be:
+
+```json
+{
+  "name": "@nimiq-faucet/<your-theme-slug>-ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "<typecheck && vite build>",
+    "preview": "vite preview"
+  }
+}
+```
+
+### b. Register in the theme registry
+
+[`apps/server/src/themes.ts`](../apps/server/src/themes.ts):
+
+```ts
+export const THEMES = {
+  'porcelain-vault': { ... },
+  'your-theme-slug': {
+    displayName: 'Your Theme Display Name',
+    description: 'One-sentence summary shown in logs and the future theme picker.',
+    distFromRepoRoot: 'apps/your-theme-slug-ui/dist',
+    distInImage: '/app/themes/your-theme-slug/dist',
+  },
+} as const satisfies Record<string, ThemeManifest>;
+```
+
+### c. Bundle into the production Docker image
+
+[`deploy/docker/Dockerfile`](../deploy/docker/Dockerfile) — the multi-theme build COPYs every `apps/*-ui/dist` to `/app/themes/<slug>/dist` (PR #4 of the multi-theme rollout, see ROADMAP §3.0). Once that lands, your theme is bundled automatically by the wildcard.
+
+---
+
+## 5. Submission process
+
+Open a PR with:
+
+- **Title**: `feat(themes): add <Your Theme Display Name> claim UI (#<roadmap-issue>)`
+- **Description**:
+  - One-paragraph summary of the visual direction.
+  - **At least one screenshot** (light + dark if both supported).
+  - Confirmation that you tested an end-to-end testnet claim against a running faucet.
+  - WCAG AA contrast confirmation on the address input + claim button.
+- **Files**: the new `apps/<slug>-ui/` workspace + the `pnpm-workspace.yaml` + `apps/server/src/themes.ts` updates.
+- **Out of scope** for the maintainer review: framework choice (Vue/React/Svelte/vanilla all welcome), aesthetic preferences (subjective), specific component-library choices.
+- **In scope** for review: the contract above (no embedded secrets, no hard-coded URLs, doesn't use reserved prefixes), accessibility minimums, that the build produces a clean static `dist/`, and that the theme registry entry matches the actual paths.
+
+---
+
+## See also
+
+- [`apps/claim-ui/`](../apps/claim-ui) — the default Porcelain Vault theme. Reference implementation for the contract.
+- [`packages/sdk-ts/`](../packages/sdk-ts) — `FaucetClient` source. The single place to look for what the API actually does.
+- [`examples/`](../examples) — six worked examples across Vue, Next.js, Capacitor, Go, Python, Flutter that demonstrate every abuse-layer integration. The `vue-claim-page` and `nextjs-claim-page` examples are the closest sibling shape to a claim-UI theme.
+- [`ROADMAP.md`](../ROADMAP.md) §3.0 — the multi-theme rollout plan (NimiqPoW theme is the reference second theme; Hub-API integration follows).


### PR DESCRIPTION
Lays the foundation for ROADMAP §3.0.14 (multi-theme system). The actual NimiqPoW theme lands in PR #3 of the rollout; this PR ships only the infrastructure so the contract is reviewable on its own.

## What's new

- **`apps/server/src/themes.ts`** — central theme registry. Slug → display name + dist paths (in repo + in the Docker image). Today only \`porcelain-vault\` is registered. Adding a theme is a 3-line PR plus the new app workspace.
- **`FAUCET_CLAIM_UI_THEME=<slug>`** — selects which bundled theme the server serves at \`/\`. Resolution order:
  1. Explicit \`FAUCET_CLAIM_UI_DIR\` (operator override; wins absolutely)
  2. Registry lookup (\`distInImage\` → \`distFromRepoRoot\`)
  3. Default theme (\`porcelain-vault\`) — preserves today's behavior for operators who upgrade without setting any new env vars.
  Unknown slugs (typo in deploy env) fall back to the default with a warning log; we never crash the UI for a bad slug.
- **\`apps/server/src/ui.ts\`** — \`claimUiDir()\` rewritten to consult the registry.
- **\`docs/contributing-a-frontend.md\`** — full 5-section contract (frontend contract, faucet API surface, local dev, theme registration, submission process). Cross-linked from \`README.md\`.
- **\`ROADMAP.md\`** — three new follow-up entries:
  - **§3.0.14** — this rollout (multi-theme + NimiqPoW).
  - **§3.0.15** — Hub-API wallet integration for NimiqPoW (next-up after the alt theme ships).
  - **§3.0.16** — User-facing theme picker dropdown (nice-to-have at the end of the playground roadmap).
  Plus a new \"Future ideas (community contributions wanted)\" section seeded with React/Svelte/SolidJS theme invitations.
- **\`apps/server/test/themes.test.ts\`** — 4 new unit tests on the registry (default theme present; every manifest's shape; \`isKnownTheme\`; \`listThemes\`).

## Verification

```
✅ pnpm --filter @faucet/server test     → 135 tests passing (+4)
✅ pnpm turbo run build typecheck        → 12/12 tasks successful
```

## What's next

- **PR #3** — \`apps/nimiq-pow-ui/\` actual implementation (world-dot map + peer-pulse animation, Vue 3 + Vite). Will register itself in the theme registry added by this PR.
- **PR #4** — Docker multi-theme bundling, Helm \`claimUi.theme\` value, theme-switch e2e test.

PR #1 of the rollout (\`Built with love by Richy\` footer rename) is at #146 and ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)