### PR TITLE
security(hardening): scope cross-theme probe + MCP deprecation warning + capacitor unsigned-visitorId docs

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -133,6 +133,24 @@ export async function buildApp(
 
   const ctx: AppContext = { config, db, driver, pipeline, stream, events };
 
+  // Deprecation surface for the legacy MCP static-token auth path
+  // (audits/findings-2026-05/027). The original audit's #88 fix replaced
+  // the static bearer with session+TOTP; the compat flag
+  // `adminMcpAllowStaticToken` was meant to be a one-minor grace, but
+  // there was no signal to operators that they were still on the legacy
+  // path. Surface a single boot WARN whenever both the legacy token is
+  // configured AND the flag is on (its current default). Operators flip
+  // the flag to silence; a future minor will flip the default to false.
+  if (config.adminMcpAllowStaticToken && config.adminMcpToken) {
+    app.log.warn(
+      '[deprecation] FAUCET_ADMIN_MCP_TOKEN is set with FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN ' +
+        'defaulting to true. The static-token auth path is deprecated; migrate to ' +
+        'session+TOTP auth (see SECURITY.md "Trust-boundary model" → admin auth) and ' +
+        'set FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=false to silence this warning. The ' +
+        'default will flip to false in an upcoming release.',
+    );
+  }
+
   const isDriverReady = (): boolean => driver.isReady?.() !== false;
 
   // Push a one-time event when the driver becomes ready.

--- a/apps/server/src/ui.ts
+++ b/apps/server/src/ui.ts
@@ -172,11 +172,19 @@ export async function registerUi(app: FastifyInstance, config: ServerConfig): Pr
     }
     // Strip query string + leading slash; reject path-traversal attempts.
     const pathOnly = url.split('?')[0]?.replace(/^\/+/, '') ?? '';
