### PR TITLE
security(claim): pad public reject responses to defeat timing attribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ FAUCET_CLAIM_AMOUNT_LUNA=100000     # 1 NIM = 100_000 luna
 FAUCET_RATE_LIMIT_PER_MINUTE=30
 FAUCET_RATE_LIMIT_PER_IP_PER_DAY=5
 
+# Minimum delay (ms) before any public claim-reject response is delivered.
+# Defends against pipeline-position timing attribution — without padding,
+# a rate-limit reject lands in ~5ms while an AI reject takes ~2s, which
+# leaks which abuse layer fired even when the response body is uniform.
+# Set to 0 to disable (e.g. local development). See SECURITY.md
+# "Public-API silence on rejection".
+# FAUCET_REJECT_DELAY_MS_MIN=1500
+
 # --- Captcha (pick one; all optional) ---
 # FAUCET_TURNSTILE_SITE_KEY=...
 # FAUCET_TURNSTILE_SECRET=...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -205,6 +205,18 @@ If a future contributor wants to add diagnostic fields back to any
 public route, that is a security-relevant change that needs a
 threat-model review — please don't quietly re-add them.
 
+**Reject responses are also timing-padded.** The abuse pipeline
+short-circuits on the first hard `deny`, so a rate-limit reject
+naturally lands in ~5ms while a captcha or AI reject takes hundreds of
+ms — which leaks which layer fired even with a uniform body. Every
+public `/v1/claim` reject path therefore pads to a configurable floor
+(`FAUCET_REJECT_DELAY_MS_MIN`, default `1500ms`) before responding.
+The Zod-invalid, integrator-auth, address-parse, deny/review, RPC and
+send-failed paths all participate. The pre-pipeline `browser_required`
+and `origin_not_allowed` gates are intentionally exempt — they have
+distinguishable bodies and fast-fail semantics for legitimate
+non-browser callers.
+
 ### What we don't defend against
 
 - **Compromised integrator**. If an integrator's HMAC secret leaks, the

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -114,6 +114,18 @@ export const ServerConfigSchema = z.object({
   challengeRatePerMinute: z.coerce.number().int().min(1).default(10),
   keyringPath: z.string().optional(),
 
+  /**
+   * Minimum delay in milliseconds before any public claim-reject response
+   * is delivered. Defends against pipeline-position timing attribution
+   * (audits/findings-2026-05/024). The pipeline's short-circuit-on-deny
+   * means a rate-limit reject lands in ~5ms while a captcha or AI reject
+   * takes hundreds of ms; padding every reject to a single floor hides
+   * which layer fired. Set to 0 to disable the padding (e.g., in tests
+   * that want fast feedback). 1500ms is conservative — covers the
+   * captcha-provider HTTP roundtrip on most networks.
+   */
+  rejectDelayMsMin: z.coerce.number().int().min(0).default(1500),
+
   requireBrowser: z.coerce.boolean().default(false),
   uiEnabled: z.coerce.boolean().default(true),
   claimUiDir: z.string().optional(),

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -23,6 +23,22 @@ const ClaimBody = ClaimRequestSchema.transform(({ powSolution, hashcashSolution,
   hashcashSolution: hashcashSolution ?? powSolution,
 }));
 
+/**
+ * Pad a reject response so its wall-clock latency is at least `targetMs`
+ * relative to the request start. Defends against pipeline-position timing
+ * attribution (audits/findings-2026-05/024) — the pipeline short-circuits
+ * on the first hard deny, so without padding a rate-limit reject lands in
+ * ~5ms and an AI reject in ~2s, which leaks layer position even when the
+ * response body is uniform. Use the same floor for every public reject
+ * path so the existence of padding itself isn't a side-channel.
+ */
+async function padRejectDelay(startedAt: number, targetMs: number): Promise<void> {
+  if (targetMs <= 0) return;
+  const elapsed = Date.now() - startedAt;
+  if (elapsed >= targetMs) return;
+  await new Promise((r) => setTimeout(r, targetMs - elapsed));
+}
+
 export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promise<void> {
   app.get('/v1/config', async () => derivePublicConfig(ctx.config));
 
@@ -66,6 +82,13 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     bodyLimit: 16 * 1024,
     preHandler: app.rateLimit({ max: ctx.config.rateLimitPerMinute, timeWindow: '1 minute' }),
   }, async (req, reply) => {
+    // Capture wall-clock start before any branch so every reject path
+    // can pad to the same minimum latency (audits/findings-2026-05/024).
+    // The browser/origin gates below are intentionally NOT padded — they
+    // have distinguishable bodies and fast-fail semantics for legitimate
+    // non-browser callers (Mini App SDKs, integrator backends).
+    const requestStart = Date.now();
+    const T_min = ctx.config.rejectDelayMsMin;
     // Browser-only enforcement: when enabled, reject requests that don't
     // originate from a real browser. Integrators bypass this via HMAC auth.
     if (ctx.config.requireBrowser) {
@@ -107,6 +130,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
     const parsed = ClaimBody.safeParse(req.body);
     if (!parsed.success) {
+      await padRejectDelay(requestStart, T_min);
       return reply.code(400).send({ error: 'invalid request' });
     }
 
@@ -143,6 +167,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         },
       });
       if (!result.ok) {
+        await padRejectDelay(requestStart, T_min);
         return reply.code(401).send({ error: 'integrator auth failed' });
       }
       integratorId = result.integratorId;
@@ -183,6 +208,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     try {
       address = ctx.driver.parseAddress(parsed.data.address);
     } catch {
+      await padRejectDelay(requestStart, T_min);
       return reply.code(400).send({ error: 'invalid address' });
     }
 
@@ -274,6 +300,9 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       // deny-vs-review distinction (status code or body). Granular reasons
       // remain in the DB row + claimsTotal Prom metric for operators.
       // See SECURITY.md "Public-API silence on rejection".
+      // Pad to T_min to defeat pipeline-position timing attribution
+      // (audits/findings-2026-05/024).
+      await padRejectDelay(requestStart, T_min);
       return reply.code(403).send({ id, status: 'rejected' });
     }
 
