### PR TITLE
chore(dependabot): ignore otplib major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,19 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # otplib v13 redesigned the API entirely (no more `authenticator`
+      # export; replaced by TOTP/HOTP classes + generate/verify functions).
+      # The repo only uses `otplib` in `tests/e2e/helpers/server.ts` to
+      # mint deterministic 6-digit codes for the admin login flow; runtime
+      # admin auth uses `@otplib/preset-default` directly. We've reviewed
+      # PR #162 and decided not to migrate now — the e2e helper would need
+      # a real rewrite for marginal value. A separate cleanup PR can drop
+      # the `otplib` umbrella entirely by switching the helper to
+      # `@otplib/preset-default` (matching runtime), at which point this
+      # ignore can come out.
+      - dependency-name: "otplib"
+        update-types: [ "version-update:semver-major" ]
 
   - package-ecosystem: github-actions
     directory: /

--- a/docs/quality/wasm-time-panic-maintainer-reply-2026-04-27.md
+++ b/docs/quality/wasm-time-panic-maintainer-reply-2026-04-27.md
@@ -1,0 +1,44 @@
+# Replies to `core-rs-albatross` maintainer — 2026-04-27
+
+**Context**: WASM `'time not implemented on this platform'` panic in `@nimiq/core` 2.4.0. Maintainer confirmed the regression, then identified the fix in [nimiq/core-rs-albatross#3729](https://github.com/nimiq/core-rs-albatross/pull/3729) (`OffsetTime: use instant::SystemTime to avoid wasm32 panic`).
+
+Related: [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119), [upstream report](./wasm-time-panic-upstream-report.md).
+
+---
+
+## Reply 1 — bisect coordinates (sent after the maintainer reproduced on 2.4.0 and identified it as a regression)
+
+That narrows it nicely. Two things that may help further:
+
+**There's a 2.3.0 gap on npm.** The version chain on npm is `2.2.0 → 2.2.1 → 2.2.2 → 2.4.0` — no `2.3.0` was ever published. So the actual last-known-good is `2.2.2`, not `2.2.0`. Worth re-confirming `2.2.2` is clean before you go too deep.
+
+**Cross-referencing `gitHead` from each npm publish to your tags**:
+
+| npm       | upstream tag | sha          | published   |
+|-----------|--------------|--------------|-------------|
+| `2.2.2`   | `v1.2.2`     | `119adae2f3` | 2026-02-27  |
+| _(none)_  | `v1.3.0`     | `5bd15d9af7` | 2026-03-27  |
+| `2.4.0`   | `v1.4.0`     | `e156ecc4a1` | 2026-04-22  |
+
+Bisect window is **`v1.2.2..v1.4.0`** — 68 commits / 128 files. `v1.3.0` is a natural midpoint (`v1.2.2..v1.3.0` = 28 commits, `v1.3.0..v1.4.0` = 40), so a single WASM build at `v1.3.0` halves the search.
+
+Three concrete asks if any are useful to you:
+
+1. We can pin our project to `2.2.2` and run our smoke job 10× to confirm `2.2.2` is panic-free in the same environment that hits ~30% on `2.4.0` — independent confirmation of your repro.
+2. If you can publish (or hand us a tarball of) a WASM build from `v1.3.0`, we'll run it through the same job and tell you which side panics — that splits the bisect in half in one round.
+3. Same offer for any candidate fix.
+
+---
+
+## Reply 2 — acknowledging PR #3729 + commit to test the candidate
+
+Thank you — clean fix, and the analysis lines up perfectly with what we'd seen from the on-disk bundle. `nodejs/main-wasm/index.js` ships zero `__wbg_now_*` / `Date.now` / `performance.now` shims (vs. 5 in `worker-wasm`), so any `std::time::SystemTime::now()` callsite reached from main-wasm code paths panics on `wasm32-unknown-unknown`. Drift validation being added to the light-blockchain sync path explains the "always shortly after `Requesting zkp from peer`" pattern in the panic logs cleanly.
+
+We'll do two runs and report back:
+
+1. **`@nimiq/core@2.2.2` baseline** — pin our project to `2.2.2` and run our smoke job 10× to give you independent confirmation it's panic-free under the same environment that hits ~30% on `2.4.0`.
+2. **`pkg.pr.new/@nimiq/core@3729` candidate** — same job, 10×. If the panic rate drops to 0/10, that's a strong signal for merge. Happy to extend to 50 or 100 boots if a higher-confidence number would help.
+
+Will post results in this thread (or directly on PR #3729, whichever you prefer).
+
+In the meantime we'll flip our public docs to recommend `2.2.2` as the workaround instead of "use the RPC driver", with a pointer to PR #3729 for the proper fix.

--- a/docs/quality/wasm-time-panic-maintainer-reply-2026-04-30.md
+++ b/docs/quality/wasm-time-panic-maintainer-reply-2026-04-30.md
@@ -1,0 +1,43 @@
+# Reply to `core-rs-albatross` maintainer — 2026-04-30
+
+**Context**: WASM `'time not implemented on this platform'` panic in `@nimiq/core` 2.4.0. Maintainer's fix [PR #3729](https://github.com/nimiq/core-rs-albatross/pull/3729) (`OffsetTime: use instant::SystemTime to avoid wasm32 panic`) merged 2026-04-28 (commit `9789c532148994352a70e5f5231e44d2c348913c`). This file records the smoke-matrix results we promised in the [2026-04-27 reply](./wasm-time-panic-maintainer-reply-2026-04-27.md) (Reply 2).
+
+Related: [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119), [upstream report](./wasm-time-panic-upstream-report.md).
+
+---
+
+## Reply 3 — smoke-matrix results (PR #3729 merged → testing baseline + candidate)
+
+Thanks again for the quick turnaround on PR #3729. The fix merged on 2026-04-28; we ran the matrix we'd promised in the previous reply against the same Docker smoke harness CI uses (deploy/docker/Dockerfile + .github/workflows/ci.yml's smoke job, modified to keep each container alive 120s past `/healthz` so the post-handshake panic window is actually exercised — the original CI shape was racing healthz against the panic and exiting early on the surviving 70%).
+
+**Environment**: Linux Mint 22.3 (kernel 6.8.0-110-generic), x86_64, 8-core, 33 GB RAM. Docker 29.1.3. node:22-bookworm-slim base. Image built from `deploy/docker/Dockerfile` with the `@nimiq/core` pin swapped per matrix row. Each boot ran `FAUCET_SIGNER_DRIVER=wasm` against TestAlbatross seed1, 120s exposure window, fresh container per run.
+
+### Results
+
+| Pin                                          | healthz_ok | panic | Notes |
+|----------------------------------------------|-----------:|------:|-------|
+| `@nimiq/core@2.2.2` (baseline)               | 10/10 | 0/10 | Every boot reached `Consensus established` and survived the full 120s exposure. |
+| `pkg.pr.new/@nimiq/core@3729` (candidate)    | 10/10 | 0/10 | Same — clean across the same harness. |
+
+For comparison: the original repro on `@nimiq/core@2.4.0` was ~3-of-10 boots (the "~30%" we'd reported). Both bundles tested above produced **zero** `'time not implemented on this platform'` panics across 10 boots × 120s exposure each — they reached `Consensus established`, the surviving 70% of the original 2.4.0 baseline made it past `Requesting zkp from peer`, and we held containers alive for ~90s past that point to catch any mid-flight panic. Independent confirmation that 2.2.2 is panic-free, and a 0/10 first signal for the candidate fix.
+
+WASM bundle SHAs (sanity-check that pkg.pr.new actually shipped a new bundle, not a fall-through to npm 2.4.0):
+
+| Pin                                       | `nodejs/worker-wasm/index_bg.wasm` SHA-256 |
+|-------------------------------------------|--------------------------------------------|
+| `@nimiq/core@2.4.0` (npm, broken)         | `b59394305f2adf78276a0b21ac6d424b4e61ad71eb629559d1a8aae88e7ac5f3` |
+| `@nimiq/core@2.2.2` (npm, last-known-good)| `baee5f7dc4b85610e467339fe5e428fbdec3623a0b648a2eabf046376a9862b7` |
+| `pkg.pr.new/@nimiq/core@3729` (candidate) | `b2d186ff9f982d1d26d611830754cd59808d4f170ab1f8c4313c6dc5d271712b` |
+
+All three are distinct, so we're testing what we think we're testing.
+
+### Next steps on our side
+
+Once a post-fix `@nimiq/core` release lands on npm (currently `latest = 2.4.0`, gitHead `e156ecc4...`, pre-fix), we'll:
+
+1. Bump `^2.4.0` → the post-fix release in [`package.json`](../../package.json) and [`packages/driver-nimiq-wasm/package.json`](../../packages/driver-nimiq-wasm/package.json).
+2. Drop the panic-string filter we added to our CI smoke job (lines 122-136 of [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)) so any future occurrence is a hard CI failure again.
+3. Revert our README + production-deployment "use `FAUCET_SIGNER_DRIVER=rpc` for production" callouts back to recommending WASM as the default.
+4. Close [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119) with a link to the bump PR.
+
+Happy to extend the matrix to 50 or 100 boots per pin if a higher-confidence number would help — or to test additional candidate builds. Just say the word.

--- a/docs/quality/wasm-time-panic-upstream-report.md
+++ b/docs/quality/wasm-time-panic-upstream-report.md
@@ -1,14 +1,24 @@
 # Upstream report: `@nimiq/core` WASM panics with `'time not implemented on this platform'`
 
-**Status**: open against this repo as [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119); not yet filed upstream.
+**Status (2026-04-30)**: upstream fix [nimiq/core-rs-albatross#3729](https://github.com/nimiq/core-rs-albatross/pull/3729) (`OffsetTime: use instant::SystemTime to avoid wasm32 panic`) **MERGED 2026-04-28** at commit `9789c532148994352a70e5f5231e44d2c348913c`. We ran a 10× × 120s smoke matrix locally against `@nimiq/core@2.2.2` (last-known-good baseline) and `pkg.pr.new/@nimiq/core@3729` (candidate fix) — both cleared 0/10 panics versus ~3/10 on the broken `2.4.0` (results in §"Smoke matrix results (2026-04-30)" below). Workaround for downstream consumers until npm ships the post-fix release: pin `@nimiq/core` to `2.2.2`. The post-fix npm release is not yet published — `latest` is still `2.4.0` (gitHead `e156ecc4...`); we'll bump our pin and revert the docs once that lands.
 
-**Hand-off target**: [`nimiq/core-rs-albatross`](https://github.com/nimiq/core-rs-albatross) (the `@nimiq/core` WASM client is built from this repo's web-client crate).
+**This repo**: tracked as [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119); replies sent to the maintainer are saved in [`wasm-time-panic-maintainer-reply-2026-04-27.md`](./wasm-time-panic-maintainer-reply-2026-04-27.md) and [`wasm-time-panic-maintainer-reply-2026-04-30.md`](./wasm-time-panic-maintainer-reply-2026-04-30.md).
 
-This file is the source-of-truth for the upstream report. The maintainer
-copies the §"Report body" section into a new `core-rs-albatross` issue
-and adds whatever `core-rs-albatross` triage requires (labels, milestone,
-linked PRs). Update this file when the upstream issue is filed and again
-when it's resolved.
+**Upstream**: [`nimiq/core-rs-albatross`](https://github.com/nimiq/core-rs-albatross) (the `@nimiq/core` WASM client is built from this repo's web-client crate). Discussion happened in a chat with a `core-rs-albatross` maintainer; we did not need to file a public issue because the maintainer triaged it directly.
+
+## Follow-up TODO (revisit in the near future)
+
+- [x] **Check whether [PR #3729](https://github.com/nimiq/core-rs-albatross/pull/3729) has merged.** Merged 2026-04-28 at commit `9789c532148994352a70e5f5231e44d2c348913c`.
+- [x] **Run the smoke job 10×** against:
+  - [x] `@nimiq/core@2.2.2` (baseline) — 0/10 panics (10/10 healthz_ok). 2026-04-30.
+  - [x] `pkg.pr.new/@nimiq/core@3729` (candidate fix) — 0/10 panics (10/10 healthz_ok). 2026-04-30.
+  - [ ] First post-fix `@nimiq/core` release on npm, once published — should be 0/10.
+- [ ] **Bump our pin** from `^2.4.0` → first post-fix release in [`package.json`](../../package.json) and [`packages/driver-nimiq-wasm/package.json`](../../packages/driver-nimiq-wasm/package.json). Blocked on npm release (`latest` is still `2.4.0`, gitHead `e156ecc4...` — pre-fix).
+- [ ] **Flip the docs back**: revert the README + `docs/deployment-production.md` notes that recommend `FAUCET_SIGNER_DRIVER=rpc`, and remove the WASM smoke-test-only callout. Blocked on the bump.
+- [ ] **Re-arm CI**: drop the panic-string filter in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) so the smoke job hard-fails on the panic again — once we trust WASM, it should be a real regression signal. Blocked on the bump.
+- [ ] **Close [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119)** with a link to the upstream PR and the version we bumped to. Blocked on the bump.
+
+This file remains the source-of-truth for the report. Update it when PR #3729 merges and again when this project bumps to the post-fix release.
 
 ---
 
@@ -202,3 +212,77 @@ When you file the upstream issue:
 - This repo: [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119) — keep open until upstream is resolved.
 - Upstream: _to be filled in once filed against `nimiq/core-rs-albatross`._
 - Workaround in CI: [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) downgrades the panic to a `::warning::` instead of failing the build.
+
+## On-disk confirmation (2026-04-27)
+
+After the maintainer confirmed they're investigating, we audited the
+actual `@nimiq/core` 2.4.0 bundle on disk. Time-shim symbol counts
+(`__wbg_now_*`, `Date.now`, `performance.now`) per bundle:
+
+| Bundle                               | Time shims | Size   |
+|--------------------------------------|-----------:|-------:|
+| `nodejs/main-wasm/index.js`          |          0 | 992 KB |
+| `nodejs/worker-wasm/index.js`        |          5 | 7.4 MB |
+| `web/main-wasm/index.js`             |          0 |        |
+| `web/worker-wasm/index.js`           |          1 |        |
+
+Both bundles are `wasm32-unknown-unknown` (otherwise no JS time shims
+would be needed). `worker-wasm` (the consensus/networking blob) has
+`web-time`-style shims wired via wasm-bindgen externs; `main-wasm`
+has none in either the Node or Web build.
+
+Any code path reaching `std::time::Instant::now()` /
+`SystemTime::now()` **directly** — i.e. not through a
+`web-time`-style wrapper — will link the stdlib's `unsupported` time
+backend on `wasm32-unknown-unknown` and panic with the exact message
+we observe. The intermittency is consistent with a callsite that
+only runs after a particular post-ZKP-handshake state is reached.
+
+**Suggested remediation patterns** (for upstream to validate):
+
+1. Replace `use std::time::{Instant, SystemTime}` with
+   `use web_time::{Instant, SystemTime}` across the workspace (or
+   add a `cargo patch` redirecting `instant` → `web-time`).
+2. For deps not owned by the workspace, add a
+   `[target.'cfg(target_arch = "wasm32")'.dependencies]` override.
+
+A grep for `std::time::Instant::now\|SystemTime::now` across
+`core-rs-albatross` + transitive deps that isn't already gated
+behind `cfg(not(target_arch = "wasm32"))` should turn up the
+offending callsite(s).
+
+---
+
+## Smoke matrix results (2026-04-30)
+
+After PR #3729 merged we ran a 10× × 120s smoke matrix locally to (a) give
+the maintainer independent confirmation that 2.2.2 is panic-free under
+the same harness that hits ~30% on 2.4.0, and (b) get a first signal on
+the candidate fix bundle from `pkg.pr.new`.
+
+**Harness**: `deploy/docker/Dockerfile` built per pin, then booted with
+the same env vars CI's `docker` smoke job uses. Modified vs CI: each
+container is held alive 120 s past `/healthz` so the post-handshake
+panic window is actually exercised — the original CI shape exits early
+on the surviving 70%, racing healthz against the panic. Per-boot we
+record healthz reachability and scan the container log for the panic
+string `time not implemented on this platform`.
+
+**Environment**: Linux Mint 22.3 (kernel 6.8.0-110), x86_64, 8 CPU,
+33 GB RAM, Docker 29.1.3. Pin swapped per worktree (`/tmp/faucet-smoke-2.2.2`
+and `/tmp/faucet-smoke-3729`) to avoid touching the working tree.
+
+| Pin                                          | healthz_ok | panic | Bundle SHA-256 (`nodejs/worker-wasm/index_bg.wasm`) |
+|----------------------------------------------|-----------:|------:|-----------------------------------------------------|
+| `@nimiq/core@2.4.0` (npm, broken — historical) | n/a (~7/10) | ~3/10 | `b59394305f2adf78276a0b21ac6d424b4e61ad71eb629559d1a8aae88e7ac5f3` |
+| `@nimiq/core@2.2.2` (npm, last-known-good)   | 10/10 | 0/10 | `baee5f7dc4b85610e467339fe5e428fbdec3623a0b648a2eabf046376a9862b7` |
+| `pkg.pr.new/@nimiq/core@3729` (candidate fix) | 10/10 | 0/10 | `b2d186ff9f982d1d26d611830754cd59808d4f170ab1f8c4313c6dc5d271712b` |
+
+All three bundles are distinct on disk, so we're testing what we think
+we're testing. Both the baseline and the candidate cleared the matrix
+with no panics, reaching `Consensus established` and surviving past
+`Requesting zkp from peer` in every boot.
+
+Once the post-fix npm release ships, we'll add a third row for it
+(also expected 0/10) and proceed with the bump → docs revert →
+CI panic-filter removal → close #119 sequence above.


### PR DESCRIPTION
## Summary

- Add `otplib` to Dependabot's `ignore` list for `version-update:semver-major`.
- otplib v13 is a complete API rewrite (no more `authenticator` namespace; replaced by `TOTP`/`HOTP` classes plus `generate`/`verify` functional helpers).
- The repo's runtime admin auth uses `@otplib/preset-default` (still v12, maintained); the umbrella `otplib` only appears in `tests/e2e/helpers/server.ts:1`. Migrating to v13 would mean rewriting both `apps/server/src/auth/session.ts` and 5 e2e test files for marginal value.
- Closes #162 (Bump otplib 12 → 13.4.0). Future cleanup: switch the e2e helper to `@otplib/preset-default` to match runtime, then this ignore can come out.

## Test plan

- [ ] CI green (yaml-only change)
- [ ] After merge: confirm Dependabot does not re-open #162 on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)