### PR TITLE
security(public-reads): extend rejection-uniformity contract to stats/recent

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -182,16 +182,27 @@ remain informative because they're documented gates with legitimate-client
 retry semantics, *or* they fire after the abuse pipeline approves so
 they're not abuse-layer attribution.
 
+**The same contract applies to every public read endpoint, not just
+the claim POST/GET.** Aggregate or recent-rows endpoints
+(`/v1/stats`, `/v1/stats/summary`, `/v1/claims/recent`) must NOT carry
+per-claim `decision`, `rejectionReason`, `signalsJson`, or
+`abuseScore`, and must NOT expose `topRejectionReasons` strings
+publicly. Otherwise an attacker reads the operator's recent-rejections
+leaderboard instead of A/B-testing their own claims — same intel leak,
+larger sample size. Operators see the granular shape via the
+authenticated `/v1/admin/*` routes (`/v1/admin/claims`,
+`/v1/admin/overview`).
+
 **Operator visibility is unchanged.** The granular `decision`,
 `rejectionReason`, `signalsJson`, and per-layer scores stay in the
 `claims` DB row, in the Prometheus `claimsTotal{decision="..."}`
-counters, and on the admin endpoints under `/v1/admin/claims`. SDKs
+counters, and on the admin endpoints under `/v1/admin/*`. SDKs
 (`@nimiq-faucet/sdk` and the framework wrappers) intentionally don't
 expose `decision` / `reason` types on public reject responses; consumers
 infer "rejected" purely from `status === "rejected"`.
 
-If a future contributor wants to add diagnostic fields back to the
-public reject body, that is a security-relevant change that needs a
+If a future contributor wants to add diagnostic fields back to any
+public route, that is a security-relevant change that needs a
 threat-model review — please don't quietly re-add them.
 
 ### What we don't defend against

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -126,7 +126,9 @@ export const StatsResponse = registry.register(
   z.object({
     total: z.number().int(),
     byStatus: z.record(z.string(), z.number().int()),
-    byDecision: z.record(z.string(), z.number().int()),
+    // `byDecision` intentionally omitted from the public schema — see
+    // SECURITY.md "Public-API silence on rejection". Operators see it via
+    // /v1/admin/overview's bucketed counts.
   }),
 );
 

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -409,19 +409,17 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
   });
 
   app.get('/v1/stats', async () => {
+    // Public response intentionally omits `byDecision` — that field carried
+    // pipeline-effectiveness intelligence (deny/review/allow ratios over
+    // the last 100 claims) which violates SECURITY.md "Public-API silence
+    // on rejection". Operators see the same data via /v1/admin/overview.
     const recent = await ctx.db
-      .select({
-        id: claims.id,
-        createdAt: claims.createdAt,
-        status: claims.status,
-        decision: claims.decision,
-      })
+      .select({ id: claims.id, status: claims.status })
       .from(claims)
       .limit(100);
     return {
       total: recent.length,
       byStatus: groupBy(recent.map((r) => r.status)),
-      byDecision: groupBy(recent.map((r) => r.decision)),
     };
   });
 
@@ -462,23 +460,18 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     const blockedCount24h = blocked24h[0]?.n ?? 0;
     const total24h = successCount24h + blockedCount24h;
 
-    const topReasons = await ctx.db
-      .select({ reason: claims.rejectionReason, n: sql<number>`count(*)` })
-      .from(claims)
-      .where(and(gte(claims.createdAt, windows['24h']), isNotNull(claims.rejectionReason)))
-      .groupBy(claims.rejectionReason)
-      .orderBy(sql`count(*) desc`)
-      .limit(5);
-
+    // Public response intentionally omits `topRejectionReasons` and the
+    // per-row `decision` / `rejectionReason` fields — they leak abuse-layer
+    // attribution and contradict SECURITY.md "Public-API silence on
+    // rejection". Operators see the same granular data via
+    // /v1/admin/overview (topRejectionReasons) and /v1/admin/claims (rows).
     const claimFields = {
       id: claims.id,
       createdAt: claims.createdAt,
       address: claims.address,
       amountLuna: claims.amountLuna,
       status: claims.status,
-      decision: claims.decision,
       txId: claims.txId,
-      rejectionReason: claims.rejectionReason,
     };
 
     const [recentClaimsRaw, recentBlockedRaw] = await Promise.all([
@@ -511,13 +504,16 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       successRate: total24h > 0 ? successCount24h / total24h : 0,
       recentClaims,
       recentBlocked,
-      topRejectionReasons: topReasons.map((r) => ({ reason: r.reason ?? 'unknown', count: r.n })),
     };
     summaryCache = { data, ts: now };
     return data;
   });
 