@@ -320,6 +349,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       inflightClaims.delete(address);
       await decrementIpCounter(ctx.db, req.ip, now);
       if (err instanceof DriverError && err.code === 'RPC_-32602') {
+        await padRejectDelay(requestStart, T_min);
         return reply.code(400).send({
           error: 'invalid address',
           message: 'Address rejected by the network (invalid checksum or format)',
@@ -343,6 +373,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       });
       claimsTotal.inc({ status: 'timeout', decision: 'allow' });
       claimDuration.observe({ phase: 'total' }, (Date.now() - now) / 1000);
+      await padRejectDelay(requestStart, T_min);
       return reply.code(503).send({
         id,
         status: 'error',

--- a/apps/server/test/blocklist-normalization.e2e.test.ts
+++ b/apps/server/test/blocklist-normalization.e2e.test.ts
@@ -43,6 +43,7 @@ function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
     rateLimitPerIpPerDay: '100',
     adminPassword: 'test-password-123',
     dev: 'true',
+    rejectDelayMsMin: '0',
     // Trust loopback (added automatically in dev) so XFF in tests is
     // honoured — the e2e mocks the socket as 127.0.0.1.
     ...overrides,

--- a/apps/server/test/claim-reject-timing-padding.e2e.test.ts
+++ b/apps/server/test/claim-reject-timing-padding.e2e.test.ts
@@ -1,0 +1,132 @@
+// Verifies the constant-time reject-delivery contract from
+// audits/findings-2026-05/024 — every public claim-reject path is padded
+// to at least `rejectDelayMsMin` so an attacker can't infer which abuse
+// layer fired by timing the response.
+//
+// Body uniformity (PR #176) is necessary but not sufficient — the pipeline
+// short-circuits on hard `deny`, so without padding a rate-limit reject
+// returns in ~5ms while a captcha or AI reject takes hundreds of ms. This
+// test enables padding and asserts every reject path waits the floor.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 7777 7777 7777 7777 7777 7777 7777 7777';
+
+class FakeDriver extends BaseTestDriver {
+  override async getBalance() {
+    return 10_000_000n;
+  }
+  override async send(): Promise<string> {
+    return 'tx_unused';
+  }
+}
+
+// Use a small floor (200ms) so the test runs quickly while still being
+// large enough to be observable above scheduler noise. Production default
+// is 1500ms — but the contract under test is "elapsed >= configured floor",
+// not "elapsed >= some specific large number".
+const TEST_T_MIN = 200;
+
+describe('public claim-reject paths pad to rejectDelayMsMin', () => {
+  let tmp: string;
+  let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'faucet-reject-timing-'));
+    const config = ServerConfigSchema.parse({
+      geoipBackend: 'none',
+      network: 'test',
+      dataDir: tmp,
+      signerDriver: 'rpc',
+      rpcUrl: 'http://unused',
+      walletAddress: FAUCET_ADDR,
+      claimAmountLuna: '100000',
+      // Tight per-IP cap so we can trip rate-limit deny in 2 calls.
+      rateLimitPerIpPerDay: '1',
+      adminPassword: 'test-password-123',
+      dev: 'true',
+      rejectDelayMsMin: String(TEST_T_MIN),
+    });
+    const built = await buildApp(config, { driverOverride: new FakeDriver(), quietLogs: true });
+    app = built.app;
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function timed(injectArgs: Parameters<typeof app.inject>[0]): Promise<{ elapsed: number; statusCode: number }> {
+    const t0 = Date.now();
+    const r = await app.inject(injectArgs);
+    return { elapsed: Date.now() - t0, statusCode: r.statusCode };
+  }
+
+  it('Zod-invalid request (400) waits >= rejectDelayMsMin', async () => {
+    const { elapsed, statusCode } = await timed({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { not_an_address: 'totally bogus' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(statusCode).toBe(400);
+    expect(elapsed).toBeGreaterThanOrEqual(TEST_T_MIN);
+  });
+
+  it('invalid-address (400) waits >= rejectDelayMsMin', async () => {
+    const { elapsed, statusCode } = await timed({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: 'this is not a NQ address' },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(statusCode).toBe(400);
+    expect(elapsed).toBeGreaterThanOrEqual(TEST_T_MIN);
+  });
+
+  it('integrator-auth-failed (401) waits >= rejectDelayMsMin', async () => {
+    const { elapsed, statusCode } = await timed({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR },
+      headers: {
+        'content-type': 'application/json',
+        'x-faucet-api-key': 'bogus-key-not-registered',
+        'x-faucet-timestamp': String(Date.now()),
+        'x-faucet-nonce': 'abc123',
+        'x-faucet-signature': 'invalid',
+      },
+    });
+    expect(statusCode).toBe(401);
+    expect(elapsed).toBeGreaterThanOrEqual(TEST_T_MIN);
+  });
+
+  it('rate-limit deny (403) waits >= rejectDelayMsMin', async () => {
+    const headers = { 'content-type': 'application/json', 'x-forwarded-for': '198.51.100.99' };
+    // First claim consumes the daily quota.
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR },
+      headers,
+    });
+    expect(ok.statusCode).toBe(200);
+    // Second claim trips deny — should be padded.
+    const { elapsed, statusCode } = await timed({
+      method: 'POST',
+      url: '/v1/claim',
+      payload: { address: USER_ADDR.replace('7777', '6666') },
+      headers,
+    });
+    expect(statusCode).toBe(403);
+    expect(elapsed).toBeGreaterThanOrEqual(TEST_T_MIN);
+  });
+});

--- a/apps/server/test/claim-rejection-uniformity.e2e.test.ts
+++ b/apps/server/test/claim-rejection-uniformity.e2e.test.ts
@@ -52,6 +52,10 @@ describe('public claim-reject responses are uniform', () => {
       rateLimitPerIpPerDay: '1',
       adminPassword: 'test-password-123',
       dev: 'true',
+      // Disable reject-delay padding here — these tests exercise body-shape
+      // correctness, not timing behaviour. Padding-correctness has its own
+      // dedicated test in claim-reject-timing-padding.e2e.test.ts.
+      rejectDelayMsMin: '0',
     });
     const built = await buildApp(config, { driverOverride: new FakeDriver(), quietLogs: true });
     app = built.app;

--- a/apps/server/test/claim.e2e.test.ts
+++ b/apps/server/test/claim.e2e.test.ts
@@ -43,6 +43,7 @@ describe('POST /v1/claim', () => {
       rateLimitPerIpPerDay: '3',
       adminPassword: 'test-password-123',
       dev: 'true',
+      rejectDelayMsMin: '0',
     });
     driver = new FakeNimiqDriver();
     const built = await buildApp(config, { driverOverride: driver, quietLogs: true });

--- a/apps/server/test/fingerprint.e2e.test.ts
+++ b/apps/server/test/fingerprint.e2e.test.ts
@@ -40,6 +40,7 @@ describe('fingerprint abuse layer', () => {
       fingerprintMaxUidsPerVisitor: '1',
       fingerprintMaxVisitorsPerUid: '10',
       dev: 'true',
+      rejectDelayMsMin: '0',
     });
     const built = await buildApp(config, { driverOverride: new StubDriver(), quietLogs: true });
     app = built.app;

--- a/apps/server/test/geoip.e2e.test.ts
+++ b/apps/server/test/geoip.e2e.test.ts
@@ -57,6 +57,7 @@ describe('geoip abuse layer (e2e)', () => {
       geoipDenyVpn: 'true',
       geoipDenyHosting: 'true',
       dev: 'true',
+      rejectDelayMsMin: '0',
     });
     driver = new StubDriver();
     // Public-looking IPs so the geoip check doesn't short-circuit on "private-ip".

--- a/apps/server/test/onchain.e2e.test.ts
+++ b/apps/server/test/onchain.e2e.test.ts
@@ -54,6 +54,7 @@ describe('onchain-nimiq abuse layer', () => {
       onchainEnabled: 'true',
       onchainDenyIfSweeper: 'true',
       dev: 'true',
+      rejectDelayMsMin: '0',
     });
     driver = new StubDriver();
     driver.historyFor.set(SWEEPER_ADDR, {

--- a/apps/server/test/trustproxy.e2e.test.ts
+++ b/apps/server/test/trustproxy.e2e.test.ts
@@ -45,6 +45,7 @@ function baseConfig(dir: string, overrides: Record<string, unknown> = {}) {
     adminPassword: 'test-password-123',
     tlsRequired: false,
     corsOrigins: 'https://example.test',
+    rejectDelayMsMin: '0',
     ...overrides,
   });
 }


### PR DESCRIPTION
## Summary

Closes finding [024](audits/findings-2026-05/024-pipeline-short-circuit-timing-attribution.md) from the 2026-05-04 re-audit.

PR #176 made every `/v1/claim` reject body byte-shape-identical so an attacker can't tell which abuse layer fired by reading the response. But the pipeline ([`packages/core/src/pipeline.ts`](packages/core/src/pipeline.ts)) short-circuits on the first hard `deny`, which means a rate-limit reject naturally lands in ~5ms while a captcha or AI reject takes hundreds of ms — leaking layer position via wall-clock timing. Body uniformity is necessary but not sufficient.

This change adds a configurable response-time floor (`FAUCET_REJECT_DELAY_MS_MIN`, default `1500ms`) and applies it to every public reject path on `/v1/claim`. After the request starts, the handler runs whatever it runs; right before the reject reply, it sleeps until total elapsed >= `T_min`. The pipeline itself stays unchanged.

## Padded paths

| File:Line | Reject |
|---|---|
| [claim.ts:126](apps/server/src/routes/claim.ts#L126) | invalid request (Zod validation) |
| [claim.ts:162](apps/server/src/routes/claim.ts#L162) | integrator auth failed |
| [claim.ts:202](apps/server/src/routes/claim.ts#L202) | invalid address (parseAddress) |
| [claim.ts:293](apps/server/src/routes/claim.ts#L293) | **deny/review uniform reject (critical path)** |
| [claim.ts:339](apps/server/src/routes/claim.ts#L339) | RPC -32602 invalid address (post-pipeline) |
| [claim.ts:362](apps/server/src/routes/claim.ts#L362) | send_failed (post-pipeline driver error) |

## Intentionally NOT padded

- `hashcash-not-enabled` / `browser_required` on `/v1/challenge` — different endpoint, fast-fail for legitimate non-browser callers
- `browser_required` / `origin_not_allowed` on `/v1/claim` — pre-pipeline access-control gates with distinguishable bodies; not abuse-pipeline attribution
- `not found` on GET `/v1/claim/:id` — different endpoint

## Tests

- New [`apps/server/test/claim-reject-timing-padding.e2e.test.ts`](apps/server/test/claim-reject-timing-padding.e2e.test.ts) (4 cases): enables a 200ms test floor and asserts every padded reject path waits at least that long.
- Existing reject-touching tests gain `rejectDelayMsMin: '0'` so functional tests don't pay 1500ms per reject (would have added ~30s to the test suite). Other test files don't hit reject paths.
- **156/156 server tests pass** (was 152; +4 timing-padding cases). Workspace typecheck green.

## Documentation

- [`SECURITY.md`](SECURITY.md) "Public-API silence on rejection" gains a paragraph documenting the padding contract, the env var, and the explicit exemption list.
- [`.env.example`](.env.example) gains the new env var with a usage comment.

## Test plan

- [x] 156/156 server tests pass (`pnpm --filter @faucet/server test`)
- [x] `pnpm -r typecheck` green across 19 packages
- [x] New timing test exercises 4 reject paths
- [ ] CI green
- [ ] Manual smoke against a running faucet — `time curl -X POST http://localhost:8080/v1/claim ...` returns >= 1.5s on any reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)