### PR TITLE
security(claim): uniform reject responses on /v1/claim — no abuse-layer leak

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -143,6 +143,57 @@ checked against `canonicalizeHostContext` (see
 | Integrator HMAC secrets    | Plaintext in DB — needed for symmetric verification. The DB is a sensitive-grade artefact; restrict filesystem access. |
 | Wallet private key         | XChaCha20-Poly1305 keyring blob when `FAUCET_KEY_PASSPHRASE` is set. RPC-driver deployments hold the key in the Nimiq node, not in the faucet's data dir. |
 
+### Public-API silence on rejection
+
+When the faucet rejects a `/v1/claim` request — for *any* reason: rate
+limit, blocklist, captcha failure, hashcash mismatch, GeoIP deny,
+fingerprint correlation, on-chain heuristic, AI scorer, soft-review
+fall-through — the **public response is uniform**:
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+
+{ "id": "<nanoid>", "status": "rejected" }
+```
+
+No `decision`, no `reason`, no `error`, no `code`, no `issues`. The
+response is byte-shape-identical regardless of which abuse layer fired,
+and `decision === "review"` collapses into the same 403 + body as a
+hard `deny` (no 202-vs-403 status-code split either).
+
+**Why**: revealing which layer rejected lets an attacker A/B-test their
+inputs until the rejection signal changes — that tells them they tripped
+a different gate, which is enough to enumerate and bypass the abuse
+pipeline. Distinguishing `deny` from `review` similarly leaks
+decision-class. Strict uniformity is the cheapest defence-in-depth here.
+
+The same principle applies to other public reject paths:
+- Zod-validation failures return `{ error: "invalid request" }` with no
+  `issues` field.
+- Integrator-auth failures return `{ error: "integrator auth failed" }`
+  with no per-reason detail.
+- Address-parse failures return `{ error: "invalid address" }` with no
+  underlying exception text.
+
+The `'browser_required'`, `'origin_not_allowed'`, `'claim_in_progress'`,
+and driver-side errors (`'invalid address'` on RPC -32602, `'send_failed'`)
+remain informative because they're documented gates with legitimate-client
+retry semantics, *or* they fire after the abuse pipeline approves so
+they're not abuse-layer attribution.
+
+**Operator visibility is unchanged.** The granular `decision`,
+`rejectionReason`, `signalsJson`, and per-layer scores stay in the
+`claims` DB row, in the Prometheus `claimsTotal{decision="..."}`
+counters, and on the admin endpoints under `/v1/admin/claims`. SDKs
+(`@nimiq-faucet/sdk` and the framework wrappers) intentionally don't
+expose `decision` / `reason` types on public reject responses; consumers
+infer "rejected" purely from `status === "rejected"`.
+
+If a future contributor wants to add diagnostic fields back to the
+public reject body, that is a security-relevant change that needs a
+threat-model review — please don't quietly re-add them.
+
 ### What we don't defend against
 
 - **Compromised integrator**. If an integrator's HMAC secret leaks, the

--- a/apps/claim-ui/src/components/ClaimStatus.vue
+++ b/apps/claim-ui/src/components/ClaimStatus.vue
@@ -83,7 +83,8 @@ function startTracking(id: string) {
         cleanup();
       } else if (s.status === 'rejected') {
         status.value = 'rejected';
-        reasonKey.value = mapReason(undefined, s.reason);
+        // Public reject body has no reason — uniform shape for all denials.
+        reasonKey.value = mapReason(undefined, undefined);
         cleanup();
       } else if (s.status === 'broadcast' && status.value !== 'confirmed') {
         status.value = 'broadcast';
@@ -118,7 +119,7 @@ watch(
     status.value = initial.status;
     txId.value = initial.txId ?? null;
     if (initial.status === 'rejected') {
-      reasonKey.value = mapReason(undefined, initial.reason);
+      reasonKey.value = mapReason(undefined, undefined);
       return;
     }
     if (initial.status === 'challenged') {

--- a/apps/nimiq-pow-ui/src/composables/useClaim.ts
+++ b/apps/nimiq-pow-ui/src/composables/useClaim.ts
@@ -79,15 +79,17 @@ export function useClaim() {
       state.txId = result.txId ?? null;
       if (result.status === 'rejected' || result.status === 'challenged') {
         state.phase = 'rejected';
-        state.errorMessage = result.reason ?? 'Claim rejected';
+        // Public reject responses are uniform — no reason is available.
+        // See SECURITY.md "Public-API silence on rejection".
+        state.errorMessage = 'Claim rejected';
         return;
       }
       state.phase = 'broadcast';
       const final = await client.waitForConfirmation(result.id);
       state.txId = final.txId ?? state.txId;
       state.phase = final.status === 'confirmed' ? 'confirmed' : 'rejected';
-      if (final.status === 'rejected' && final.reason) {
-        state.errorMessage = final.reason;
+      if (final.status === 'rejected') {
+        state.errorMessage = 'Claim rejected';
       }
     } catch (err) {
       state.phase = 'error';

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -60,9 +60,9 @@ export const ClaimResponse = registry.register(
   z.object({
     id: z.string(),
     status: z.enum(['broadcast', 'confirmed', 'rejected', 'challenged', 'timeout', 'expired', 'manual-allow']),
-    decision: z.enum(['allow', 'deny', 'review', 'challenge']).optional(),
+    // `decision` and `reason` intentionally omitted from the public reject
+    // response. See SECURITY.md "Public-API silence on rejection".
     txId: z.string().optional(),
-    reason: z.string().optional(),
   }),
 );
 
@@ -75,8 +75,9 @@ export const ClaimStatusResponse = registry.register(
     amountLuna: z.string(),
     txId: z.string().nullable(),
     createdAt: z.union([z.string(), z.number()]),
-    decision: z.string().nullable(),
-    rejectionReason: z.string().nullable(),
+    // `decision` and `rejectionReason` intentionally omitted from the
+    // public claim-status response. Operators retrieve granular abuse
+    // attribution via /v1/admin/claims (see ClaimListItem).
   }),
 );
 
@@ -135,7 +136,6 @@ export const ErrorResponse = registry.register(
     error: z.string(),
     code: z.string().optional(),
     message: z.string().optional(),
-    issues: z.array(z.unknown()).optional(),
   }),
 );
 

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -107,7 +107,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
     const parsed = ClaimBody.safeParse(req.body);
     if (!parsed.success) {
-      return reply.code(400).send({ error: 'invalid body', issues: parsed.error.issues });
+      return reply.code(400).send({ error: 'invalid request' });
     }
 
     let integratorId: string | undefined;
@@ -143,7 +143,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         },
       });
       if (!result.ok) {
-        return reply.code(401).send({ error: `integrator auth failed: ${result.reason}` });
+        return reply.code(401).send({ error: 'integrator auth failed' });
       }
       integratorId = result.integratorId;
       hostContextVerified = true;
@@ -182,10 +182,8 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     let address: string;
     try {
       address = ctx.driver.parseAddress(parsed.data.address);
-    } catch (err) {
-      return reply
-        .code(400)
-        .send({ error: 'invalid address', message: (err as Error).message });
+    } catch {
+      return reply.code(400).send({ error: 'invalid address' });
     }
 
     // Idempotency lookup (#86). Scoped by:
@@ -272,14 +270,11 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       });
       claimsTotal.inc({ status: 'rejected', decision: evaluation.decision });
       claimDuration.observe({ phase: 'total' }, (Date.now() - now) / 1000);
-      const reason = evaluation.reasons[0] ?? evaluation.decision;
-      return reply.code(evaluation.decision === 'deny' ? 403 : 202).send({
-        id,
-        status: 'rejected',
-        decision: evaluation.decision,
-        reason,
-        error: reason,
-      });
+      // Uniform public reject shape: no abuse-layer attribution, no
+      // deny-vs-review distinction (status code or body). Granular reasons
+      // remain in the DB row + claimsTotal Prom metric for operators.
+      // See SECURITY.md "Public-API silence on rejection".
+      return reply.code(403).send({ id, status: 'rejected' });
     }
 
     if (evaluation.decision === 'challenge') {
@@ -399,6 +394,10 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     const { id } = req.params as { id: string };
     const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
     if (!row) return reply.code(404).send({ error: 'not found' });
+    // Public claim-status response intentionally omits `decision` and
+    // `rejectionReason`. Operators querying for granular abuse-pipeline
+    // attribution use the admin endpoints (/v1/admin/claims/:id).
+    // See SECURITY.md "Public-API silence on rejection".
     return {
       id: row.id,
       status: row.status,
@@ -406,8 +405,6 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       amountLuna: row.amountLuna,
       txId: row.txId,
       createdAt: row.createdAt,
-      decision: row.decision,
-      rejectionReason: row.rejectionReason,
     };
   });
 

--- a/apps/server/test/blocklist-normalization.e2e.test.ts
+++ b/apps/server/test/blocklist-normalization.e2e.test.ts
@@ -94,8 +94,8 @@ describe('blocklist normalization (#94)', () => {
     });
     expect(res.statusCode).toBe(403);
     const body = res.json();
-    expect(body.decision).toBe('deny');
-    expect(body.reason).toMatch(/blocklisted ip/i);
+    expect(body.status).toBe('rejected');
+    expect(Object.keys(body).sort()).toEqual(['id', 'status']);
   });
 
   it('re-normalises pre-existing rows on boot (idempotent migration)', async () => {

--- a/apps/server/test/claim-rejection-uniformity.e2e.test.ts
+++ b/apps/server/test/claim-rejection-uniformity.e2e.test.ts
@@ -1,0 +1,150 @@
+// Verifies the uniform-public-rejection contract: every reject path on
+// `/v1/claim` returns *exactly* `{ id, status: 'rejected' }` with HTTP 403.
+// No abuse-layer attribution, no decision/reason/error/code/issues fields,
+// no 202 vs 403 split between deny and review. See SECURITY.md
+// "Public-API silence on rejection".
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 9999 9999 9999 9999 9999 9999 9999 9999';
+
+class FakeDriver extends BaseTestDriver {
+  override async getBalance() {
+    return 10_000_000n;
+  }
+  override async send(): Promise<string> {
+    return 'tx_unused';
+  }
+}
+
+function expectUniformRejectShape(body: unknown, statusCode: number) {
+  expect(statusCode).toBe(403);
+  expect(typeof body).toBe('object');
+  expect(body).not.toBeNull();
+  const obj = body as Record<string, unknown>;
+  expect(Object.keys(obj).sort()).toEqual(['id', 'status']);
+  expect(typeof obj['id']).toBe('string');
+  expect(obj['status']).toBe('rejected');
+}
+
+describe('public claim-reject responses are uniform', () => {
+  let tmp: string;
+  let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-uniform-reject-'));
+    const config = ServerConfigSchema.parse({
+      geoipBackend: 'none',
+      network: 'test',
+      dataDir: tmp,
+      signerDriver: 'rpc',
+      rpcUrl: 'http://unused',
+      walletAddress: FAUCET_ADDR,
+      claimAmountLuna: '100000',
+      // Tight rate limit so we can trip the rate-limit deny path quickly.
+      rateLimitPerIpPerDay: '1',
+      adminPassword: 'test-password-123',
+      dev: 'true',
+    });
+    const built = await buildApp(config, { driverOverride: new FakeDriver(), quietLogs: true });
+    app = built.app;
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('rate-limit deny → uniform 403 + {id, status}', async () => {
+    const headers = { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.10' };
+    // First claim consumes the daily quota.
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR },
+      headers,
+    });
+    expect(ok.statusCode).toBe(200);
+    // Second claim trips the rate limit.
+    const denied = await app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('9999', '8888') },
+      headers,
+    });
+    expectUniformRejectShape(denied.json(), denied.statusCode);
+  });
+
+  it('GET /v1/claim/:id never leaks decision or rejectionReason on the public route', async () => {
+    // Trip a reject so we have a row whose internal `decision` and
+    // `rejectionReason` columns are populated, then poll the public GET.
+    const headers = { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.20' };
+    const first = await app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('9999', '7777') },
+      headers,
+    });
+    expect(first.statusCode).toBe(200);
+    const denied = await app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('9999', '6666') },
+      headers,
+    });
+    expectUniformRejectShape(denied.json(), denied.statusCode);
+    const id = (denied.json() as { id: string }).id;
+
+    const status = await app.inject({ method: 'GET', url: `/v1/claim/${id}` });
+    expect(status.statusCode).toBe(200);
+    const body = status.json() as Record<string, unknown>;
+    // Public claim-status response intentionally omits `decision` and
+    // `rejectionReason`. Operators retrieve them via /v1/admin/claims.
+    expect('decision' in body).toBe(false);
+    expect('rejectionReason' in body).toBe(false);
+    expect(body['status']).toBe('rejected');
+  });
+
+  it('rejection response keys are stable across distinct deny reasons', async () => {
+    // Cross-IP sweep: each pair of requests trips the rate limit on a
+    // different IP, so the deny is independent. Bodies must be
+    // byte-shape-identical (modulo id).
+    const seen = new Set<string>();
+    const cases: Array<{ ip: string; first: string; second: string }> = [
+      { ip: '198.51.100.40', first: '4040', second: '4141' },
+      { ip: '198.51.100.50', first: '5050', second: '5151' },
+      { ip: '198.51.100.60', first: '6060', second: '6161' },
+      { ip: '198.51.100.70', first: '7070', second: '7171' },
+    ];
+    for (const c of cases) {
+      const headers = { 'content-type': 'application/json', 'x-forwarded-for': c.ip };
+      // Burn the quota.
+      await app.inject({
+        method: 'POST',
+        url: '/v1/claim',
+        payload: { address: USER_ADDR.replace('9999', c.first) },
+        headers,
+      });
+      // Trip the deny.
+      const r = await app.inject({
+        method: 'POST',
+        url: '/v1/claim',
+        payload: { address: USER_ADDR.replace('9999', c.second) },
+        headers,
+      });
+      expectUniformRejectShape(r.json(), r.statusCode);
+      seen.add(JSON.stringify(Object.keys(r.json() as object).sort()));
+    }
+    // All bodies share the same key shape.
+    expect(seen.size).toBe(1);
+    expect([...seen][0]).toBe(JSON.stringify(['id', 'status']));
+  });
+});

--- a/apps/server/test/claim.e2e.test.ts
+++ b/apps/server/test/claim.e2e.test.ts
@@ -101,8 +101,10 @@ describe('POST /v1/claim', () => {
     });
     expect(capped.statusCode).toBe(403);
     const body = capped.json();
-    expect(body.decision).toBe('deny');
-    expect(body.reason).toMatch(/daily cap/);
+    // Public reject body is uniform: { id, status: 'rejected' } only.
+    // No decision/reason leak. See SECURITY.md "Public-API silence on rejection".
+    expect(Object.keys(body).sort()).toEqual(['id', 'status']);
+    expect(body.status).toBe('rejected');
   });
 
   it('looks up a claim by id', async () => {

--- a/apps/server/test/fingerprint.e2e.test.ts
+++ b/apps/server/test/fingerprint.e2e.test.ts
@@ -81,7 +81,6 @@ describe('fingerprint abuse layer', () => {
       headers: { 'content-type': 'application/json' },
     });
     expect(second.statusCode).toBe(403);
-    expect(second.json().decision).toBe('deny');
-    expect(second.json().reason).toMatch(/uids/);
+    expect(second.json().status).toBe('rejected');
   });
 });

--- a/apps/server/test/geoip.e2e.test.ts
+++ b/apps/server/test/geoip.e2e.test.ts
@@ -104,8 +104,7 @@ describe('geoip abuse layer (e2e)', () => {
       headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.20' },
     });
     expect(res.statusCode).toBe(403);
-    expect(res.json().decision).toBe('deny');
-    expect(res.json().reason).toMatch(/KP/);
+    expect(res.json().status).toBe('rejected');
   });
 
   it('denies a claim from a VPN / proxy ASN (denyVpn)', async () => {
@@ -116,8 +115,7 @@ describe('geoip abuse layer (e2e)', () => {
       headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.40' },
     });
     expect(res.statusCode).toBe(403);
-    expect(res.json().decision).toBe('deny');
-    expect(res.json().reason).toMatch(/VPN|proxy/i);
+    expect(res.json().status).toBe('rejected');
   });
 
   it('flags hosting providers and escalates based on score thresholds', async () => {
@@ -129,6 +127,6 @@ describe('geoip abuse layer (e2e)', () => {
       headers: { 'content-type': 'application/json', 'x-forwarded-for': '203.0.113.30' },
     });
     expect(res.statusCode).toBe(403);
-    expect(res.json().reason).toMatch(/hosting/);
+    expect(res.json().status).toBe('rejected');
   });
 });

--- a/apps/server/test/onchain.e2e.test.ts
+++ b/apps/server/test/onchain.e2e.test.ts
@@ -87,8 +87,7 @@ describe('onchain-nimiq abuse layer', () => {
       headers: { 'content-type': 'application/json' },
     });
     expect(res.statusCode).toBe(403);
-    expect(res.json().decision).toBe('deny');
-    expect(res.json().reason).toMatch(/sweeper/i);
+    expect(res.json().status).toBe('rejected');
     expect(driver.sends).toHaveLength(0);
   });
 

--- a/apps/server/test/trustproxy.e2e.test.ts
+++ b/apps/server/test/trustproxy.e2e.test.ts
@@ -88,7 +88,7 @@ describe('trustProxy CIDR allow-list (#87)', () => {
     expect(a.statusCode).toBe(200);
     expect(b.statusCode).toBe(200);
     expect(c.statusCode).toBe(403);
-    expect(c.json().reason).toMatch(/daily cap/);
+    expect(c.json().status).toBe('rejected');
   });
 
   it('honours X-Forwarded-For when the upstream peer is in the trust list (dev → loopback auto-trusted)', async () => {

--- a/examples/capacitor-mobile-app/src/App.tsx
+++ b/examples/capacitor-mobile-app/src/App.tsx
@@ -147,20 +147,22 @@ export default function App() {
       setPhase('submitting');
       setTxId(result.txId ?? null);
       if (result.status === 'rejected') {
+        // Public reject body has no reason — uniform shape for all denials.
+        // See SECURITY.md "Public-API silence on rejection".
         setPhase('rejected');
-        setErrorMessage(result.reason ?? 'Claim rejected');
+        setErrorMessage('Claim rejected');
         return;
       }
       if (result.status === 'challenged') {
         setPhase('rejected');
-        setErrorMessage(result.reason ?? 'Captcha challenge required');
+        setErrorMessage('Captcha challenge required');
         return;
       }
       setPhase('broadcast');
       const final = await client.waitForConfirmation(result.id);
       setTxId((prev) => final.txId ?? prev);
       setPhase(final.status === 'confirmed' ? 'confirmed' : 'rejected');
-      if (final.status === 'rejected' && final.reason) setErrorMessage(final.reason);
+      if (final.status === 'rejected') setErrorMessage('Claim rejected');
     } catch (err) {
       setPhase('error');
       setErrorMessage(err instanceof Error ? err.message : String(err));

--- a/examples/mini-app-claim-react/src/hooks/useMiniAppFaucet.ts
+++ b/examples/mini-app-claim-react/src/hooks/useMiniAppFaucet.ts
@@ -112,19 +112,13 @@ export function useMiniAppFaucet(faucetUrl: string) {
       const initial = await client.claim(address, initialOpts);
       setState((prev) => ({ ...prev, txId: initial.txId ?? null }));
       if (initial.status === 'rejected') {
-        setState((prev) => ({
-          ...prev,
-          phase: 'rejected',
-          errorMessage: initial.reason ?? 'Claim rejected',
-        }));
+        // Public reject body has no reason — uniform shape for all denials.
+        // See SECURITY.md "Public-API silence on rejection".
+        setState((prev) => ({ ...prev, phase: 'rejected', errorMessage: 'Claim rejected' }));
         return;
       }
       if (initial.status === 'challenged') {
-        setState((prev) => ({
-          ...prev,
-          phase: 'challenged',
-          errorMessage: initial.reason ?? 'Captcha required',
-        }));
+        setState((prev) => ({ ...prev, phase: 'challenged', errorMessage: 'Captcha required' }));
         return;
       }
       setState((prev) => ({ ...prev, phase: 'broadcast' }));
@@ -133,7 +127,7 @@ export function useMiniAppFaucet(faucetUrl: string) {
         ...prev,
         txId: final.txId ?? prev.txId,
         phase: final.status === 'confirmed' ? 'confirmed' : 'rejected',
-        errorMessage: final.status === 'rejected' && final.reason ? final.reason : prev.errorMessage,
+        errorMessage: final.status === 'rejected' ? 'Claim rejected' : prev.errorMessage,
       }));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/examples/mini-app-claim-vue/src/composables/useMiniAppFaucet.ts
+++ b/examples/mini-app-claim-vue/src/composables/useMiniAppFaucet.ts
@@ -107,21 +107,23 @@ export function useMiniAppFaucet(faucetUrl: string) {
       const initial = await client.claim(address, initialOpts);
       state.txId = initial.txId ?? null;
       if (initial.status === 'rejected') {
+        // Public reject body has no reason — uniform shape for all denials.
+        // See SECURITY.md "Public-API silence on rejection".
         state.phase = 'rejected';
-        state.errorMessage = initial.reason ?? 'Claim rejected';
+        state.errorMessage = 'Claim rejected';
         return;
       }
       if (initial.status === 'challenged') {
         state.phase = 'challenged';
-        state.errorMessage = initial.reason ?? 'Captcha required';
+        state.errorMessage = 'Captcha required';
         return;
       }
       state.phase = 'broadcast';
       const final = await client.waitForConfirmation(initial.id);
       state.txId = final.txId ?? state.txId;
       state.phase = final.status === 'confirmed' ? 'confirmed' : 'rejected';
-      if (final.status === 'rejected' && final.reason) {
-        state.errorMessage = final.reason;
+      if (final.status === 'rejected') {
+        state.errorMessage = 'Claim rejected';
       }
     } catch (err) {
       state.phase = 'error';

--- a/examples/vue-claim-page/src/App.vue
+++ b/examples/vue-claim-page/src/App.vue
@@ -150,20 +150,22 @@ async function handleSubmit() {
     phase.value = 'submitting';
     txId.value = result.txId ?? null;
     if (result.status === 'rejected') {
+      // Public reject body has no reason — uniform shape for all denials.
+      // See SECURITY.md "Public-API silence on rejection".
       phase.value = 'rejected';
-      errorMessage.value = result.reason ?? 'Claim rejected';
+      errorMessage.value = 'Claim rejected';
       return;
     }
     if (result.status === 'challenged') {
       phase.value = 'rejected';
-      errorMessage.value = result.reason ?? 'Captcha challenge required';
+      errorMessage.value = 'Captcha challenge required';
       return;
     }
     phase.value = 'broadcast';
     const final = await client.waitForConfirmation(result.id);
     txId.value = final.txId ?? txId.value;
     phase.value = final.status === 'confirmed' ? 'confirmed' : 'rejected';
-    if (final.status === 'rejected' && final.reason) errorMessage.value = final.reason;
+    if (final.status === 'rejected') errorMessage.value = 'Claim rejected';
   } catch (err) {
     phase.value = 'error';
     errorMessage.value = err instanceof Error ? err.message : String(err);

--- a/packages/sdk-flutter/lib/src/client.dart
+++ b/packages/sdk-flutter/lib/src/client.dart
@@ -160,16 +160,13 @@ class FaucetClient {
     if (res.statusCode >= 400) {
       var message = 'HTTP ${res.statusCode}';
       String? code;
-      String? decision;
       if (parsed is Map<String, dynamic>) {
         final err = parsed['error'];
         if (err is String) message = err;
         final c = parsed['code'];
         if (c is String) code = c;
-        final d = parsed['decision'];
-        if (d is String) decision = d;
       }
-      throw FaucetException(message, status: res.statusCode, code: code, decision: decision);
+      throw FaucetException(message, status: res.statusCode, code: code);
     }
     return parsed;
   }

--- a/packages/sdk-flutter/lib/src/types.dart
+++ b/packages/sdk-flutter/lib/src/types.dart
@@ -90,29 +90,25 @@ class ClaimOptions {
   }
 }
 
+/// Public reject responses are uniform: `{ id, status: "rejected" }` only.
+/// No abuse-layer attribution leaks to clients. See SECURITY.md
+/// "Public-API silence on rejection".
 class ClaimResponse {
   final String id;
   /// One of: 'queued' | 'broadcast' | 'confirmed' | 'rejected' | 'challenged'.
   final String status;
   final String? txId;
-  /// One of: 'allow' | 'challenge' | 'review' | 'deny'.
-  final String? decision;
-  final String? reason;
 
   const ClaimResponse({
     required this.id,
     required this.status,
     this.txId,
-    this.decision,
-    this.reason,
   });
 
   factory ClaimResponse.fromJson(Map<String, dynamic> json) => ClaimResponse(
         id: json['id'] as String,
         status: json['status'] as String,
         txId: json['txId'] as String?,
-        decision: json['decision'] as String?,
-        reason: json['reason'] as String?,
       );
 }
 
@@ -194,11 +190,10 @@ class FaucetException implements Exception {
   final int status;
   final String message;
   final String? code;
-  final String? decision;
 
-  const FaucetException(this.message, {required this.status, this.code, this.decision});
+  const FaucetException(this.message, {required this.status, this.code});
 
   @override
   String toString() =>
-      'FaucetException($status: $message${code != null ? ' code=$code' : ''}${decision != null ? ' decision=$decision' : ''})';
+      'FaucetException($status: $message${code != null ? ' code=$code' : ''})';
 }

--- a/packages/sdk-go/faucet.go
+++ b/packages/sdk-go/faucet.go
@@ -230,9 +230,8 @@ func (c *Client) do(req *http.Request, out interface{}) error {
 	if resp.StatusCode >= 400 {
 		fe := &FaucetError{Status: resp.StatusCode, Message: fmt.Sprintf("HTTP %d", resp.StatusCode)}
 		var errBody struct {
-			Error    string `json:"error"`
-			Code     string `json:"code"`
-			Decision string `json:"decision"`
+			Error string `json:"error"`
+			Code  string `json:"code"`
 		}
 		if len(body) > 0 {
 			if jerr := json.Unmarshal(body, &errBody); jerr == nil {
@@ -240,7 +239,6 @@ func (c *Client) do(req *http.Request, out interface{}) error {
 					fe.Message = errBody.Error
 				}
 				fe.Code = errBody.Code
-				fe.Decision = errBody.Decision
 			}
 		}
 		return fe

--- a/packages/sdk-go/faucet_test.go
+++ b/packages/sdk-go/faucet_test.go
@@ -135,9 +135,13 @@ func TestClaimHMACSignedHeaders(t *testing.T) {
 }
 
 func TestErrorBodyDecoded(t *testing.T) {
+	// Public reject body shape is uniform: { id, status: "rejected" } only.
+	// The SDK still gracefully handles legacy bodies that include
+	// `error`/`code` fields (used by 4xx responses from non-pipeline
+	// rejections like 'invalid address' or 'integrator auth failed').
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(403)
-		_, _ = w.Write([]byte(`{"error":"denied","decision":"deny","code":"abuse"}`))
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"error":"integrator auth failed","code":"auth"}`))
 	}))
 	defer srv.Close()
 	c := New(Config{URL: srv.URL})
