### PR TITLE
chore(deps): bump zod 3.25.76 → 4.4.1 + zod-to-openapi 7 → 8

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -47,7 +47,7 @@
     "prom-client": "^15.1.3",
     "undici": "^8.1.0",
     "yaml": "^2.6.0",
-    "zod": "^3.23.8"
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,7 @@
     "freeze:openapi": "tsx scripts/freeze-openapi.ts"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.3.0",
+    "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@fastify/cookie": "^11.0.1",
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -38,7 +38,7 @@ export const FingerprintDTO = registry.register(
   z.object({
     visitorId: z.string().optional(),
     confidence: z.number().min(0).max(1).optional(),
-    components: z.record(z.unknown()).optional(),
+    components: z.record(z.string(), z.unknown()).optional(),
   }),
 );
 
@@ -124,8 +124,8 @@ export const StatsResponse = registry.register(
   'StatsResponse',
   z.object({
     total: z.number().int(),
-    byStatus: z.record(z.number().int()),
-    byDecision: z.record(z.number().int()),
+    byStatus: z.record(z.string(), z.number().int()),
+    byDecision: z.record(z.string(), z.number().int()),
   }),
 );
 
@@ -242,7 +242,7 @@ export const AuditEntry = registry.register(
     action: z.string(),
     target: z.string().nullable(),
     // NOTE: signals shape will be tightened as admin actions stabilise.
-    signals: z.record(z.unknown()),
+    signals: z.record(z.string(), z.unknown()),
   }),
 );
 
@@ -283,9 +283,9 @@ export const AdminConfigResponse = registry.register(
       rateLimitPerIpPerDay: z.number().int(),
       abuseDenyThreshold: z.number(),
       abuseReviewThreshold: z.number(),
-      layers: z.record(z.boolean()),
+      layers: z.record(z.string(), z.boolean()),
     }),
-    overrides: z.record(z.unknown()),
+    overrides: z.record(z.string(), z.unknown()),
   }),
 );
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "typescript": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   apps/server:
     dependencies:
       '@asteasolutions/zod-to-openapi':
-        specifier: ^7.3.0
-        version: 7.3.4(zod@4.4.1)
+        specifier: ^8.5.0
+        version: 8.5.0(zod@4.4.1)
       '@fastify/cookie':
         specifier: ^11.0.1
         version: 11.0.2
@@ -798,10 +798,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@asteasolutions/zod-to-openapi@7.3.4':
-    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
-      zod: ^3.20.2
+      zod: ^4.0.0
 
   '@axe-core/playwright@4.11.2':
     resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
@@ -6068,7 +6068,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@asteasolutions/zod-to-openapi@7.3.4(zod@4.4.1)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.4.1)':
     dependencies:
       openapi3-ts: 4.5.0
       zod: 4.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
     dependencies:
       '@asteasolutions/zod-to-openapi':
         specifier: ^7.3.0
-        version: 7.3.4(zod@3.25.76)
+        version: 7.3.4(zod@4.4.1)
       '@fastify/cookie':
         specifier: ^11.0.1
         version: 11.0.2
@@ -217,7 +217,7 @@ importers:
         version: link:../../packages/driver-nimiq-wasm
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.1)
       '@noble/ciphers':
         specifier: ^2.2.0
         version: 2.2.0
@@ -238,7 +238,7 @@ importers:
         version: 5.8.5
       fastify-type-provider-zod:
         specifier: ^4.0.2
-        version: 4.0.2(fastify@5.8.5)(zod@3.25.76)
+        version: 4.0.2(fastify@5.8.5)(zod@4.4.1)
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -261,8 +261,8 @@ importers:
         specifier: ^2.6.0
         version: 2.8.3
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.1
+        version: 4.4.1
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.11
@@ -575,8 +575,8 @@ importers:
   packages/core:
     dependencies:
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.1
+        version: 4.4.1
     devDependencies:
       typescript:
         specifier: ^5.6.2
@@ -5944,6 +5944,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -6065,10 +6068,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@4.4.1)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.4.1
 
   '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
     dependencies:
@@ -6949,7 +6952,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.1)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.15)
       ajv: 8.18.0
@@ -6966,8 +6969,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8906,12 +8909,12 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-type-provider-zod@4.0.2(fastify@5.8.5)(zod@3.25.76):
+  fastify-type-provider-zod@4.0.2(fastify@5.8.5)(zod@4.4.1):
     dependencies:
       '@fastify/error': 4.2.0
       fastify: 5.8.5
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
 
   fastify@5.8.5:
     dependencies:
@@ -11703,10 +11706,12 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.4.1):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.1
 
   zod@3.25.76: {}
+
+  zod@4.4.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

Supersedes #164. Includes Dependabot's zod 4 bump plus the two compat changes the workspace needed:

- **`apps/server/src/openapi/schemas.ts`**: migrate 6 `z.record()` call sites from v3's single-arg shape to v4's `(keySchema, valueSchema)`:
  - `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`
  - `z.record(z.number().int())` → `z.record(z.string(), z.number().int())`
  - `z.record(z.boolean())` → `z.record(z.string(), z.boolean())`
- **`apps/server/package.json`**: bump `@asteasolutions/zod-to-openapi` `^7.3.0` → `^8.5.0`. v7 has a hard peer-dep gate on `zod ^3.x`; v8 is the `zod ^4` compatible major. Without this, `GET /openapi.json` 500'd because the v7 generator threw on the v4 schema shapes.

## Test plan

- [x] `pnpm --filter @faucet/server build` clean
- [x] `pnpm --filter @faucet/server test` — 146/146 pass (vs. 145/146 before the `zod-to-openapi` bump, where only `openapi.e2e` `/openapi.json` failed)
- [x] Full workspace `pnpm build` green (27/27 tasks)
- [ ] CI green here

After merge: close #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)