-    if (pathOnly && !pathOnly.includes('..') && /\.[a-zA-Z0-9]+$/.test(pathOnly)) {
-      // Looks like an asset (has an extension) — try every non-active
-      // theme's dist before falling back to the SPA shell. This is what
-      // makes the picker's hashed assets resolve when ?theme=<slug>
-      // serves a different theme's HTML.
+    // Cross-theme asset probe: ONLY for paths under `assets/` (Vite's
+    // hashed-output directory). Restricting the probe scope here closes
+    // the cross-theme leak from audits/findings-2026-05/026 — without
+    // it, an operator who accidentally bundles a sensitive root-level
+    // file (e.g., `staging-config.json`) into one theme's dist makes it
+    // reachable from every other theme. Vite hashes its bundle outputs
+    // into `assets/`, so legitimate picker UX is unaffected.
+    if (
+      pathOnly &&
+      !pathOnly.includes('..') &&
+      pathOnly.startsWith('assets/') &&
+      /\.[a-zA-Z0-9]+$/.test(pathOnly)
+    ) {
       for (const altDir of altThemeDirs) {
         const candidate = resolve(altDir, pathOnly);
         if (existsSync(candidate)) {

--- a/packages/sdk-capacitor/README.md
+++ b/packages/sdk-capacitor/README.md
@@ -18,3 +18,26 @@ await client.claim(address); // fingerprint.visitorId auto-filled from Device.ge
 ```
 
 Caller-provided `fingerprint.visitorId` always wins. Everything else in `@nimiq-faucet/sdk` is re-exported (`FaucetClient`, `solveHashcash`, types).
+
+## Security: `visitorId` is unsigned client input
+
+The auto-populated `visitorId` is **untrusted** by design — an attacker who controls the Capacitor app (modified APK/IPA, JS tampering, runtime hook) can spoof this value to bypass per-device abuse correlation. The faucet's fingerprint abuse-layer treats `visitorId` as a **correlation hint, not authentication**.
+
+For real trust, lean on:
+
+1. **Per-IP rate limit** (`FAUCET_RATE_LIMIT_PER_IP_PER_DAY`) — the primary cap; can't be spoofed without distinct network paths.
+2. **Signed `hostContext`** — if you run an integrator backend, sign the `hostContext` envelope server-side using `FaucetClient.signHostContext()` (from `@nimiq-faucet/sdk`) and pass the signed value into this SDK's `claim()` via the `hostContext` option:
+
+   ```ts
+   // On your backend (where the HMAC secret lives):
+   const signedHostContext = FaucetClient.signHostContext(hostContext, {
+     integratorId: 'your-integrator-id',
+     hmacSecret: process.env.FAUCET_HMAC_SECRET,
+   });
+   // Pass the signed envelope down to the Capacitor app, then:
+   await client.claim(address, { hostContext: signedHostContext });
+   ```
+
+   The faucet verifies the HMAC server-side and treats the contained fields (KYC level, account age, verified identities) as trusted. Without the signature, the same fields are stripped before the abuse pipeline sees them.
+
+This mirrors the parity hardening that closed audit finding #104 for `sdk-go` and `sdk-flutter`. Don't reintroduce unsigned `visitorId` weighting in your operator config.

--- a/packages/sdk-capacitor/src/index.ts
+++ b/packages/sdk-capacitor/src/index.ts
@@ -16,6 +16,24 @@ export * from '@nimiq-faucet/sdk';
  * The returned value extends `FaucetClient`, so the full SDK surface
  * (`status`, `waitForConfirmation`, `config`, `requestChallenge`, `subscribe`)
  * is untouched and passes straight through.
+ *
+ * **SECURITY NOTE.** `visitorId` is **unsigned client input.** The faucet's
+ * fingerprint abuse-layer uses it for correlation, not authentication —
+ * an attacker who controls the Capacitor app (modified APK/IPA, JS
+ * tampering, runtime hook) can spoof this value to bypass per-device
+ * abuse correlation. Don't weight `visitorId` heavily in abuse scoring.
+ *
+ * For trust, rely on:
+ * 1. **Per-IP rate limit** (`FAUCET_RATE_LIMIT_PER_IP_PER_DAY`) — the
+ *    primary cap; can't be spoofed without distinct network paths.
+ * 2. **Signed `hostContext`** — when an integrator backend is in the
+ *    loop, sign hostContext server-side via `FaucetClient.signHostContext()`
+ *    (from `@nimiq-faucet/sdk`) and pass the signed envelope into this
+ *    SDK's `claim()` via the `hostContext` option. The mini-app-claim
+ *    examples follow this pattern.
+ *
+ * Mirror of audit finding #104 (closed for sdk-go and sdk-flutter), now
+ * documented for sdk-capacitor as findings-2026-05/028.
  */
 export class CapacitorFaucetClient extends FaucetClient {
   private cachedDeviceId: string | undefined;


### PR DESCRIPTION
## Summary

Closes the three independent low-severity findings from the 2026-05-04 re-audit. With this PR + #177 + #178, all 7 re-audit findings ([022](audits/findings-2026-05/022-stats-summary-leaks-rejection-attribution.md), [023](audits/findings-2026-05/023-claims-recent-leaks-decision-and-reason.md), [024](audits/findings-2026-05/024-pipeline-short-circuit-timing-attribution.md), [025](audits/findings-2026-05/025-stats-byDecision-aggregate-leak.md), [026](audits/findings-2026-05/026-cross-theme-asset-probe-leakage.md), [027](audits/findings-2026-05/027-mcp-static-token-default-true-no-expiry.md), [028](audits/findings-2026-05/028-sdk-capacitor-fingerprint-not-signed.md)) are addressed.

## Changes

### 026 — cross-theme asset probe scoped to `assets/` ([apps/server/src/ui.ts](apps/server/src/ui.ts))

The SPA fall-through handler probed every non-active theme's `dist/` for any extensioned file when the picker was enabled. An operator who accidentally bundled a sensitive root-level file (e.g., `staging-config.json`, `team-notes.txt`) into one theme's dist made it reachable from every other theme.

**Fix**: restrict the cross-theme probe to paths under `assets/` (Vite's hashed-output directory). Preserves picker UX (Vite emits hashed JS/CSS into `assets/`) while closing the leak class for root-level operator footguns.

### 027 — boot-time deprecation WARN for static MCP token ([apps/server/src/app.ts](apps/server/src/app.ts))

The original audit's #88 fix introduced `adminMcpAllowStaticToken` (defaults to `true`) as a one-minor grace for the legacy bearer-token auth path. No signal told operators they were still on the legacy path → indefinite drift.

**Fix**: emit a single boot-time `WARN` whenever `FAUCET_ADMIN_MCP_TOKEN` is set AND `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN` is on (its current default), naming the flag and announcing the default flip in an upcoming release. **No behaviour change yet** — the default flip ships in a follow-up release.

### 028 — sdk-capacitor: document `visitorId` as unsigned ([packages/sdk-capacitor/](packages/sdk-capacitor/))

The auto-injected `fingerprint.visitorId` from `Device.getId()` is **unsigned client input**. An attacker who controls the Capacitor app (modified APK/IPA, JS tampering, runtime hook) can spoof the value to bypass per-device abuse correlation. Mirror of audit finding #104 (closed for `sdk-go` and `sdk-flutter`).

**Fix**: documentation only.
- JSDoc on `CapacitorFaucetClient` now warns about the trust boundary and points at `FaucetClient.signHostContext()` as the correct hardening pattern.
- [README.md](packages/sdk-capacitor/README.md) gains a "Security: `visitorId` is unsigned client input" section with a code sample showing how integrators should sign hostContext server-side.

## Test plan

- [x] 156/156 server tests pass (no behavioural changes that would affect test suite)
- [x] `pnpm -r typecheck` green across 19 packages
- [x] `pnpm --filter @nimiq-faucet/capacitor build` regenerates dist/ with the new JSDoc
- [ ] CI green
- [ ] Manual smoke: boot the faucet with `FAUCET_ADMIN_MCP_TOKEN=test123` (and `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN` unset) → boot logs include the deprecation warning

## Out of scope

- **Default flip of `adminMcpAllowStaticToken` to `false`** — that's a behaviour change deserving its own release-noted PR. This PR adds the warning so operators know it's coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)