@@ -149,7 +153,7 @@ func TestErrorBodyDecoded(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *FaucetError, got %T", err)
 	}
-	if fe.Status != 403 || fe.Decision != "deny" || fe.Code != "abuse" || fe.Message != "denied" {
+	if fe.Status != 401 || fe.Code != "auth" || fe.Message != "integrator auth failed" {
 		t.Fatalf("bad error fields: %+v", fe)
 	}
 }

--- a/packages/sdk-go/types.go
+++ b/packages/sdk-go/types.go
@@ -31,12 +31,14 @@ type ClaimOptions struct {
 }
 
 // ClaimResponse mirrors the TS `ClaimResponse`.
+//
+// Public reject responses are uniform: `{ id, status: "rejected" }` only.
+// No abuse-layer attribution leaks to clients.
+// See SECURITY.md "Public-API silence on rejection".
 type ClaimResponse struct {
-	ID       string `json:"id"`
-	Status   string `json:"status"` // queued | broadcast | confirmed | rejected | challenged
-	TxID     string `json:"txId,omitempty"`
-	Decision string `json:"decision,omitempty"` // allow | challenge | review | deny
-	Reason   string `json:"reason,omitempty"`
+	ID     string `json:"id"`
+	Status string `json:"status"` // queued | broadcast | confirmed | rejected | challenged
+	TxID   string `json:"txId,omitempty"`
 }
 
 // HashcashChallenge mirrors the TS `HashcashChallenge`.
