### PR TITLE
chore: drop umbrella otplib dep, switch e2e helper to @otplib/preset-default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,20 +19,6 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      # otplib v13 redesigned the API entirely (no more `authenticator`
-      # export; replaced by TOTP/HOTP classes + generate/verify functions).
-      # The repo only uses `otplib` in `tests/e2e/helpers/server.ts` to
-      # mint deterministic 6-digit codes for the admin login flow; runtime
-      # admin auth uses `@otplib/preset-default` directly. We've reviewed
-      # PR #162 and decided not to migrate now — the e2e helper would need
-      # a real rewrite for marginal value. A separate cleanup PR can drop
-      # the `otplib` umbrella entirely by switching the helper to
-      # `@otplib/preset-default` (matching runtime), at which point this
-      # ignore can come out.
-      - dependency-name: "otplib"
-        update-types: [ "version-update:semver-major" ]
-
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,9 @@ importers:
       '@faucet/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@otplib/preset-default':
+        specifier: ^12.0.1
+        version: 12.0.1
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.59.1
@@ -715,9 +718,6 @@ importers:
       fastify:
         specifier: ^5.0.0
         version: 5.8.5
-      otplib:
-        specifier: ^12.0.1
-        version: 12.0.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2001,9 +2001,6 @@ packages:
   '@otplib/preset-default@12.0.1':
     resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
     deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
-
-  '@otplib/preset-v11@12.0.1':
-    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -4579,9 +4576,6 @@ packages:
   openapi3-ts@4.5.0:
     resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
-  otplib@12.0.1:
-    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
-
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -7120,12 +7114,6 @@ snapshots:
       thirty-two: 1.0.2
 
   '@otplib/preset-default@12.0.1':
-    dependencies:
-      '@otplib/core': 12.0.1
-      '@otplib/plugin-crypto': 12.0.1
-      '@otplib/plugin-thirty-two': 12.0.1
-
-  '@otplib/preset-v11@12.0.1':
     dependencies:
       '@otplib/core': 12.0.1
       '@otplib/plugin-crypto': 12.0.1
@@ -9904,12 +9892,6 @@ snapshots:
   openapi3-ts@4.5.0:
     dependencies:
       yaml: 2.8.3
-
-  otplib@12.0.1:
-    dependencies:
-      '@otplib/core': 12.0.1
-      '@otplib/preset-default': 12.0.1
-      '@otplib/preset-v11': 12.0.1
 
   outdent@0.5.0: {}
 

--- a/tests/e2e/helpers/server.ts
+++ b/tests/e2e/helpers/server.ts
@@ -1,4 +1,4 @@
-import { authenticator } from 'otplib';
+import { authenticator } from '@otplib/preset-default';
 
 export { StubDriver } from '../fixtures/StubDriver.js';
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -10,10 +10,10 @@
     "@axe-core/playwright": "^4.11.2",
     "@faucet/abuse-hashcash": "workspace:*",
     "@faucet/core": "workspace:*",
+    "@otplib/preset-default": "^12.0.1",
     "@playwright/test": "^1.48.0",
     "@types/node": "^22.7.0",
     "fastify": "^5.0.0",
-    "otplib": "^12.0.1",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- Switch [tests/e2e/helpers/server.ts:1](tests/e2e/helpers/server.ts#L1) from `import { authenticator } from 'otplib'` to `import { authenticator } from '@otplib/preset-default'` — matches the runtime convention used in [apps/server/src/auth/session.ts:19](apps/server/src/auth/session.ts#L19) and 5 server e2e tests.
- Remove `otplib` from [tests/e2e/package.json](tests/e2e/package.json) (was the only consumer of the umbrella package).
- Revert the `otplib` ignore stanza added by #169 in [.github/dependabot.yml](.github/dependabot.yml) — with `otplib` gone from package.json, there's nothing for Dependabot to bump.
- Closes #162.

## Why this over #169's approach

#169 added a Dependabot ignore for otplib major bumps. That works, but leaves a redundant umbrella dep around forever and a special-case in `dependabot.yml`. Dropping the umbrella is one extra line of effort and removes both.

## Test plan

- [ ] CI green — server build, e2e helpers compile, lockfile valid
- [ ] After merge: confirm Dependabot doesn't re-open #162 (no `otplib` left to bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)