### PR TITLE
fix(playground): skip YAML frontmatter in /abuse-layers/ include

### DIFF
--- a/apps/playground/abuse-layers/index.md
+++ b/apps/playground/abuse-layers/index.md
@@ -2,4 +2,10 @@
 outline: deep
 ---
 
-<!--@include: ../../../docs/abuse-layers/README.md{59,}-->
+<!--
+  The source has 63 lines of YAML frontmatter (a `layers:` data array
+  consumed by the playground's layer-summary widget). Start the include
+  at the H1 (line 65) so the frontmatter doesn't bleed into the page
+  as raw text. Re-count if the layers array grows.
+-->
+<!--@include: ../../../docs/abuse-layers/README.md{65,}-->


### PR DESCRIPTION
The deployed playground at [faucetplayground.wevpage.com/abuse-layers/](https://faucetplayground.wevpage.com/abuse-layers/) was rendering raw YAML above the H1:

> name: AI Anomaly Scoring
> details: \"Deterministic rules engine with optional ONNX classifier hook.\"
> enabledBy: \"FAUCET_AI_ENABLED\"
> link: /abuse-layers/ai-scoring

## Root cause

[`apps/playground/abuse-layers/index.md`](apps/playground/abuse-layers/index.md) does:

```html
<!--@include: ../../../docs/abuse-layers/README.md{59,}-->
```

But the source [`docs/abuse-layers/README.md`](docs/abuse-layers/README.md) has **63 lines of YAML frontmatter** (the `layers:` data array consumed by the playground's layer-summary widget). Line 59 is INSIDE that frontmatter — at item #10 (AI Anomaly Scoring). The include was pulling in the tail of item #10 plus the closing `---` fence; both rendered as plain text above the H1.

## Fix

Bump the include start line to 65 (the H1) and leave a comment so future maintainers re-count when the layers array grows.

```diff
-<!--@include: ../../../docs/abuse-layers/README.md{59,}-->
+<!--
+  The source has 63 lines of YAML frontmatter (a \`layers:\` data array
+  consumed by the playground's layer-summary widget). Start the include
+  at the H1 (line 65) so the frontmatter doesn't bleed into the page
+  as raw text. Re-count if the layers array grows.
+-->
+<!--@include: ../../../docs/abuse-layers/README.md{65,}-->
```

## Verification

I checked the other 5 \`@include\` directives in [apps/playground/](apps/playground/) — they all use \`{2,}\` against doc files that have no frontmatter, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)