-  // ── /v1/claims/recent — public paginated claims (no sensitive fields) ──
+  // ── /v1/claims/recent — public paginated claims ──
+  // Per SECURITY.md "Public-API silence on rejection": this endpoint
+  // intentionally omits `decision` and `rejectionReason` (those carry
+  // abuse-layer attribution). Operators get the granular shape via
+  // /v1/admin/claims.
 
   app.get('/v1/claims/recent', async (req) => {
     const query = req.query as { limit?: string; offset?: string; status?: string };
@@ -534,9 +530,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         address: claims.address,
         amountLuna: claims.amountLuna,
         status: claims.status,
-        decision: claims.decision,
         txId: claims.txId,
-        rejectionReason: claims.rejectionReason,
       })
       .from(claims)
       .where(conds)

--- a/apps/server/test/claim-rejection-uniformity.e2e.test.ts
+++ b/apps/server/test/claim-rejection-uniformity.e2e.test.ts
@@ -113,6 +113,58 @@ describe('public claim-reject responses are uniform', () => {
     expect(body['status']).toBe('rejected');
   });
 
+  it('GET /v1/stats omits byDecision from the public response', async () => {
+    const r = await app.inject({ method: 'GET', url: '/v1/stats' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json() as Record<string, unknown>;
+    expect('byDecision' in body).toBe(false);
+    // Allowed public fields only.
+    expect(Object.keys(body).sort()).toEqual(['byStatus', 'total']);
+  });
+
+  it('GET /v1/stats/summary omits topRejectionReasons + per-row decision/rejectionReason', async () => {
+    // Trip a few rejects so the recentBlocked array isn't empty.
+    const headers = { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.80' };
+    await app.inject({ method: 'POST', url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('9999', '8080') }, headers });
+    await app.inject({ method: 'POST', url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('9999', '8181') }, headers });
+    const r = await app.inject({ method: 'GET', url: '/v1/stats/summary' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json() as Record<string, unknown>;
+    expect('topRejectionReasons' in body).toBe(false);
+    const recentBlocked = body['recentBlocked'] as Array<Record<string, unknown>>;
+    if (recentBlocked.length > 0) {
+      const rowKeys = Object.keys(recentBlocked[0]!).sort();
+      // No abuse-layer attribution fields per row.
+      expect(rowKeys).not.toContain('decision');
+      expect(rowKeys).not.toContain('rejectionReason');
+    }
+    const recentClaims = body['recentClaims'] as Array<Record<string, unknown>>;
+    for (const row of recentClaims) {
+      const rowKeys = Object.keys(row);
+      expect(rowKeys).not.toContain('decision');
+      expect(rowKeys).not.toContain('rejectionReason');
+    }
+  });
+
+  it('GET /v1/claims/recent omits decision and rejectionReason from row shape', async () => {
+    const r = await app.inject({ method: 'GET', url: '/v1/claims/recent?status=rejected&limit=5' });
+    expect(r.statusCode).toBe(200);
+    const body = r.json() as { items: Array<Record<string, unknown>> };
+    for (const row of body.items) {
+      const rowKeys = Object.keys(row);
+      expect(rowKeys).not.toContain('decision');
+      expect(rowKeys).not.toContain('rejectionReason');
+    }
+    if (body.items.length > 0) {
+      // Allowed public fields only.
+      expect(Object.keys(body.items[0]!).sort()).toEqual(
+        ['address', 'amountLuna', 'createdAt', 'id', 'status', 'txId'],
+      );
+    }
+  });
+
   it('rejection response keys are stable across distinct deny reasons', async () => {
     // Cross-IP sweep: each pair of requests trips the rate limit on a
     // different IP, so the deny is independent. Bodies must be


### PR DESCRIPTION
## Summary

Closes the contract-contradiction trio surfaced by the 2026-05-04 re-audit (findings [022](audits/findings-2026-05/022-stats-summary-leaks-rejection-attribution.md), [023](audits/findings-2026-05/023-claims-recent-leaks-decision-and-reason.md), [025](audits/findings-2026-05/025-stats-byDecision-aggregate-leak.md)).

PR #176 closed `POST /v1/claim` and `GET /v1/claim/:id` against abuse-layer attribution leakage. Three sibling public endpoints surfaced the same data and contradicted [SECURITY.md "Public-API silence on rejection"](SECURITY.md):

| Endpoint | Was leaking | Severity |
|---|---|---|
| `GET /v1/stats` | `byDecision` aggregate counts (allow/deny/review/challenge) | Low |
| `GET /v1/stats/summary` | `topRejectionReasons` strings + per-row `decision`/`rejectionReason` in `recentClaims`/`recentBlocked` | Medium |
| `GET /v1/claims/recent` | `decision` + `rejectionReason` per row (with a comment misleadingly claiming "no sensitive fields") | Medium |

An attacker could poll any of these endpoints to read the operator's recent-rejections leaderboard — exactly the abuse-layer attribution #176 was designed to hide, just on a different route.

## Changes

### Server ([apps/server/src/routes/claim.ts](apps/server/src/routes/claim.ts))
- `/v1/stats`: drop `byDecision` from response and from the SELECT.
- `/v1/stats/summary`: drop `topRejectionReasons`; drop `decision` and `rejectionReason` from `recentClaims` and `recentBlocked` row shapes.
- `/v1/claims/recent`: drop `decision` and `rejectionReason` from row shape; rewrite the misleading section comment.

### OpenAPI ([apps/server/src/openapi/schemas.ts](apps/server/src/openapi/schemas.ts))
- Drop `byDecision` from the public `StatsResponse` schema.

### Tests ([apps/server/test/claim-rejection-uniformity.e2e.test.ts](apps/server/test/claim-rejection-uniformity.e2e.test.ts))
- 3 new cases verify the stats/recent endpoints don't carry the dropped fields.
- Total: 6 cases (was 3); 149/149 server tests pass.

### Documentation ([SECURITY.md](SECURITY.md))
- Expand "Public-API silence on rejection" section to cover every public read, not just claim POST/GET. Explicitly call out aggregate and recent-rows endpoints as part of the contract.

## Operator visibility — unchanged

Granular fields remain on:
- `/v1/admin/overview` — `topRejectionReasons`
- `/v1/admin/claims` — per-row `decision`, `rejectionReason`, `abuseScore`, `signalsJson`
- Prometheus `claimsTotal{decision="..."}` counters

## Test plan

- [x] 149/149 server tests pass (`pnpm --filter @faucet/server test`)
- [x] Full `pnpm -r typecheck` green across all 19 packages
- [x] New uniformity cases assert key shape on `/v1/stats`, `/v1/stats/summary`, `/v1/claims/recent`
- [ ] CI green
- [ ] Manual smoke: `curl -s http://localhost:8080/v1/claims/recent?status=rejected | jq '.items[0] | keys'` returns only `["address","amountLuna","createdAt","id","status","txId"]`

## What this PR deliberately does NOT do

- **Doesn't add admin equivalents** — they already exist at `/v1/admin/overview` and `/v1/admin/claims` (the granular fields didn't move; they were just removed from public).
- **Doesn't address timing-side-channel attribution (finding 024)** — that's a separate PR (constant-time reject delivery via `T_min` padding).
- **Doesn't touch the cross-theme asset probe, MCP static-token default, or sdk-capacitor signing (findings 026/027/028)** — separate hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)