### PR TITLE
feat(nimiq-pow-ui): NimiqPoW alt theme — visual tribute to web-miner (§3.0.14)

### DIFF
--- a/apps/nimiq-pow-ui/README.md
+++ b/apps/nimiq-pow-ui/README.md
@@ -1,0 +1,58 @@
+# Nimiq PoW — alternative Claim UI theme
+
+Visual tribute to the original [`nimiq/web-miner`](https://github.com/nimiq/web-miner) (live at [miner.nimiq-testnet.com](https://miner.nimiq-testnet.com/)). Animated world-dot map + peer-pulse network visualization, dark-navy palette, claim-NIM CTA at the bottom.
+
+**This is decorative.** The old web-miner ran actual proof-of-work in the browser; this theme does not. The claim flow is the same plain HTTP `client.solveAndClaim` (or `client.claim`) used by every other theme — the visualization just suggests network activity.
+
+## Switch to this theme
+
+```bash
+# Local dev
+FAUCET_CLAIM_UI_THEME=nimiq-pow pnpm --filter @faucet/server start
+
+# Docker (once the multi-theme image lands in PR #4)
+docker run -e FAUCET_CLAIM_UI_THEME=nimiq-pow ghcr.io/panoramicrum/nimiq-simple-faucet:latest
+```
+
+The default theme remains [`porcelain-vault`](../claim-ui/) — see [`docs/contributing-a-frontend.md`](../../docs/contributing-a-frontend.md) for the multi-theme system and how to ship your own.
+
+## Run locally
+
+```bash
+# From repo root
+pnpm install
+pnpm --filter @nimiq-faucet/nimiq-pow-ui dev
+# Open http://localhost:5174
+```
+
+The dev server proxies `/v1/*` to a faucet on `http://localhost:8080` (override with `FAUCET_PORT=...`). For a full stack:
+
+```bash
+cd deploy/compose && cp .env.example .env  # edit credentials
+docker compose --profile local-node up -d  # faucet + nimiq node
+# Then in another terminal:
+pnpm --filter @nimiq-faucet/nimiq-pow-ui dev
+```
+
+## What's in the box
+
+| File | Purpose |
+|---|---|
+| [`src/App.vue`](src/App.vue) | Layout: header + hero panel + map background + footer |
+| [`src/components/WorldMap.vue`](src/components/WorldMap.vue) | Canvas-based dot grid with continent silhouette + peer-pulse animation |
+| [`src/components/ConnectWallet.vue`](src/components/ConnectWallet.vue) | Paste-address input. Hub-API integration is roadmap §3.0.15. |
+| [`src/components/ClaimButton.vue`](src/components/ClaimButton.vue) | Pulsing gold CTA |
+| [`src/components/StatusBar.vue`](src/components/StatusBar.vue) | Phase / tx / error display |
+| [`src/components/FooterBar.vue`](src/components/FooterBar.vue) | Footer + GitHub + web-miner credit |
+| [`src/composables/useClaim.ts`](src/composables/useClaim.ts) | Wraps `FaucetClient`, reads `/v1/config`, runs `solveAndClaim` when hashcash is enabled |
+
+## Roadmap
+
+- **Now (v1)**: paste-address claim, decorative network animation. Shipped in [PR #148](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/148).
+- **Next (§3.0.15)**: Hub-API wallet connect — replaces the paste input with a Nimiq Hub flow. No keys ever held by the page.
+- **Future (§3.0.16)**: user-facing theme picker so visitors can swap between bundled themes from the UI.
+- **Future (community)**: more themes — see [Future ideas](../../ROADMAP.md#future-ideas-community-contributions-wanted).
+
+## Credits
+
+The old [`nimiq/web-miner`](https://github.com/nimiq/web-miner) is the visual inspiration. Their dot-map + peer-pulse aesthetic was the defining look of early Nimiq; recreating it as a faucet theme felt right. The PoW mechanic itself is intentionally not reproduced here — the faucet is the source of NIM, not the user's CPU.

--- a/apps/nimiq-pow-ui/index.html
+++ b/apps/nimiq-pow-ui/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1F2348" />
+    <title>Nimiq Faucet — PoW theme</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/nimiq-pow-ui/package.json
+++ b/apps/nimiq-pow-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nimiq-faucet/nimiq-pow-ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Alternative Claim UI theme — visual tribute to nimiq/web-miner. World-dot map + peer-pulse animation, dark navy. Decorative only; the claim is plain HTTP.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "typecheck": "vue-tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nimiq-faucet/sdk": "workspace:*",
+    "vue": "^3.5.33"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.6",
+    "typescript": "^5.6.2",
+    "vite": "^8.0.10",
+    "vue-tsc": "^2.1.6"
+  }
+}

--- a/apps/nimiq-pow-ui/public/favicon.svg
+++ b/apps/nimiq-pow-ui/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="28" fill="#F6AE2D" />
+  <path d="M32 14 L48 24 L48 40 L32 50 L16 40 L16 24 Z" fill="#1F2348" stroke="#1F2348" stroke-width="2" stroke-linejoin="round" />
+</svg>

--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import WorldMap from './components/WorldMap.vue';
+import ConnectWallet from './components/ConnectWallet.vue';
+import ClaimButton from './components/ClaimButton.vue';
+import StatusBar from './components/StatusBar.vue';
+import FooterBar from './components/FooterBar.vue';
+import { useClaim } from './composables/useClaim';
+
+const address = ref('');
+const { config, state, claim, reset } = useClaim();
+
+const canClaim = computed(() => {
+  if (!address.value.trim()) return false;
+  return state.phase === 'idle' || state.phase === 'rejected' || state.phase === 'error' || state.phase === 'confirmed';
+});
+
+const isPending = computed(() =>
+  ['loading-config', 'solving-hashcash', 'submitting', 'broadcast'].includes(state.phase),
+);
+
+function handleClaim() {
+  if (!canClaim.value) return;
+  if (state.phase === 'confirmed' || state.phase === 'rejected' || state.phase === 'error') {
+    reset();
+  }
+  void claim(address.value);
+}
+</script>
+
+<template>
+  <div class="layout">
+    <!-- Decorative animated map fills the background. -->
+    <WorldMap class="map-bg" />
+
+    <!-- Header bar -->
+    <header class="header">
+      <div class="brand">
+        <svg class="logo" viewBox="0 0 64 64" aria-hidden="true">
+          <circle cx="32" cy="32" r="28" fill="#F6AE2D" />
+          <path
+            d="M32 14 L48 24 L48 40 L32 50 L16 40 L16 24 Z"
+            fill="#1F2348"
+            stroke="#1F2348"
+            stroke-width="2"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <div class="title">
+          <h1>Nimiq Faucet</h1>
+          <p class="tagline">PoW theme &mdash; tribute to the original web-miner</p>
+        </div>
+      </div>
+      <StatusBar
+        :phase="state.phase"
+        :tx-id="state.txId"
+        :error-message="state.errorMessage"
+        :hashcash-attempts="state.hashcashAttempts"
+      />
+    </header>
+
+    <!-- Centerpiece content -->
+    <main class="content">
+      <div class="panel">
+        <h2 class="hero">Claim your free NIM</h2>
+        <p class="sub">
+          Decentralised peer-to-peer cash. Below is a live(ish) view of the network — paste your testnet
+          address and the faucet will send you {{ config?.claimAmountLuna ? `${(Number(config.claimAmountLuna) / 1e5).toFixed(2)} NIM` : 'some NIM' }} to get you started.
+        </p>
+
+        <ConnectWallet v-model="address" :disabled="isPending" />
+
+        <div class="cta-row">
+          <ClaimButton
+            :disabled="!canClaim"
+            :pending="isPending"
+            :label="
+              state.phase === 'confirmed' ? 'Claim again' :
+              state.phase === 'rejected' || state.phase === 'error' ? 'Try again' :
+              isPending ? 'Mining…' :
+              'Claim NIM'
+            "
+            @click="handleClaim"
+          />
+          <p v-if="config?.hashcash" class="hashcash-note">
+            Proof-of-work difficulty {{ config.hashcash.difficulty }} bits — solved in your browser.
+          </p>
+        </div>
+      </div>
+    </main>
+
+    <FooterBar class="footer" />
+  </div>
+</template>
+
+<style scoped>
+.layout {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.map-bg {
+  position: absolute !important;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.55;
+}
+
+.header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo {
+  width: 2.75rem;
+  height: 2.75rem;
+  filter: drop-shadow(0 4px 14px rgba(246, 174, 45, 0.35));
+}
+
+.title h1 {
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+.tagline {
+  font-size: 0.7rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.panel {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2.5rem;
+  background: rgba(20, 23, 46, 0.78);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+.hero {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+.sub {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.cta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.hashcash-note {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.footer {
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .panel {
+    padding: 1.5rem;
+  }
+  .hero {
+    font-size: 1.5rem;
+  }
+}
+</style>

--- a/apps/nimiq-pow-ui/src/components/ClaimButton.vue
+++ b/apps/nimiq-pow-ui/src/components/ClaimButton.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+defineProps<{
+  disabled?: boolean;
+  pending?: boolean;
+  label?: string;
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    class="claim"
+    :disabled="disabled"
+    :data-pending="pending ? 'true' : 'false'"
+  >
+    <span class="label">{{ label ?? 'Claim NIM' }}</span>
+    <span class="arrow" aria-hidden="true">→</span>
+  </button>
+</template>
+
+<style scoped>
+.claim {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 2.25rem;
+  background: var(--gold);
+  color: var(--navy-3);
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  box-shadow: 0 0 0 0 rgba(246, 174, 45, 0.3), 0 12px 30px rgba(0, 0, 0, 0.35);
+  transition: background-color 160ms ease, transform 120ms ease, box-shadow 200ms ease;
+}
+
+.claim:not(:disabled):hover {
+  background: var(--amber);
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 8px rgba(246, 174, 45, 0.18), 0 14px 32px rgba(0, 0, 0, 0.4);
+}
+.claim:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.claim[data-pending='true'] {
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(246, 174, 45, 0.4), 0 12px 30px rgba(0, 0, 0, 0.35); }
+  50%      { box-shadow: 0 0 0 14px rgba(246, 174, 45, 0), 0 12px 30px rgba(0, 0, 0, 0.35); }
+}
+
+.arrow { font-size: 1.2rem; }
+</style>

--- a/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
+++ b/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+/**
+ * Paste-address input. v1 of the NimiqPoW theme uses a simple
+ * paste-and-claim flow; Hub-API integration is roadmap §3.0.15.
+ */
+import { computed } from 'vue';
+
+const props = defineProps<{ modelValue: string; disabled?: boolean }>();
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>();
+
+const isValidShape = computed(() => {
+  // Loose check — server-side validation does the real work.
+  // NQ + 36 alphanumeric chars (with optional spaces every 4 = 40 chars).
+  const stripped = props.modelValue.replace(/\s/g, '').toUpperCase();
+  return /^NQ[0-9]{2}[A-Z0-9]{32}$/.test(stripped);
+});
+</script>
+
+<template>
+  <div class="connect-wallet">
+    <label for="addr-input" class="label">Your Nimiq address</label>
+    <div class="input-row" :class="{ valid: isValidShape, dirty: modelValue.length > 0 }">
+      <input
+        id="addr-input"
+        type="text"
+        spellcheck="false"
+        autocomplete="off"
+        autocorrect="off"
+        :placeholder="'NQ00 0000 0000 0000 0000 0000 0000 0000 0000'"
+        :value="modelValue"
+        :disabled="disabled"
+        @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      />
+      <span v-if="modelValue.length > 0" class="hint">{{ isValidShape ? '✓' : '…' }}</span>
+    </div>
+    <p class="help">
+      Paste any testnet NIM address. We'll send the claim there. No wallet connection required —
+      <a href="https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119" target="_blank" rel="noopener">Hub-API support is on the roadmap</a>.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.connect-wallet {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.7rem;
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.input-row {
+  display: flex;
+  align-items: center;
+  background: rgba(20, 23, 46, 0.6);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+.input-row.dirty {
+  border-color: rgba(246, 174, 45, 0.4);
+}
+.input-row.valid {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 4px rgba(246, 174, 45, 0.10);
+}
+
+input {
+  flex: 1;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+input::placeholder {
+  color: rgba(158, 163, 199, 0.45);
+}
+
+.hint {
+  margin-left: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--gold);
+  font-weight: 700;
+}
+
+.help {
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+</style>

--- a/apps/nimiq-pow-ui/src/components/FooterBar.vue
+++ b/apps/nimiq-pow-ui/src/components/FooterBar.vue
@@ -1,0 +1,35 @@
+<template>
+  <footer class="footer">
+    <div class="left">
+      Built with love by
+      <a
+        href="https://github.com/PanoramicRum/nimiq-simple-faucet"
+        target="_blank"
+        rel="noopener"
+      >Richy</a>.
+    </div>
+    <nav class="right">
+      <a href="https://github.com/PanoramicRum/nimiq-simple-faucet" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/nimiq/web-miner" target="_blank" rel="noopener" title="Visual tribute to the original">web-miner ↗</a>
+    </nav>
+  </footer>
+</template>
+
+<style scoped>
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.25rem 2rem;
+  font-size: 0.78rem;
+  color: rgba(158, 163, 199, 0.7);
+  border-top: 1px solid var(--line);
+}
+
+.right {
+  display: flex;
+  gap: 1.5rem;
+}
+</style>

--- a/apps/nimiq-pow-ui/src/components/StatusBar.vue
+++ b/apps/nimiq-pow-ui/src/components/StatusBar.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Phase } from '../composables/useClaim';
+
+const props = defineProps<{
+  phase: Phase;
+  txId: string | null;
+  errorMessage: string | null;
+  hashcashAttempts: number;
+}>();
+
+const message = computed(() => {
+  switch (props.phase) {
+    case 'idle': return 'Ready to mine your free NIM.';
+    case 'loading-config': return 'Reading server config…';
+    case 'solving-hashcash': return `Proof-of-work: ${props.hashcashAttempts.toLocaleString()} attempts…`;
+    case 'submitting': return 'Submitting claim to the faucet…';
+    case 'broadcast': return 'Broadcast — waiting for confirmation…';
+    case 'confirmed': return 'Confirmed! Welcome to Nimiq.';
+    case 'rejected': return props.errorMessage ?? 'Claim rejected.';
+    case 'error': return props.errorMessage ?? 'Something went wrong.';
+    default: return '';
+  }
+});
+
+const tone = computed<'idle' | 'busy' | 'good' | 'bad'>(() => {
+  if (props.phase === 'confirmed') return 'good';
+  if (props.phase === 'rejected' || props.phase === 'error') return 'bad';
+  if (props.phase === 'idle' || props.phase === 'loading-config') return 'idle';
+  return 'busy';
+});
+</script>
+
+<template>
+  <div class="status-bar" :data-tone="tone">
+    <span class="dot" />
+    <span class="msg">{{ message }}</span>
+    <span v-if="txId" class="tx">
+      tx
+      <a
+        :href="`https://nimiq-testnet.observer/transactions/${txId}`"
+        target="_blank"
+        rel="noopener"
+      >{{ txId.slice(0, 16) }}…</a>
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.status-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 1rem;
+  background: rgba(20, 23, 46, 0.6);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.status-bar[data-tone='busy']  .dot { background: var(--amber); animation: pulse-dot 1.2s infinite; }
+.status-bar[data-tone='good']  .dot { background: var(--success); }
+.status-bar[data-tone='bad']   .dot { background: var(--error); }
+.status-bar[data-tone='good']  { color: var(--success); border-color: rgba(111, 207, 151, 0.25); }
+.status-bar[data-tone='bad']   { color: var(--error);   border-color: rgba(235, 87, 87, 0.25); }
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.45; }
+}
+
+.tx {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  opacity: 0.85;
+  border-left: 1px solid var(--line);
+  padding-left: 0.6rem;
+  margin-left: 0.2rem;
+}
+</style>

--- a/apps/nimiq-pow-ui/src/components/WorldMap.vue
+++ b/apps/nimiq-pow-ui/src/components/WorldMap.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref } from 'vue';
+
+/**
+ * Decorative world-dot map + peer-pulse animation.
+ *
+ * Visual tribute to nimiq/web-miner. The old miner did real PoW + showed
+ * actual peer connections; this is purely decorative — pulses fire on a
+ * timer to suggest network activity. The faucet claim itself is a plain
+ * HTTP POST handled by `useClaim()` — none of this code path produces
+ * cryptographic work.
+ *
+ * Implementation: canvas with a coarse dot grid clipped (loosely) to a
+ * stylised continents bitmap. Every ~600 ms a few "peer" dots get a
+ * pulse animation (radial expand + fade); independently, occasional
+ * peer-to-peer lines fade in/out between random pairs.
+ */
+
+const canvas = ref<HTMLCanvasElement | null>(null);
+
+// Coarse 60-col × 24-row continents bitmap. 1 = land, 0 = sea. This is a
+// stylised silhouette — not geographically accurate, just enough to read
+// as "world map" at a glance. A nicer-looking version is a future polish.
+const LAND_BITMAP: ReadonlyArray<string> = [
+  '............................................................',
+  '..........###........................##........#####.......',
+  '........######.....#######........#######......######......',
+  '.......#########..##########.....#########....#########....',
+  '......##############################...####...##########...',
+  '.....##########################........###...############..',
+  '....##########################...........#...##############',
+  '....########################..............#..##############',
+  '....#####################...................##############.',
+  '....##################...................#################.',
+  '.....################......................##############..',
+  '......##############......................################.',
+  '.......#############.......................##############..',
+  '........############........................############...',
+  '.........###########..........................##########...',
+  '..........#########............................########....',
+  '...........#######...............................######....',
+  '...........######..................................####....',
+  '............####.....................................##....',
+  '.............###..............................#.....##.....',
+  '.............##..............................##....##......',
+  '..............#.............................###....#.......',
+  '..............##............................##.............',
+  '...............#.............................#.............',
+];
+
+interface Peer {
+  // Grid coords (col, row) of an active land dot.
+  col: number;
+  row: number;
+  // Active = currently pulsing; resets after the animation duration.
+  pulseStartedAt: number | null;
+}
+
+interface Link {
+  from: Peer;
+  to: Peer;
+  startedAt: number;
+}
+
+const PULSE_DURATION_MS = 1_400;
+const LINK_DURATION_MS = 2_400;
+const PULSE_SPAWN_INTERVAL_MS = 700;
+const LINK_SPAWN_INTERVAL_MS = 1_900;
+const ACTIVE_PEER_COUNT = 14;
+
+let rafId = 0;
+let resizeObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+  const c = canvas.value;
+  if (!c) return;
+  const ctx = c.getContext('2d');
+  if (!ctx) return;
+
+  // Hand-pick `ACTIVE_PEER_COUNT` random land dots as our "peers".
+  const landDots: { col: number; row: number }[] = [];
+  for (let row = 0; row < LAND_BITMAP.length; row++) {
+    const line = LAND_BITMAP[row];
+    if (!line) continue;
+    for (let col = 0; col < line.length; col++) {
+      if (line[col] === '#') landDots.push({ col, row });
+    }
+  }
+
+  const peers: Peer[] = [];
+  // Use a deterministic shuffle to keep the visual stable across hot reloads.
+  const shuffled = [...landDots].sort((a, b) => (a.col * 31 + a.row * 7) - (b.col * 31 + b.row * 7));
+  const stride = Math.max(1, Math.floor(shuffled.length / ACTIVE_PEER_COUNT));
+  for (let i = 0; i < ACTIVE_PEER_COUNT && i * stride < shuffled.length; i++) {
+    const dot = shuffled[i * stride];
+    if (!dot) continue;
+    peers.push({ col: dot.col, row: dot.row, pulseStartedAt: null });
+  }
+
+  const links: Link[] = [];
+
+  let lastPulseAt = 0;
+  let lastLinkAt = 0;
+
+  function resize() {
+    if (!c) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = c.getBoundingClientRect();
+    c.width = Math.floor(rect.width * dpr);
+    c.height = Math.floor(rect.height * dpr);
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+  resize();
+  resizeObserver = new ResizeObserver(resize);
+  resizeObserver.observe(c);
+
+  function tick(t: number) {
+    if (!c || !ctx) return;
+    const w = c.clientWidth;
+    const h = c.clientHeight;
+
+    // Cell sizing: fit the bitmap inside the canvas with some padding.
+    const cols = LAND_BITMAP[0]?.length ?? 60;
+    const rows = LAND_BITMAP.length;
+    const cell = Math.min(w / (cols + 2), h / (rows + 2));
+    const dotR = Math.max(1.2, cell * 0.22);
+    const offsetX = (w - cols * cell) / 2;
+    const offsetY = (h - rows * cell) / 2;
+
+    ctx.clearRect(0, 0, w, h);
+
+    // Dots — sea is faint, land is brighter. Peers are gold.
+    for (let row = 0; row < rows; row++) {
+      const line = LAND_BITMAP[row];
+      if (!line) continue;
+      for (let col = 0; col < cols; col++) {
+        const isLand = line[col] === '#';
+        const cx = offsetX + (col + 0.5) * cell;
+        const cy = offsetY + (row + 0.5) * cell;
+        ctx.beginPath();
+        ctx.arc(cx, cy, dotR, 0, Math.PI * 2);
+        ctx.fillStyle = isLand ? 'rgba(245, 246, 250, 0.42)' : 'rgba(158, 163, 199, 0.10)';
+        ctx.fill();
+      }
+    }
+
+    // Spawn pulses at intervals.
+    if (t - lastPulseAt > PULSE_SPAWN_INTERVAL_MS) {
+      const idx = Math.floor(Math.random() * peers.length);
+      const peer = peers[idx];
+      if (peer) peer.pulseStartedAt = t;
+      lastPulseAt = t;
+    }
+
+    // Draw peer dots (gold) + ongoing pulses.
+    for (const peer of peers) {
+      const cx = offsetX + (peer.col + 0.5) * cell;
+      const cy = offsetY + (peer.row + 0.5) * cell;
+      ctx.beginPath();
+      ctx.arc(cx, cy, dotR * 1.4, 0, Math.PI * 2);
+      ctx.fillStyle = '#F6AE2D';
+      ctx.fill();
+
+      if (peer.pulseStartedAt !== null) {
+        const age = t - peer.pulseStartedAt;
+        if (age > PULSE_DURATION_MS) {
+          peer.pulseStartedAt = null;
+        } else {
+          const p = age / PULSE_DURATION_MS;
+          const r = dotR * 1.4 + p * cell * 4;
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, 0, Math.PI * 2);
+          ctx.strokeStyle = `rgba(255, 177, 13, ${(1 - p) * 0.6})`;
+          ctx.lineWidth = 1.2;
+          ctx.stroke();
+        }
+      }
+    }
+
+    // Spawn p2p links occasionally.
+    if (t - lastLinkAt > LINK_SPAWN_INTERVAL_MS && peers.length >= 2) {
+      const a = peers[Math.floor(Math.random() * peers.length)];
+      let b = peers[Math.floor(Math.random() * peers.length)];
+      let attempts = 0;
+      while (b === a && attempts < 5) {
+        b = peers[Math.floor(Math.random() * peers.length)];
+        attempts++;
+      }
+      if (a && b && a !== b) links.push({ from: a, to: b, startedAt: t });
+      lastLinkAt = t;
+    }
+
+    // Draw + age-out links.
+    for (let i = links.length - 1; i >= 0; i--) {
+      const link = links[i];
+      if (!link) continue;
+      const age = t - link.startedAt;
+      if (age > LINK_DURATION_MS) {
+        links.splice(i, 1);
+        continue;
+      }
+      const p = age / LINK_DURATION_MS;
+      const alpha = p < 0.5 ? p * 2 * 0.55 : (1 - p) * 2 * 0.55;
+      const ax = offsetX + (link.from.col + 0.5) * cell;
+      const ay = offsetY + (link.from.row + 0.5) * cell;
+      const bx = offsetX + (link.to.col + 0.5) * cell;
+      const by = offsetY + (link.to.row + 0.5) * cell;
+      ctx.beginPath();
+      ctx.moveTo(ax, ay);
+      // Slight quadratic bezier so lines don't look like a wireframe.
+      const mx = (ax + bx) / 2;
+      const my = (ay + by) / 2 - cell * 1.5;
+      ctx.quadraticCurveTo(mx, my, bx, by);
+      ctx.strokeStyle = `rgba(255, 177, 13, ${alpha})`;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    rafId = requestAnimationFrame(tick);
+  }
+  rafId = requestAnimationFrame(tick);
+});
+
+onBeforeUnmount(() => {
+  if (rafId) cancelAnimationFrame(rafId);
+  resizeObserver?.disconnect();
+});
+</script>
+
+<template>
+  <div class="world-map">
+    <canvas ref="canvas" />
+  </div>
+</template>
+
+<style scoped>
+.world-map {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+</style>

--- a/apps/nimiq-pow-ui/src/composables/useClaim.ts
+++ b/apps/nimiq-pow-ui/src/composables/useClaim.ts
@@ -1,0 +1,108 @@
+import { reactive, ref } from 'vue';
+import { FaucetClient, type FaucetConfig, type ClaimResponse } from '@nimiq-faucet/sdk';
+
+/**
+ * NimiqPoW theme's claim composable. Bypasses `useFaucetClaim` because
+ * we want to interleave hashcash + captcha prep before the actual
+ * claim — same pattern used in examples/vue-claim-page after the
+ * §3.0.7 abuse-layer integration. The visual peer-mining loop is
+ * decorative; this is the real claim flow.
+ */
+
+export type Phase =
+  | 'idle'
+  | 'loading-config'
+  | 'submitting'
+  | 'solving-hashcash'
+  | 'broadcast'
+  | 'confirmed'
+  | 'rejected'
+  | 'error';
+
+export interface ClaimState {
+  phase: Phase;
+  txId: string | null;
+  errorMessage: string | null;
+  hashcashAttempts: number;
+}
+
+export function useClaim() {
+  const faucetUrl = import.meta.env.VITE_FAUCET_URL || window.location.origin;
+  const client = new FaucetClient({ url: faucetUrl });
+
+  const config = ref<FaucetConfig | null>(null);
+  const state = reactive<ClaimState>({
+    phase: 'loading-config',
+    txId: null,
+    errorMessage: null,
+    hashcashAttempts: 0,
+  });
+  let inFlight = false;
+
+  void client.config().then(
+    (cfg) => {
+      config.value = cfg;
+      state.phase = 'idle';
+    },
+    (err) => {
+      state.phase = 'error';
+      state.errorMessage = err instanceof Error ? err.message : String(err);
+    },
+  );
+
+  async function claim(address: string): Promise<void> {
+    if (inFlight) return;
+    if (!address.trim()) return;
+    inFlight = true;
+    state.errorMessage = null;
+    state.txId = null;
+    state.hashcashAttempts = 0;
+
+    try {
+      let result: ClaimResponse;
+      if (config.value?.hashcash) {
+        state.phase = 'solving-hashcash';
+        result = await client.solveAndClaim(address.trim(), {
+          uid: 'nimiq-pow-ui',
+          hostContext: { uid: 'nimiq-pow-ui' },
+          onProgress: (n) => {
+            state.hashcashAttempts = n;
+          },
+        });
+      } else {
+        state.phase = 'submitting';
+        result = await client.claim(address.trim(), {
+          hostContext: { uid: 'nimiq-pow-ui' },
+        });
+      }
+      state.phase = 'submitting';
+      state.txId = result.txId ?? null;
+      if (result.status === 'rejected' || result.status === 'challenged') {
+        state.phase = 'rejected';
+        state.errorMessage = result.reason ?? 'Claim rejected';
+        return;
+      }
+      state.phase = 'broadcast';
+      const final = await client.waitForConfirmation(result.id);
+      state.txId = final.txId ?? state.txId;
+      state.phase = final.status === 'confirmed' ? 'confirmed' : 'rejected';
+      if (final.status === 'rejected' && final.reason) {
+        state.errorMessage = final.reason;
+      }
+    } catch (err) {
+      state.phase = 'error';
+      state.errorMessage = err instanceof Error ? err.message : String(err);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  function reset(): void {
+    state.phase = config.value ? 'idle' : 'loading-config';
+    state.txId = null;
+    state.errorMessage = null;
+    state.hashcashAttempts = 0;
+  }
+
+  return { config, state, claim, reset };
+}

--- a/apps/nimiq-pow-ui/src/env.d.ts
+++ b/apps/nimiq-pow-ui/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FAUCET_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/nimiq-pow-ui/src/main.ts
+++ b/apps/nimiq-pow-ui/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './styles.css';
+
+createApp(App).mount('#app');

--- a/apps/nimiq-pow-ui/src/styles.css
+++ b/apps/nimiq-pow-ui/src/styles.css
@@ -1,0 +1,65 @@
+/* Nimiq PoW theme — visual tribute to nimiq/web-miner.
+   Brand palette:
+     --navy:    #1F2348   (primary background, deep)
+     --navy-2:  #2A2F5A   (panel surface)
+     --gold:    #F6AE2D   (accent, claim CTA)
+     --amber:   #FFB10D   (peer pulses, hover)
+     --text:    #F5F6FA   (primary text)
+     --muted:   #9EA3C7   (secondary text) */
+
+:root {
+  --navy: #1F2348;
+  --navy-2: #2A2F5A;
+  --navy-3: #14172E;
+  --gold: #F6AE2D;
+  --amber: #FFB10D;
+  --text: #F5F6FA;
+  --muted: #9EA3C7;
+  --success: #6FCF97;
+  --error: #EB5757;
+  --line: rgba(245, 246, 250, 0.08);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body, #app {
+  width: 100%;
+  min-height: 100vh;
+  background: var(--navy-3);
+  color: var(--text);
+  font-family: 'Mulish', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  overflow-x: hidden;
+}
+
+body {
+  background:
+    radial-gradient(ellipse at top, rgba(31, 35, 72, 0.9) 0%, rgba(20, 23, 46, 1) 60%),
+    var(--navy-3);
+}
+
+a {
+  color: var(--gold);
+  text-decoration: none;
+}
+a:hover { color: var(--amber); }
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  transition: background-color 120ms ease, transform 120ms ease, opacity 120ms ease;
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+input {
+  font-family: 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+}

--- a/apps/nimiq-pow-ui/tsconfig.json
+++ b/apps/nimiq-pow-ui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true,
+    "types": ["vite/client"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}

--- a/apps/nimiq-pow-ui/vite.config.ts
+++ b/apps/nimiq-pow-ui/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+const faucetPort = process.env.FAUCET_PORT ?? '8080';
+const httpTarget = `http://localhost:${faucetPort}`;
+const wsTarget = `ws://localhost:${faucetPort}`;
+
+export default defineConfig({
+  plugins: [vue()],
+  base: '/',
+  build: {
+    target: 'es2022',
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: process.env.NODE_ENV !== 'production',
+  },
+  server: {
+    port: 5174,
+    proxy: {
+      '/v1': { target: httpTarget, changeOrigin: true },
+      '/v1/stream': { target: wsTarget, ws: true, changeOrigin: true },
+    },
+  },
+});

--- a/apps/server/src/themes.ts
+++ b/apps/server/src/themes.ts
@@ -37,6 +37,13 @@ export const THEMES = {
     distFromRepoRoot: 'apps/claim-ui/dist',
     distInImage: '/app/themes/porcelain-vault/dist',
   },
+  'nimiq-pow': {
+    displayName: 'Nimiq PoW',
+    description:
+      'Visual tribute to the original nimiq/web-miner — world-dot map + peer-pulse animation, dark navy. Decorative; the claim is plain HTTP.',
+    distFromRepoRoot: 'apps/nimiq-pow-ui/dist',
+    distInImage: '/app/themes/nimiq-pow/dist',
+  },
 } as const satisfies Record<string, ThemeManifest>;
 
 export type ThemeSlug = keyof typeof THEMES;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,28 @@ importers:
         specifier: ^3.5.33
         version: 3.5.33(typescript@5.9.3)
 
+  apps/nimiq-pow-ui:
+    dependencies:
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      vue:
+        specifier: ^3.5.33
+        version: 3.5.33(typescript@5.9.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.6
+        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ^2.1.6
+        version: 2.2.12(typescript@5.9.3)
+
   apps/playground:
     devDependencies:
       vitepress:


### PR DESCRIPTION
Visual tribute to the original [`nimiq/web-miner`](https://github.com/nimiq/web-miner) (live at [miner.nimiq-testnet.com](https://miner.nimiq-testnet.com/)). Animated world-dot map + peer-pulse animation, dark-navy palette, claim-NIM CTA at the bottom. Registered in the theme registry from #147 as `nimiq-pow`.

## What's in the box

| File | Purpose |
|---|---|
| `apps/nimiq-pow-ui/src/App.vue` | Layout: header + hero panel + map background + footer |
| `apps/nimiq-pow-ui/src/components/WorldMap.vue` | Canvas dot grid (60×24 continents bitmap) + peer-pulse animation + quadratic-bezier p2p link lines |
| `apps/nimiq-pow-ui/src/components/ConnectWallet.vue` | Paste-address input with shape validation. Hub-API integration is roadmap §3.0.15. |
| `apps/nimiq-pow-ui/src/components/ClaimButton.vue` | Gold pulsing CTA |
| `apps/nimiq-pow-ui/src/components/StatusBar.vue` | Phase / tx / error display with tx-explorer link |
| `apps/nimiq-pow-ui/src/components/FooterBar.vue` | \"Built with love by Richy\" + GitHub + web-miner credit |
| `apps/nimiq-pow-ui/src/composables/useClaim.ts` | Wraps `FaucetClient`, runs `solveAndClaim` when the server has hashcash configured |

Vue 3 + Vite, **no Tailwind** (deliberate — different aesthetic from the Porcelain Vault default; plain CSS keeps deps light). Picked up by the workspace's `apps/*` glob automatically.

## Switch to it

```bash
# Local dev (after PR #4)
FAUCET_CLAIM_UI_THEME=nimiq-pow pnpm --filter @faucet/server start

# Today (early-adopter, manual override path that's always supported)
FAUCET_CLAIM_UI_DIR=$(pwd)/apps/nimiq-pow-ui/dist pnpm --filter @faucet/server start

# Docker (after PR #4 lands)
docker run -e FAUCET_CLAIM_UI_THEME=nimiq-pow ghcr.io/panoramicrum/nimiq-simple-faucet:latest
```

## Decorative — not a real miner

The old web-miner ran actual PoW in the browser. **This theme does not.** The visualization is decorative; the claim is the same plain HTTP call every other theme uses. This is called out in the plan and the README as a hard \"will not be implemented\" item — the faucet is the source of NIM, not the user's CPU.

## Verification

```
✅ pnpm turbo run build --filter @nimiq-faucet/nimiq-pow-ui
   → dist/index.html 0.52 KB / dist/assets/index-*.css 5.51 KB / dist/assets/index-*.js 74.87 KB (29.29 KB gz)
✅ pnpm --filter @faucet/server test
   → 136 tests passing (was 135; +1 from the parameterized manifest check picking up the new theme)
```

## Roadmap follow-ups

- **§3.0.15** — Hub-API wallet integration to replace paste-address (filed when #147 landed).
- **§3.0.16** — User-facing theme picker dropdown (nice-to-have, filed).
- **PR #4** of this rollout — Docker multi-theme bundling so `FAUCET_CLAIM_UI_THEME` works without `FAUCET_CLAIM_UI_DIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)