@@ -69,10 +71,9 @@ type HashcashConfig struct {
 
 // FaucetError is returned for non-2xx server responses. It implements `error`.
 type FaucetError struct {
-	Status   int
-	Message  string
-	Code     string
-	Decision string
+	Status  int
+	Message string
+	Code    string
 }
 
 // Error implements the standard error interface.

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -42,7 +42,6 @@ export function useFaucetClaim(args: UseFaucetClaimArgs): UseFaucetClaimResult {
     status: 'idle',
     id: null,
     txId: null,
-    decision: null,
     error: null,
   });
   const manager = useRef<ClaimManager | null>(null);
@@ -121,7 +120,6 @@ export type {
   ClaimOptions,
   ClaimResponse,
   ClaimStatus,
-  ClaimDecision,
   HostContext,
   FingerprintBundle,
   ClaimState,

--- a/packages/sdk-ts/src/claimManager.ts
+++ b/packages/sdk-ts/src/claimManager.ts
@@ -16,7 +16,6 @@ export interface ClaimState {
   status: 'idle' | 'pending' | ClaimStatus;
   id: string | null;
   txId: string | null;
-  decision: ClaimResponse['decision'] | null;
   error: Error | null;
 }
 
@@ -24,7 +23,6 @@ const INITIAL_STATE: ClaimState = {
   status: 'idle',
   id: null,
   txId: null,
-  decision: null,
   error: null,
 };
 
@@ -56,14 +54,12 @@ export class ClaimManager {
         id: response.id,
         status: response.status,
         txId: response.txId ?? null,
-        decision: response.decision ?? null,
       });
       if (pollForConfirmation && (response.status === 'broadcast' || response.status === 'queued')) {
         const confirmed = await this.#client.waitForConfirmation(response.id);
         this.#set({
           status: confirmed.status,
           txId: confirmed.txId ?? response.txId ?? null,
-          decision: confirmed.decision ?? null,
         });
       }
     } catch (err) {

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -23,15 +23,12 @@ export interface ClaimOptions {
   signal?: AbortSignal | undefined;
 }
 
-export type ClaimDecision = 'allow' | 'challenge' | 'review' | 'deny';
 export type ClaimStatus = 'queued' | 'broadcast' | 'confirmed' | 'rejected' | 'challenged';
 
 export interface ClaimResponse {
   id: string;
   status: ClaimStatus;
   txId?: string | undefined;
-  decision?: ClaimDecision | undefined;
-  reason?: string | undefined;
 }
 
 export interface HashcashChallenge {
@@ -67,14 +64,12 @@ export interface FaucetClientOptions {
 export class FaucetError extends Error {
   readonly status: number;
   readonly code: string | undefined;
-  readonly decision: ClaimDecision | undefined;
 
-  constructor(message: string, status: number, code?: string, decision?: ClaimDecision) {
+  constructor(message: string, status: number, code?: string) {
     super(message);
     this.name = 'FaucetError';
     this.status = status;
     this.code = code;
-    this.decision = decision;
   }
 }
 
@@ -243,8 +238,8 @@ export class FaucetClient {
         const err = (parsed as { error: unknown }).error;
         if (typeof err === 'string') message = err;
       }
-      const obj = parsed as { code?: string; decision?: ClaimDecision } | undefined;
-      throw new FaucetError(message, res.status, obj?.code, obj?.decision);
+      const obj = parsed as { code?: string } | undefined;
+      throw new FaucetError(message, res.status, obj?.code);
     }
     return parsed as T;
   }

--- a/packages/sdk-vue/src/index.ts
+++ b/packages/sdk-vue/src/index.ts
@@ -35,7 +35,6 @@ export function useFaucetClaim(args: UseFaucetClaimArgs) {
     status: 'idle',
     id: null,
     txId: null,
-    decision: null,
     error: null,
   });
   const manager = new ClaimManager(client, (s) => Object.assign(state, s));
@@ -89,7 +88,6 @@ export type {
   ClaimOptions,
   ClaimResponse,
   ClaimStatus,
-  ClaimDecision,
   HostContext,
   FingerprintBundle,
   ClaimState,


### PR DESCRIPTION
## Summary

When the faucet rejects a `/v1/claim` request, the public response is now byte-shape-identical regardless of which abuse layer fired:

```http
HTTP/1.1 403 Forbidden
{ "id": "<nanoid>", "status": "rejected" }
```

No `decision`, no `reason`, no `error`, no `code`, no `issues`. `decision === "review"` collapses into the same 403 + body as a hard `deny` (no 202-vs-403 status-code split).

**Why**: revealing which abuse layer rejected — or even distinguishing `deny` vs `review` — lets an attacker A/B-test their inputs until the response signal changes, telling them they tripped a different gate. Strict uniformity is cheap defence-in-depth. The audit (#87–#107) didn't catch this; surfaced as a hardening item.

## Changes by area

### Server ([apps/server/src/routes/claim.ts](apps/server/src/routes/claim.ts) + [openapi/schemas.ts](apps/server/src/openapi/schemas.ts))
- Collapse the deny + review branch to `403 { id, status: 'rejected' }`.
- Strip `decision` and `rejectionReason` from the public `GET /v1/claim/:id` response. Admin endpoints under `/v1/admin/claims` keep them.
- Scrub other public reject paths: drop Zod `issues` from invalid-body 400, drop per-reason interpolation from integrator-auth 401, drop raw exception text from invalid-address 400.
- OpenAPI: drop `decision` / `rejectionReason` from public `ClaimResponse` and `ClaimStatus`; drop `issues` from `ErrorResponse`. Admin schemas (`ClaimListItem`) keep granular attribution.

### SDKs (TS / Vue / React / Go / Flutter)
- Drop `decision` and `reason` from `ClaimResponse` types.
- Drop `decision` from `FaucetError` / `FaucetException` (constructor + field).
- Drop `decision` from framework `ClaimState` plumbing in `ClaimManager`, sdk-vue, sdk-react.
- Drop `ClaimDecision` re-exports.
- Update Go `TestErrorBodyDecoded` to test the post-uniformity shape.

### Tests
- New [apps/server/test/claim-rejection-uniformity.e2e.test.ts](apps/server/test/claim-rejection-uniformity.e2e.test.ts) (3 cases): trip rate-limit, verify GET stays opaque, verify response keys are stable across distinct deny reasons.
- Tighten 5 existing e2e tests (`blocklist-normalization`, `geoip`, `fingerprint`, `onchain`, `trustproxy`, `claim`) that previously asserted on the now-dropped fields.

### Frontend consumers
- [apps/claim-ui/src/components/ClaimStatus.vue](apps/claim-ui/src/components/ClaimStatus.vue) and [apps/nimiq-pow-ui/src/composables/useClaim.ts](apps/nimiq-pow-ui/src/composables/useClaim.ts) no longer read `result.reason` (gone from SDK types).

### Documentation
- [SECURITY.md](SECURITY.md) gains a **"Public-API silence on rejection"** section under the trust-boundary model. Documents the contract, the rationale, and the explicit "don't quietly re-add diagnostic fields" guidance.

## Operator visibility — unchanged

- `claims.rejectionReason`, `claims.decision`, `claims.signalsJson` still written to the DB on every reject.
- Prometheus `claimsTotal{decision="..."}` counters still increment with the right label.
- Admin endpoints (`/v1/admin/claims`) still surface granular attribution.

## Test plan

- [x] 149/149 server tests pass (`pnpm --filter @faucet/server test`).
- [x] Full `pnpm -r typecheck` green across all 19 packages.
- [x] New `claim-rejection-uniformity.e2e.test.ts` exercises uniform-shape contract.
- [ ] CI green
- [ ] Manual smoke: `curl -i -X POST http://localhost:8080/v1/claim ...` against a running faucet returns a body with `Object.keys === ['id', 'status']` only.

## Out of scope (deliberately)

- The `'browser_required'`, `'origin_not_allowed'`, `'claim_in_progress'`, and driver-side errors stay informative — they're either documented gates with legitimate-client retry semantics, or they fire after the abuse pipeline approves so they're not abuse-layer attribution.
- Constant-time response delivery (defeating timing-based fingerprinting): orthogonal hardening; today's pipeline runs all checks before the 403 so timing variance is mostly compute-cost-driven, not branch-driven. Re-evaluate if the unified-shape change reveals timing leakage in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)