### PR TITLE
docs(audits): land the audit trail on main

### DIFF
--- a/audits/AUDIT-REPORT-2026-05.md
+++ b/audits/AUDIT-REPORT-2026-05.md
@@ -1,0 +1,221 @@
+# Nimiq Simple Faucet — Security Re-Audit (Second Edition)
+
+**Target:** [`PanoramicRum/nimiq-simple-faucet`](https://github.com/PanoramicRum/nimiq-simple-faucet)
+**Commit audited:** `main @ 855868a` (2026-05-04)
+**Audit dates:** 2026-05-04
+**Auditor:** Claude (Opus 4.7, 1M context), driven by maintainer (`PanoramicRum` / `richy@nimiq.com`)
+**Predecessor:** [`AUDIT-REPORT.md`](AUDIT-REPORT.md) — 21 findings (#87–#107) at `main @ ee34d1e` on 2026-04-23, all merged via #108–#134 by 2026-04-25
+**Disclosure channel:** Public GitHub issues with `security` label per the SECURITY.md waiver. Each issue body carries the inheritable-disclosure-warning banner. **Findings in this report have been drafted but NOT YET FILED** — maintainer wanted to review before publishing.
+**Tooling:** [`~/.claude/skills/crypto-faucet-audit/SKILL.md`](~/.claude/skills/crypto-faucet-audit/SKILL.md) (same skill as the original audit)
+
+---
+
+## Executive summary
+
+Re-audit of the faucet 11 days after the original 21-finding audit closed and the post-audit feature work (53 commits) landed. The headline result: **7 new findings, all Medium or Low, no Critical or High**. Three of the seven (022, 023, 024) directly contradict the [`SECURITY.md` "Public-API silence on rejection"](../SECURITY.md) contract introduced in PR [#176](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/176) — the same contract that motivated this audit cycle. Four others are smaller hardening items.
+
+**Severity histogram:** Medium ×3 · Low ×4 · (no Critical or High; no fixed findings regressed)
+
+The contract-contradiction trio (022/023/024) is the most actionable. PR #176 closed `POST /v1/claim` and `GET /v1/claim/:id` against abuse-layer attribution leakage, but three sibling public endpoints surface the same data:
+- `/v1/stats/summary` returns `topRejectionReasons` strings AND per-row `decision`/`rejectionReason` in `recentClaims`/`recentBlocked`
+- `/v1/claims/recent` exposes `decision` + `rejectionReason` per row (and the section comment misleadingly says "no sensitive fields")
+- The pipeline still short-circuits on `deny`, leaking layer-position via response timing — defeating body uniformity for any attacker who measures wall-clock
+
+The trio's combined fix is small (~30 lines of route-handler diff plus a pipeline strategy decision) and ships as one PR. After it lands, the `SECURITY.md` contract is materially stronger.
+
+The remaining four findings (025-028) are individually-Low hardening items; each independent.
+
+**No regression** of the original 21 findings (#87–#107). The major dep bumps (TS 5.9 → 6, zod 3 → 4, vitest 2 → 4, react 18 → 19) introduced no security regressions in critical paths — Zod 4's stricter discriminator inference holds; TS 6 type-narrowing changes don't weaken the trust-boundary guards.
+
+---
+
+## Scope
+
+**In scope:** `apps/`, `packages/`, `deploy/`, `.github/workflows/`, `scripts/`, `SECURITY.md`, `openapi/`, MCP tool surface, and specifically the new code surface added since 2026-04-23 (theme registry, Hub-API wallet connect, FCaptcha URL split, sdk-capacitor, CORS wildcard, MCP session-vs-static-token migration, rejection-uniformity contract).
+
+**Out of scope:** unchanged from the original audit — third-party provider internals (Cloudflare, hCaptcha, MaxMind, IPinfo, DB-IP, FCaptcha), downstream integrator apps using the SDKs, `core-rs-albatross` node, load/DoS testing against live instances, social engineering, abuse-AI ONNX adversarial bounds.
+
+---
+
+## Methodology
+
+1. Three Explore agents in parallel covering distinct slices: (A) new code surface, (B) rejection-uniformity contract verification, (C) regression check on #87–#107 + dep-bump implications.
+2. Every candidate finding cross-checked against the actual code (Read tool), not just agent recall. Two agent-flagged candidates (path-traversal in `ui.ts`, CORS wildcard regex) were retired after cross-check — not exploitable on Linux given existing guards.
+3. Disclosure model: public issues for Medium/Low (no Critical/High required GHSA private path); banner inherited from the original audit.
+4. Drafts produced under [`audits/findings-2026-05/`](findings-2026-05/) per the skill template (one finding per markdown file, full issue-body shape).
+
+---
+
+## Findings index
+
+All findings are draft markdown under [`audits/findings-2026-05/`](findings-2026-05/). They have NOT been filed as issues yet — pending maintainer review.
+
+| # | Sev | Title | Issue (TBD) | Local draft |
+|---|-----|-------|------|-------------|
+| 022 | Med | `/v1/stats/summary` leaks abuse-layer attribution despite #176 | TBD | [022](findings-2026-05/022-stats-summary-leaks-rejection-attribution.md) |
+| 023 | Med | `/v1/claims/recent` exposes decision + rejectionReason per row | TBD | [023](findings-2026-05/023-claims-recent-leaks-decision-and-reason.md) |
+| 024 | Med | Pipeline short-circuits on hard `deny` — timing side-channel attribution | TBD | [024](findings-2026-05/024-pipeline-short-circuit-timing-attribution.md) |
+| 025 | Low | `/v1/stats` `byDecision` aggregate counts publicly exposed | TBD | [025](findings-2026-05/025-stats-byDecision-aggregate-leak.md) |
+| 026 | Low | Cross-theme asset probe serves any bundled theme's `dist/` | TBD | [026](findings-2026-05/026-cross-theme-asset-probe-leakage.md) |
+| 027 | Low | `adminMcpAllowStaticToken` defaults to `true` indefinitely; no expiry | TBD | [027](findings-2026-05/027-mcp-static-token-default-true-no-expiry.md) |
+| 028 | Low | sdk-capacitor injects `visitorId` without HMAC signing — parity gap with closed #104 | TBD | [028](findings-2026-05/028-sdk-capacitor-fingerprint-not-signed.md) |
+
+---
+
+## Suggested fix bundling
+
+Three logical PRs cover all 7 findings:
+
+### PR 1 — Public-API rejection silence on stats/recent endpoints (022 + 023 + 025)
+- `apps/server/src/routes/claim.ts` L411-426 (`/v1/stats`): drop `byDecision` from public response; drop `decision` from SELECT
+- `apps/server/src/routes/claim.ts` L432-518 (`/v1/stats/summary`): drop `topRejectionReasons` from public response; drop `decision` and `rejectionReason` from `recentClaims` and `recentBlocked` row shapes
+- `apps/server/src/routes/claim.ts` L520-555 (`/v1/claims/recent`): drop `decision` and `rejectionReason` from row shape; fix the "no sensitive fields" comment
+- New admin equivalents under `/v1/admin/*` if operator dashboards need the granular shape (most likely they already use `/v1/admin/claims`)
+- Update the `claim-rejection-uniformity.e2e.test.ts` (or add a new uniformity test) to cover stats/recent endpoints
+- One-paragraph addition to [`SECURITY.md` "Public-API silence on rejection"](../SECURITY.md) noting that the contract applies to *every* public read, not just claim-status
+
+### PR 2 — Constant-time reject delivery (024)
+- `apps/server/src/routes/claim.ts`: pad every public reject (deny, review, Zod-invalid, integrator-auth-failed, invalid-address) to a configurable `T_min` (default 1500ms) using server-side `setTimeout`
+- Don't change `packages/core/src/pipeline.ts` — short-circuit-on-deny is fine internally; the padding lives at the route layer where the response timing actually matters
+- New env: `FAUCET_REJECT_DELAY_MS_MIN` (default 1500). Document it in the production-deployment guide.
+- New test that verifies `process.hrtime` between request and response is ≥ T_min for each reject path
+
+### PR 3 — Hardening (026 + 027 + 028)
+- `apps/server/src/ui.ts`: only probe the *requested* theme's `dist/` in the SPA fallback (drop the cross-theme loop)
+- `apps/server/src/config.ts`: emit boot-time `WARN` when `adminMcpAllowStaticToken=true` AND `adminMcpToken` is set; flip `default(true)` → `default(false)` in the next minor (release-notes-driven decision)
+- `packages/sdk-capacitor/`: add JSDoc + README warning that `visitorId` is unsigned client input; document the integrator-backend signing pattern
+- These three are independent and can ship in any order
+
+---
+
+## Regression matrix — original audit findings #87–#107
+
+All 21 findings remain in their fixed state. No regression detected.
+
+| # | Title | Fix verified at | Status |
+|---|-------|-----------------|--------|
+| 87 | trustProxy CIDR | `apps/server/src/app.ts:54` | still-fixed |
+| 88 | MCP static token | `apps/server/src/mcp/index.ts` (session-path preferred); BUT default is permissive — see finding 027 | still-fixed (with hygiene gap) |
+| 89 | Admin first-login compare + brute-force | `apps/server/src/routes/admin/auth.ts:54-59` `safeEqualUtf8` + 5 req/min limit | still-fixed |
+| 90 | `--frozen-lockfile=false` | Dockerfile + 6 workflows enforce `--frozen-lockfile` | still-fixed |
+| 91 | Captcha try/catch + timeout | `apps/server/src/abuse/turnstile.ts:41-64` (and parity in hcaptcha/fcaptcha) | still-fixed |
+| 92 | Dockerfile base image digest | `deploy/docker/Dockerfile:1` SHA-pinned | still-fixed |
+| 93 | GH Actions SHA-pinned | `.github/workflows/*.yml` audited | still-fixed |
+| 94 | Blocklist normalization | `apps/server/src/abuse/blocklist.ts:22` `normalizeBlocklistValue()` | still-fixed |
+| 95 | Hashcash replay cache | `packages/abuse-hashcash/src/index.ts:26-70` `HashcashReplayStore` | still-fixed |
+| 96 | Unsigned hostContext stripping | `apps/server/src/routes/claim.ts:236` `stripUnsignedHostContext()` before pipeline | still-fixed |
+| 97 | Cookie `__Host-` prefix | `apps/server/src/auth/middleware.ts:40` | still-fixed |
+| 98 | sdk-ts randomNonce Math.random fallback | `packages/sdk-ts/src/index.ts:328-341` WebCrypto only | still-fixed |
+| 99 | ci.yml `permissions:` block | `.github/workflows/ci.yml` top-level | still-fixed |
+| 100 | release.yml tag validation | semver pattern | still-fixed |
+| 101 | Helm PDB + NetworkPolicy | `deploy/helm/` templates | still-fixed |
+| 102 | RPC SSRF validation | `packages/driver-nimiq-rpc/` validates rpcUrl | still-fixed |
+| 103 | GeoIP unknown-country | hard-deny in allow-list mode | still-fixed |
+| 104 | SDK hostContext HMAC parity | sdk-go + sdk-flutter signed; **but** sdk-capacitor regressed — see finding 028 | still-fixed (with new instance) |
+| 105 | Fingerprint null-UID counting | `apps/server/src/abuse/fingerprint.ts` excludes null | still-fixed |
+| 106 | CSP connect-src narrowed | `apps/server/src/hardening.ts:64-71` provider-specific | still-fixed |
+| 107 | 6 transitive CVEs | `package.json:54-60` overrides + post-bump verification | still-addressed |
+
+Two findings have new "instances" (different code path, same class): **#88 → finding 027** (default-permissive flag) and **#104 → finding 028** (sdk-capacitor unsigned visitorId). Treat as fresh findings, not regressions.
+
+---
+
+## Improvements (non-vulnerability hardening)
+
+Below the issue-worthy threshold but on the long-term hardening list:
+
+- **Cross-SDK uniformity test fixture.** A single JSON fixture replayed by every SDK in CI would catch any future regression of #176's body shape (and would have caught the SDK side of finding 028 mechanically).
+- **Boot-time security-flag audit.** A startup helper that scans the resolved config for known footguns (`adminMcpAllowStaticToken=true`, `requireBrowser=false` outside dev, `corsOrigins='*'` outside dev) and emits a single consolidated `WARN` line. Reduces the number of "comments promised; nobody flipped the default" classes (finding 027).
+- **`SECURITY.md` "Public-API silence on rejection" expansion.** The current section narrowly covers the claim endpoint. After the PR 1 fix (findings 022 + 023 + 025), expand it to cover the contract for all public reads: "Aggregate or recent-row endpoints must NOT carry per-claim `decision` or `rejectionReason`."
+- **Per-claim treasury cap monitor.** Same as the original audit's improvements list. A daily global ceiling (`max_luna_per_day_global`) would limit blast radius of any not-yet-found bypass; with the new MCP `send` tool, this becomes more relevant.
+- **Document the rejection-timing contract once PR 2 lands.** Add a doc page or `SECURITY.md` subsection "Constant-time reject delivery" describing `T_min` and how to tune it.
+
+---
+
+## Checklist coverage
+
+| Check | Status | Note |
+|-------|--------|------|
+| Admin auth / session / TOTP | ✅ | All audit fixes intact; finding 027 is hygiene, not auth bypass |
+| Crypto primitives | ✅ | XChaCha20 random nonce, Argon2id, TOTP via @otplib/preset-default (umbrella `otplib` removed in #172), `timingSafeEqual` everywhere — clean |
+| Key storage | ✅ | Unchanged from original audit; passphrase + XChaCha unchanged |
+| Signer drivers | ✅ | RPC SSRF guard (#102) intact; WASM driver unchanged |
+| Claim endpoint / race conditions | ✅ | IP counter pre-pipeline (TOCTOU close) intact; uniform reject body new in #176 |
+| Public read endpoints (NEW) | ⚠️ | Findings 022, 023, 025 — `/v1/stats`, `/v1/stats/summary`, `/v1/claims/recent` leak |
+| Rejection-response timing (NEW) | ⚠️ | Finding 024 — pipeline short-circuit |
+| Theme registry / asset routing (NEW) | ⚠️ | Finding 026 — cross-theme probe |
+| Abuse layer: blocklist | ✅ | Fix #94 intact |
+| Abuse layer: rate limit | ✅ | Fix #87 intact (CIDR-based trust) |
+| Abuse layer: captcha | ✅ | Fix #91 intact; FCaptcha provider new but follows the same try/catch + timeout shape |
+| Abuse layer: hashcash | ✅ | Fix #95 intact |
+| Abuse layer: geoip / ASN | ✅ | Fix #103 intact |
+| Abuse layer: fingerprint | ✅ | Fix #105 intact; finding 028 is SDK-side |
+| Abuse layer: on-chain heuristics | ✅ | Unchanged |
+| Abuse layer: AI / ONNX | ✅ | Unchanged; fail-closed on inference error |
+| MCP tool exposure | ⚠️ | Session+TOTP path correct; finding 027 (default-permissive flag) |
+| Input validation (Zod) | ✅ | zod 4 migration audited; no schema loosened |
+| CORS / Helmet / headers | ✅ | Wildcard regex anchored; CSP unchanged |
+| Database (Drizzle, SQLite/Postgres) | ✅ | No raw SQL interpolation found |
+| Dependencies | ✅ | No new moderate+ CVEs introduced by zod 4 / TS 6 / vitest 4 / react 19 |
+| Docker | ✅ | Multi-theme bundling didn't introduce new surface |
+| Helm / K8s | ✅ | Unchanged |
+| CI / supply chain | ✅ | All audit fixes intact |
+| SDK hostContext HMAC | ⚠️ | sdk-go + sdk-flutter intact; sdk-capacitor regressed → finding 028 |
+
+---
+
+## Appendix A — Tool output
+
+### `pnpm audit --audit-level=moderate`
+
+(Run inline during the audit; current state matches package.json overrides — no NEW moderate+ CVEs introduced by the post-#107 dep bumps. The pre-existing dev-only ignored CVEs in `package.json:54-60` are unchanged.)
+
+### Custom-skill grep sweeps (per Appendix A of the original audit)
+
+| Sweep | Original audit | This audit | Verdict |
+|---|---|---|---|
+| `Math.random` | 4 hits, 1 valid (#98) | 4 hits, 0 valid | clean — fix #134 holds |
+| `trustProxy` | 1 hit, valid (#87) | 1 hit, fixed | clean |
+| `rejectUnauthorized: false` | 0 | 0 | clean |
+| `=== '...'` against secrets | 1 hit (#89) | 0 — `timingSafeEqual` everywhere | clean |
+| `dangerouslySetInnerHTML` / `v-html` | 0 | 0 | clean |
+| Raw `drizzle.sql\`...\${var}\`` | 0 | 0 | clean |
+| New: `decision: claims.decision` in public route | n/a | **3 hits** (#411-426, #480-498, #537-539) | findings 022, 023, 025 |
+| New: `rejectionReason: claims.rejectionReason` in public route | n/a | **2 hits** (#481, #539) | findings 022, 023 |
+
+### CI runs not re-executed locally
+
+- CodeQL, Trivy, Gitleaks: trusted from CI (same as original audit).
+
+---
+
+## Appendix B — Environment
+
+- Auditor OS: Linux 6.8.0-110-generic
+- Node: v22 (per Dockerfile target)
+- pnpm: 9.15.5 (current local; 10.33.2 update available, untaken)
+- `gh` CLI: authenticated as `PanoramicRum`
+- Skill: `~/.claude/skills/crypto-faucet-audit/SKILL.md` (unchanged from original audit)
+- Plan: `/home/richy/.claude/plans/look-athe-last-session-dreamy-fog.md`
+- Findings drafts: `audits/findings-2026-05/022-028.md` (this directory)
+
+---
+
+## Appendix C — Suggested follow-on audits
+
+- **Re-audit after PR 1 + PR 2 land.** The contract-contradiction trio (022/023/024) has a single coherent fix bundle; once it merges, re-verify by spot-checking the new admin endpoints and the timing harness.
+- **Mini-app real-phone audit.** `INTEGRATION_NOTES.md` has an open `Origin`-header empirical test (#121) that requires phone-in-hand. Out of scope here, still pending.
+- **Operator-dashboard view of the granular fields after PR 1.** When granular `decision`/`rejectionReason` move behind admin auth, audit the admin claims-list rendering for any client-side caching that might leak to a non-admin tab.
+- **Adversarial ONNX inputs.** Same as the original audit's recommendation; still on the list.
+
+---
+
+## Appendix D — Skill update suggestions
+
+Append to [`~/.claude/skills/crypto-faucet-audit/SKILL.md`](~/.claude/skills/crypto-faucet-audit/SKILL.md) (deferred — propose to the user):
+
+1. **Section "Public-read endpoints"**: a checklist item for "any aggregate or recent-rows endpoint must not carry per-row `decision` / `rejectionReason` / `signalsJson` fields." Findings 022/023/025 would have been auto-flagged.
+2. **Section "Rejection timing"**: a checklist item for "pipelines that aggregate decisions must not short-circuit if response uniformity is part of the threat model — pad at the route layer." Finding 024 would have been auto-flagged.
+3. **Section "Cross-SDK parity"**: when a new SDK (e.g., sdk-capacitor, sdk-react-native) lands, run the cross-SDK HMAC-parity sweep that #104's fix established. Finding 028 would have been auto-flagged.
+
+Don't apply these changes to the skill yet — wait for maintainer sign-off on this audit.

--- a/audits/AUDIT-REPORT.md
+++ b/audits/AUDIT-REPORT.md
@@ -1,0 +1,175 @@
+# Nimiq Simple Faucet — Security Audit Report
+
+**Target:** [`PanoramicRum/nimiq-simple-faucet`](https://github.com/PanoramicRum/nimiq-simple-faucet)
+**Commit audited:** `main @ ee34d1e2e3385e64a77463a4d9aaff85750a5d55`
+**Audit dates:** 2026-04-23 → 2026-04-24
+**Auditor:** Claude (Opus 4.7, 1M context), driven by maintainer (`PanoramicRum` / `richy@nimiq.com`)
+**Disclosure channel:** Public GitHub issues, label `security`. Maintainer waived the private-disclosure policy in [`SECURITY.md`](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/SECURITY.md). Each issue body carries a banner noting the waiver so downstream forks don't blindly inherit the channel.
+**Tooling installed:** Custom user-level skill `/crypto-faucet-audit` at `~/.claude/skills/crypto-faucet-audit/SKILL.md`. Built-in `/security-review` was not applicable (it reviews pending diffs, not snapshot audits).
+
+---
+
+## Executive summary
+
+The faucet is a substantial monorepo (TypeScript, Vue 3, Go, Dart, Python; 8 SDKs, 10 abuse-prevention layers, MCP server, Docker/Helm). The crypto and session-management primitives are largely well-chosen — XChaCha20-Poly1305 with random 24-byte nonces, Argon2id KDF, TOTP via `otplib`, `nanoid` ≥21 chars, `timingSafeEqual` on the HMAC and CSRF compare paths, atomic upsert on the IP rate-limit counter, generated-from-Zod OpenAPI. The audit found **21 issues** worth tracking publicly — 4 High, 11 Medium, 6 Low — concentrated in three themes:
+
+1. **Trust-boundary slips around proxy headers and unsigned client-supplied context.** `trustProxy: true` (#87) makes per-IP rate-limit and blocklist spoofable; unsigned `hostContext` from the SDK is accepted with only a 0.3 score penalty (#96), letting forged KYC fields nudge AI/fingerprint scoring.
+2. **Admin-side static credentials and seed-time gaps.** `FAUCET_ADMIN_MCP_TOKEN` is a long-lived env-var bearer for root-equivalent MCP tools (#88); the first-login admin password compare is `!==` (timing-leaky) and unthrottled (#89).
+3. **Supply-chain hygiene.** `--frozen-lockfile=false` in 7 install sites (#90), unpinned base image (#92), unpinned GitHub Actions (#93), 6 transitive CVEs in lockfile (#107).
+
+None of these are remote-unauthenticated treasury-drain bugs; the weighted-score abuse pipeline plus claim-amount caps mitigate worst-case payouts. The most leveraged single fix is **#87 (trustProxy CIDR)** — once spoofing is closed, the rate-limit and blocklist regain their teeth and several adjacent findings (e.g., hashcash replay #95) lose most of their amplification.
+
+The MCP admin auth gap (#88) is acknowledged as a TODO in code comments and is the highest-value design fix. Documenting `FAUCET_ADMIN_MCP_TOKEN` as a root-equivalent secret in the interim is essential.
+
+---
+
+## Scope
+
+**In scope:** `apps/`, `packages/`, `deploy/`, `.github/workflows/`, `scripts/`, `SECURITY.md`, `openapi/`, MCP tool surface.
+
+**Out of scope:** third-party provider internals (Cloudflare, hCaptcha, MaxMind, IPinfo, DB-IP), downstream integrator apps using the SDKs, `core-rs-albatross` node, load/DoS testing against live instances, social engineering.
+
+---
+
+## Methodology
+
+1. **Skill installed.** Wrote `/crypto-faucet-audit` user-level skill encoding the Nimiq+faucet+abuse-layer checklist for repeatable future audits.
+2. **Three Explore agents in parallel** over server/auth/crypto, abuse layers, and deploy/CI/SDKs respectively. Their findings were cross-checked against actual file contents (not just agent recall) before any issue was filed.
+3. **Targeted greps** for `trustProxy`, `Math.random`, `rejectUnauthorized`, IP-trust headers, raw SQL, etc.
+4. **`pnpm audit`** for dependency CVEs (6 moderate, consolidated into #107). `osv-scanner` was not installable from npm at audit time; `trivy` and `gitleaks` not present locally — repo's own CI workflows for those were trusted as canary.
+5. **Disclosure**: 21 issues filed with the `security` label, each prefixed with the SECURITY.md-waiver banner.
+
+---
+
+## Findings index
+
+All issues filed at `github.com/PanoramicRum/nimiq-simple-faucet`.
+
+| # | Sev | Title | Issue | Local draft |
+|---|-----|-------|-------|-------------|
+| 001 | High | trustProxy: true → IP-spoofing bypass of rate-limit + blocklist | [#87](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/87) | [findings/001](findings/001-trustproxy-ip-spoofing.md) |
+| 002 | High | MCP admin via static FAUCET_ADMIN_MCP_TOKEN (no rotation/session) | [#88](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/88) | [findings/002](findings/002-mcp-admin-token-static-env.md) |
+| 003 | High | Admin first-login: non-constant-time compare + brute-force window | [#89](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/89) | [findings/003](findings/003-admin-first-login-timing-and-ratelimit.md) |
+| 004 | High | `pnpm install --frozen-lockfile=false` in Dockerfile + 6 workflows | [#90](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/90) | [findings/004](findings/004-pnpm-frozen-lockfile-disabled.md) |
+| 005 | Med | Captcha checks: no try/catch, no timeout → DoS + IP-quota burn | [#91](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/91) | [findings/005](findings/005-captcha-no-try-catch-or-timeout.md) |
+| 006 | Med | Dockerfile base image not pinned to digest | [#92](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/92) | [findings/006](findings/006-dockerfile-base-image-not-pinned.md) |
+| 007 | Med | All GitHub Actions pinned to version tags, not commit SHAs | [#93](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/93) | [findings/007](findings/007-github-actions-not-sha-pinned.md) |
+| 008 | Med | Blocklist: no IP/address normalization (IPv6-mapped, NQ case) | [#94](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/94) | [findings/008](findings/008-blocklist-no-normalization.md) |
+| 009 | Med | Hashcash: no per-solution replay cache | [#95](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/95) | [findings/009](findings/009-hashcash-no-solution-replay-protection.md) |
+| 010 | Med | Unsigned hostContext: only 0.3 soft penalty, fields still consumed | [#96](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/96) | [findings/010](findings/010-unsigned-hostcontext-soft-penalty.md) |
+| 011 | Low | Session cookie missing `__Host-` prefix | [#97](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/97) | [findings/011](findings/011-session-cookie-host-prefix.md) |
+| 012 | Low | SDK `randomNonce` has Math.random fallback | [#98](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/98) | [findings/012](findings/012-sdk-random-nonce-math-random-fallback.md) |
+| 013 | Low | ci.yml has no top-level `permissions:` block | [#99](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/99) | [findings/013](findings/013-ci-yml-no-permissions-block.md) |
+| 014 | Med | release.yml workflow_dispatch tag input not validated | [#100](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/100) | [findings/014](findings/014-release-workflow-dispatch-tag-unvalidated.md) |
+| 015 | Low | Helm: no PDB template, NetworkPolicy off by default | [#101](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/101) | [findings/015](findings/015-helm-missing-pdb-and-netpol-default.md) |
+| 016 | Low | RPC driver: no SSRF validation on configured rpcUrl | [#102](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/102) | [findings/016](findings/016-rpc-driver-no-ssrf-validation.md) |
+| 017 | Med | GeoIP unknown-country with allow-list returns soft 0.9 not deny | [#103](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/103) | [findings/017](findings/017-geoip-unknown-country-soft-score.md) |
+| 018 | Low | sdk-go and sdk-flutter don't implement hostContext HMAC signing | [#104](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/104) | [findings/018](findings/018-sdk-go-flutter-hostcontext-signing-gap.md) |
+| 019 | Med | Fingerprint store: COUNT(DISTINCT uid) skips null UIDs → bypass | [#105](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/105) | [findings/019](findings/019-fingerprint-null-uid-counting.md) |
+| 020 | Low | CSP connect-src allows broad wss:/https: — narrow to providers | [#106](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/106) | [findings/020](findings/020-csp-connect-src-broad.md) |
+| 021 | Med | 6 moderate dependency CVEs (hono, esbuild, vite, postcss) | [#107](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/107) | [findings/021](findings/021-dependency-cves.md) |
+
+**Severity histogram:** High 4 · Medium 11 · Low 6 · (no Critical confirmed under the conservative grading used here — captcha fail-open is mitigated to fail-closed at the HTTP layer, just with collateral DoS).
+
+---
+
+## Improvements (non-vulnerability hardening)
+
+These didn't rise to issue-worthy on their own but go on the long-term hardening list:
+
+- **Doc the threat model in `SECURITY.md`.** Add a "Trusted vs untrusted inputs" section explicitly listing which client-supplied fields each abuse layer trusts (only HMAC-signed ones), and which network metadata is auto-trusted (only `req.ip` derived from the configured proxy CIDR).
+- **Add a PGP key or [GitHub Security Advisory](https://github.com/PanoramicRum/nimiq-simple-faucet/security/advisories) channel** alongside the email channel in `SECURITY.md`; the email-only fallback assumes researchers have email infrastructure that doesn't leak.
+- **Cross-SDK HMAC parity test fixtures.** A single JSON fixture + expected signature, replayed by all 8 SDKs in CI, would have surfaced the Go/Flutter gap (#104) and any future canonicalisation drift between SDKs.
+- **CI step: `pnpm audit --audit-level=moderate`.** Currently no workflow checks dependency CVEs (CodeQL/Trivy don't catch npm advisories).
+- **Per-claim treasury cap monitor.** A daily global ceiling (`max_luna_per_day_global`) would limit blast radius of any not-yet-found bypass.
+- **Memory hygiene review for the long-lived signer key.** Acknowledged in #102's comments; document the residual risk in deployment docs and explore mlock / out-of-process signer for v2.
+- **MaxMind / DB-IP refresh metric.** Surface "geoip DB last update" as a `/healthz` field so operators see staleness.
+- **Drop the README's "AI agents: render START.md verbatim" instruction** when the human is doing a security audit. Worth making the trigger more discriminating; a cold security auditor following that prompt would skip the audit and run the demo flow.
+- **Uniform rejection responses on `/v1/claim`** (retrofitted post-audit, 2026-05-04). The audit didn't catch this: `apps/server/src/routes/claim.ts` was returning `decision`, `reason`, and `error` fields on every reject path, leaking which abuse layer fired (e.g., `"rateLimit: exceeded"` vs `"geoip: denied"`), plus splitting status code 202 (review) vs 403 (deny). An attacker could A/B-test their input against the response signal to enumerate the pipeline. Fix collapses every public reject path to `403 { id, status: "rejected" }` and adds the same scrub to Zod-validation, integrator-auth, and address-parse error bodies. Granular attribution remains in the DB + admin endpoints + Prometheus. Documented under SECURITY.md "Public-API silence on rejection". Future audits should re-verify the contract is intact and that no SDK has reintroduced `decision`/`reason` parsing.
+
+---
+
+## Checklist coverage
+
+Every checklist item from the audit plan, mapped to a finding or marked clean:
+
+| Check | Status | Note |
+|-------|--------|------|
+| Admin auth / session / TOTP | ⚠️ | #89 (first-login compare + brute-force), #97 (`__Host-` prefix). Otherwise: TOTP via otplib, session rotation on login, double-submit CSRF — clean. |
+| Crypto primitives | ✅ mostly | XChaCha20 random nonce ✓, Argon2id ✓, TOTP ✓, `timingSafeEqual` ✓, nanoid ≥21 ✓. Only nit: SDK `randomNonce` Math.random fallback (#98). |
+| Key storage | ✅ mostly | Encryption-at-rest with XChaCha + KDF ✓, file 0o600 ✓, pino redact paths ✓. Residual: plaintext in memory during signing — documented as known Node limitation. |
+| Signer drivers | ⚠️ | #102 (RPC SSRF hardening). WASM/RPC tx construction otherwise correct: Ed25519, validity-start-height set, fees bounded by config. |
+| Claim endpoint / race conditions | ✅ | IP counter incremented BEFORE pipeline (TOCTOU close) ✓, Drizzle parameterised ✓, idempotency key honoured ✓. |
+| Abuse layer: blocklist | ⚠️ | #94 (normalization). |
+| Abuse layer: rate limit | ⚠️ | #87 (IP source). Atomic upsert ✓ otherwise. |
+| Abuse layer: turnstile / hcaptcha / fcaptcha | ⚠️ | #91 (no try/catch, no timeout). |
+| Abuse layer: hashcash | ⚠️ | #95 (no replay cache). HMAC + difficulty + freshness ✓. |
+| Abuse layer: geoip / ASN | ⚠️ | #103 (unknown-country in allow-list mode). Private-IP skip ✓. |
+| Abuse layer: fingerprint | ⚠️ | #96 (unsigned context), #105 (null UID count). |
+| Abuse layer: on-chain heuristics | ⚠️ | Hardcoded thresholds noted as a config-flexibility gap (not filed; documented under Improvements). |
+| Abuse layer: AI / ONNX | ✅ | Fail-closed on inference error ✓. Model integrity / adversarial bounds noted as residual risk. |
+| MCP tool exposure | ⚠️ | #88. Tools are admin-gated via `requireAdminToken`, but the token is static. |
+| Input validation (Zod) | ✅ | Every route has Zod with `.safeParse`. No `z.any()` on trust boundary. |
+| CORS / Helmet / headers | ⚠️ | #106 (CSP). HSTS, X-Frame-Options, Referrer-Policy ✓ in non-dev. |
+| Database (Drizzle, SQLite/Postgres) | ✅ | Parameterised throughout; no raw `sql\`\`` interpolation found. |
+| Dependencies | ⚠️ | #107 (6 moderate CVEs). |
+| Docker | ⚠️ | #92 (digest pin). USER node ✓, multi-stage ✓, HEALTHCHECK ✓. |
+| Helm / K8s | ⚠️ | #101 (PDB, NetworkPolicy default). securityContext ✓, resource limits ✓. |
+| CI / supply chain | ⚠️ | #90, #93, #99, #100. OIDC for npm ✓, sbom.yml ✓, separate codeql/trivy/gitleaks ✓. |
+| SDK hostContext HMAC | ⚠️ | #104 (Go/Flutter gap). TS+Python parity ✓, server `timingSafeEqual` ✓, signature field excluded from canonical form ✓. |
+
+---
+
+## Appendix A — Tool output
+
+### `pnpm audit`
+
+```
+6 vulnerabilities found
+Severity: 6 moderate
+- hono <4.12.14 (GHSA-458j-xx4x-4375) — JSX HTML injection (via @modelcontextprotocol/sdk)
+- esbuild <=0.24.2 (GHSA-67mh-4wv8-2f99) — dev server SSRF
+- vite <=6.4.1 (GHSA-4w7w-66w2-5vf9) — path traversal in optimized deps
+- postcss <8.5.10 (GHSA-qx2v-qp2m-jg93) — XSS in CSS stringify
+```
+
+Filed as #107.
+
+### `osv-scanner`
+Not run — package not available on npm at audit time. Falling back to `pnpm audit` and the CodeQL / Trivy CI runs.
+
+### Custom-skill grep sweeps
+
+- `Math.random` — 4 hits, 1 valid concern (sdk-ts randomNonce fallback, #98), 3 false positives (PoW search nonces, DOM ID generation).
+- `trustProxy` — 1 hit, valid (#87).
+- `rejectUnauthorized: false` — 0 hits.
+- `req.ip / X-Forwarded-For / cf-connecting-ip` — multiple expected hits in rate-limit and blocklist code, all sourced from `req.ip` which depends on #87 being fixed.
+- `dangerouslySetInnerHTML / v-html` — 0 hits.
+- raw `drizzle.sql\`...\${var}\`` — 0 hits.
+- `=== '...'` against secrets — 1 hit (#89), the rest use `timingSafeEqual`.
+
+### CI runs not re-executed locally
+- CodeQL (`.github/workflows/codeql.yml`): trusted from CI.
+- Trivy (`.github/workflows/trivy.yml`): trusted from CI.
+- Gitleaks (`.github/workflows/gitleaks.yml`): trusted from CI.
+
+---
+
+## Appendix B — Environment
+
+- Auditor OS: Linux 6.8.0-110-generic
+- Node: v22 (per Dockerfile target)
+- pnpm: 9.12.0 (per CI lockfile expectation)
+- `gh` CLI: authenticated as `PanoramicRum`
+- Skill: `~/.claude/skills/crypto-faucet-audit/SKILL.md`
+- Plan: `/home/richy/.claude/plans/create-the-plan-to-reactive-flute.md`
+- Findings drafts: `/home/richy/Projects/Faucet Reviews/Security/Claude/findings/001-021.md`
+
+---
+
+## Appendix C — Suggested follow-on audits
+
+- **Re-audit after #87 + #88 fixes land.** Several Medium findings derive their leverage from those two; closing them changes the threat-model headline.
+- **Cross-SDK HMAC parity replay** (worth a one-shot fixture-based test, beyond #104).
+- **Hostile RPC node simulation** — point the driver at a node that lies about heights/balances and observe whether on-chain heuristics still hold.
+- **Adversarial ONNX inputs** — out of scope here; worth a focused review when v1 of the AI layer ships beyond CPU-only.

--- a/audits/INTEGRATION_NOTES.md
+++ b/audits/INTEGRATION_NOTES.md
@@ -1,0 +1,280 @@
+# Integration notes — Mini App ↔ Nimiq Simple Faucet
+
+A live report kept while building `examples/mini-app-claim-vue/` and `examples/mini-app-claim-react/` in [`PanoramicRum/nimiq-simple-faucet`](https://github.com/PanoramicRum/nimiq-simple-faucet) (branch `mini-app-claim-examples`). Each entry is something a future integrator would want to know, or an issue worth filing on the relevant upstream.
+
+This doubles as the "test of the repo" you asked me to do — the friction below is what someone will hit if they try to ship a Mini App against this faucet today.
+
+Legend:
+- 🟢 **Worked first try** — copy/paste, no friction.
+- 🟡 **Worked after a workaround** — record what and why.
+- 🔴 **Real bug / blocker / docs gap** — should be filed as an issue.
+
+---
+
+## Working stack confirmed (smoke + runtime checks)
+
+Both per-example compose stacks come up clean:
+
+| Surface | URL the phone uses | Result |
+|---|---|---|
+| Vue mini app (Vite dev) | `http://<LAN_IP>:5173/` | HTTP 200, full SPA shell |
+| React mini app (Vite dev) | `http://<LAN_IP>:5174/` | HTTP 200, full SPA shell |
+| Faucet `/healthz` | `http://<LAN_IP>:28080/healthz` (Vue stack) | HTTP 200 |
+| Faucet `/v1/config` | same | returns `captcha: { provider: 'fcaptcha', siteKey, serverUrl }` |
+| fcaptcha widget bundle | `http://<LAN_IP>:3010/fcaptcha.js` | HTTP 200, 98 KB |
+| fcaptcha PoW challenge | `http://<LAN_IP>:3010/api/challenge` | issues challenge JSON |
+
+Both `pnpm turbo run build` chains in Docker succeed: Vue produces 72 KB / 28 KB gz, React 153 KB / 50 KB gz.
+
+End-to-end claim flow validation against a real Nimiq Pay WebView is the manual gate (`mini-apps-checklist` skill). Cannot be automated in CI — that's a doc-of-record limit, not something I can close.
+
+---
+
+## Findings
+
+### 🟢 SDK shapes are consistent across frameworks
+
+`@nimiq-faucet/sdk`, `/vue`, `/react` all delegate to `ClaimManager`, `StatusPoller`, `StreamManager` from the framework-agnostic core. A future Svelte/vanilla example reuses them with no SDK fork. No drift between Vue and React `useFaucetClaim` shapes.
+
+### 🟢 `FaucetConfig.captcha` discriminator is well-typed for fcaptcha
+
+```ts
+captcha: {
+  provider: 'turnstile' | 'hcaptcha' | 'fcaptcha';
+  siteKey: string;
+  serverUrl?: string;  // present only when provider is 'fcaptcha'
+} | null;
+```
+
+`/v1/config` returns this exactly as documented — the mini app picks the right widget purely from the response. (Caveat: `serverUrl` is a single value; it must be reachable from BOTH the faucet container AND the browser. See finding 🟡 below.)
+
+### 🟡 `@nimiq/mini-app-sdk@0.0.2` — error returns aren't a clean discriminated union
+
+From the published SDK's `dist/provider.d.ts`:
+
+```ts
+listAccounts(): Promise<string[] | ErrorResponse>;
+sign(message: ...): Promise<SignatureResult | ErrorResponse>;
+sendBasicTransaction(tx: ...): Promise<string | ErrorResponse>;
+```
+
+`ErrorResponse` is `{ error: { type: string; message: string } }`. Every call site has to write a runtime guard:
+
+```ts
+const result = await provider.listAccounts();
+if ('error' in result) throw new Error(result.error.message);
+const addresses = result; // typed as string[]
+```
+
+Either thrown errors or a `{ ok: true; value } | { ok: false; error }` union would let TS narrow naturally. Our shared bridge wraps this once so consumers don't repeat it.
+
+→ **Issue (developer-center)**: standardise on a single error convention across all `NimiqProvider` methods and document it on the SDK reference page.
+
+### 🟡 `@nimiq/mini-app-sdk` is at `0.0.2` and unversioned in the scaffold skill
+
+The best-practices and scaffold skills in [`nimiq/developer-center#175`](https://github.com/nimiq/developer-center/pull/175) say `npm install @nimiq/mini-app-sdk` with no range. `0.0.x` versions imply more breaking changes ahead.
+
+→ **Issue (developer-center)**: pin a `^0.0.2` (or whatever's tested) in the scaffold skill, document upgrade story in build-with-AI.
+
+### 🔴 The published SDK and the official demo disagree on package name
+
+- `nimiq/developer-center#175` best-practices skill: `@nimiq/mini-app-sdk`.
+- [`Eligioo/nimiq-mini-app-demo`](https://github.com/Eligioo/nimiq-mini-app-demo) (linked from best-practices as a reference impl): `@trustwallet/web3-provider-nimiq` from a relative file path.
+
+They're related (the published SDK wraps the trust-web3-provider package), but a brand-new contributor following the demo will install a different package than the docs prescribe.
+
+→ **Issue (developer-center)**: update the demo to consume `@nimiq/mini-app-sdk` from npm, OR call out the relationship explicitly in the demo README.
+
+### 🔴 No empirical test of WebView `Origin` header
+
+I have not been able to test what Android WebView vs iOS WKWebView puts in the `Origin` header for fetches from a LAN-loaded mini app. If `null`, the faucet's browser-only enforcement (`FAUCET_REQUIRE_BROWSER=true`) blocks it, AND `FAUCET_CORS_ORIGINS` matching needs explicit `null`-origin handling.
+
+The example compose sets `FAUCET_CORS_ORIGINS=*` and `FAUCET_REQUIRE_BROWSER=false` so this is a non-issue for LAN dev — but production deployments need a real answer.
+
+→ **Issue (faucet)**: real-phone test that records the `Origin` header from inside Nimiq Pay's WebView on Android + iOS. Document in `apps/docs/`.
+→ **Issue (developer-center)**: add a "fetching backends from a Mini App" section to `mini-apps-best-practices` covering CORS + the `Origin` question.
+
+### 🔴 Repo-root `.dockerignore` excludes `examples/` and most framework SDKs
+
+```
+# faucet/.dockerignore
+examples
+packages/sdk-vue
+packages/sdk-react
+packages/sdk-flutter
+packages/sdk-go
+packages/sdk-react-native
+packages/sdk-capacitor
+deploy/compose
+```
+
+Plain `docker build -f examples/<any>/Dockerfile -t x .` from the repo root fails because the build context is missing the example AND most of the SDK packages. The existing `examples/vue-claim-page/Dockerfile` and `examples/nextjs-claim-page/Dockerfile` are subject to the same — they likely never run via plain `docker build`, only via the existing `examples/docker-compose.yml` pipeline (and even that is suspect; see the next finding).
+
+**Workaround**: each new example ships a sibling `Dockerfile.dockerignore` (and `Dockerfile.dev.dockerignore`) that BuildKit honors instead of the root one.
+
+→ **Issue (faucet)**: either move the per-image excludes into per-Dockerfile dockerignores everywhere, or provide a `.dockerignore` per build context. Today's setup quietly breaks any plain `docker build` of an example.
+
+### 🔴 Existing per-example Dockerfiles assume a deps-only-cache layer that can't actually install
+
+Both `examples/vue-claim-page/Dockerfile` and `examples/nextjs-claim-page/Dockerfile` follow a "copy package.jsons → pnpm install → copy source" pattern. They `COPY` only `pnpm-workspace.yaml`, the root `package.json`, the lockfile, and a few example-specific `package.json` files.
+
+But the root `package.json` has:
+
+```json
+"devDependencies": {
+  "@faucet/abuse-hashcash": "workspace:*"
+}
+```
+
+…and `pnpm install` validates the lockfile against every workspace member. Without `packages/abuse-hashcash/package.json` in the build context, install fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. I hit this. The simplest correct pattern is to copy the full workspace once, then `pnpm install --filter @nimiq-faucet/example-...`.
+
+→ **Issue (faucet)**: rewrite `examples/vue-claim-page/Dockerfile` and `examples/nextjs-claim-page/Dockerfile` to either (a) include all workspace `package.json` files, or (b) match the simpler "copy everything, filtered install" pattern used by the new mini-app examples. Add a CI job that actually runs `docker build` against each example to prevent regression.
+
+### 🔴 `deploy/compose/fcaptcha.yml` references a non-existent public image
+
+```yaml
+fcaptcha:
+  image: ghcr.io/webdecoy/fcaptcha:latest
+```
+
+`docker pull ghcr.io/webdecoy/fcaptcha:latest` returns `unauthorized`, and `docker pull webdecoy/fcaptcha:latest` returns `pull access denied`. The image isn't published anywhere public. Following the documented fcaptcha enable path silently breaks.
+
+**Workaround**: our example ships [`examples/mini-app-claim-shared/fcaptcha/Dockerfile`](faucet/examples/mini-app-claim-shared/fcaptcha/Dockerfile) which clones [WebDecoy/FCaptcha](https://github.com/WebDecoy/FCaptcha) and builds the server-node container locally. Per-example compose overrides the `fcaptcha.image` and points to this build context.
+
+→ **Issue (faucet)**: either publish a real `ghcr.io/panoramicrum/fcaptcha:<ref>` image (mirror or fork), or replace `image:` with a `build:` block in `deploy/compose/fcaptcha.yml` that builds from the upstream repo. The current value is broken-as-shipped.
+→ **Issue (developer-center, indirectly)**: when a faucet example is added to the Mini Apps ideas page, link the fixed compose so people don't hit this.
+
+### 🔴 FCaptcha's server-node does not serve `client/fcaptcha.js`
+
+The widget bundle the browser needs lives at `client/fcaptcha.js` in the upstream repo, but the `server-node/server.js` express app only registers `/health`, `/api/verify`, `/api/score`, `/api/token/verify`, `/api/pow/challenge`, `/api/challenge`. Browsers fetching `<serverUrl>/fcaptcha.js` get 404.
+
+The faucet's `FaucetConfig.captcha.serverUrl` returns the operator-provided fcaptcha URL — implying the operator's deployment is supposed to serve the widget. Upstream's published deploy story doesn't.
+
+**Workaround (currently shipping)**: this repo's `deploy/compose/fcaptcha/Dockerfile` (PR [#137](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/137)) and the per-example `examples/mini-app-claim-shared/fcaptcha/Dockerfile` both `sed`-patch `server.js` to add `app.use('/fcaptcha.js', express.static('/app/client/fcaptcha.js'))`. Verified working: `curl http://<LAN_IP>:3010/fcaptcha.js` returns the 98 KB bundle.
+
+→ **Issue (FCaptcha upstream)**: filed as [WebDecoy/FCaptcha#4](https://github.com/WebDecoy/FCaptcha/issues/4). Maintainer reaction status below.
+→ **Issue (faucet)**: until upstream FCaptcha ships the fix in a tagged release, keep the `sed`-patched Dockerfile as the recommended path. Mention in `packages/abuse-fcaptcha/` README.
+
+#### Upstream status (2026-04-27)
+
+Maintainer [@cport1](https://github.com/cport1) confirmed the fix is welcome and asked for three small tweaks before we open the PR. Comment thread: [WebDecoy/FCaptcha#4 (comment)](https://github.com/WebDecoy/FCaptcha/issues/4#issuecomment-4330147804).
+
+- **`server-go` already serves `/fcaptcha.js`** (via `main.go:63` + Docker `COPY client/fcaptcha.js ./static/`). The actual gap is `server-node` + `server-python` only.
+- **Use `res.sendFile` instead of `express.static`** — single-file route is cleaner than the directory-binding shape:
+  ```js
+  app.get('/fcaptcha.js', (req, res) => {
+    res.sendFile(path.join(__dirname, '..', 'client', 'fcaptcha.js'));
+  });
+  ```
+- **Add `FCAPTCHA_CLIENT_PATH` env override** — the `../client` assumption breaks if anyone copies `server-node/` standalone.
+- **Confirmed**: opt-out default + the `FCAPTCHA_SERVE_CLIENT` env name are both fine. Open the PR. `server-python` parity is fine as a follow-up.
+
+PR opened upstream as **[WebDecoy/FCaptcha#5](https://github.com/WebDecoy/FCaptcha/pull/5)** (2026-04-28; 2 files, +29/-0). Already used `res.sendFile` from the original draft, then amended on the fork to add the `FCAPTCHA_CLIENT_PATH` override and correct the INSTALLATION.md `server-go` parity note.
+
+#### Follow-up TODO
+
+- [x] ~~Amend the draft branch per the three asks above.~~ Done — commit `9a3514f` on `PanoramicRum/FCaptcha:serve-client-bundle`.
+- [x] ~~Open PR upstream against [WebDecoy/FCaptcha](https://github.com/WebDecoy/FCaptcha).~~ Done — [PR #5](https://github.com/WebDecoy/FCaptcha/pull/5).
+- [ ] **Watch [PR #5](https://github.com/WebDecoy/FCaptcha/pull/5) (server-node) for review feedback** and amend if @cport1 asks for changes.
+- [x] ~~`server-python` parity as a separate follow-up PR.~~ Done — [PR #6](https://github.com/WebDecoy/FCaptcha/pull/6) (`PanoramicRum/FCaptcha:serve-client-bundle-python`, FastAPI `FileResponse` route + same `FCAPTCHA_SERVE_CLIENT` / `FCAPTCHA_CLIENT_PATH` env vars).
+- [ ] **Watch [PR #6](https://github.com/WebDecoy/FCaptcha/pull/6) (server-python) for review feedback** and amend if @cport1 asks for changes.
+- [ ] **Once merged + tagged**: bump the `RELEASE_TAG`/`git checkout` reference in [`deploy/compose/fcaptcha/Dockerfile`](../deploy/compose/fcaptcha/Dockerfile) and [`examples/mini-app-claim-shared/fcaptcha/Dockerfile`](../examples/mini-app-claim-shared/fcaptcha/Dockerfile), then drop the `sed` patch (the route now ships in upstream `server.js`).
+- [ ] **Update `packages/abuse-fcaptcha/` README** to point at the upstream tag instead of the workaround once the patch ships.
+
+### 🔴 `FAUCET_FCAPTCHA_URL` conflates server-side and browser-side URLs
+
+The same env var is used for two purposes:
+1. **Server-to-server**: faucet → fcaptcha to verify a token (`POST /api/verify`). Best value: internal Docker DNS (`http://fcaptcha:3000`).
+2. **Browser-facing**: returned in `/v1/config.captcha.serverUrl`. Best value: a URL the browser can actually reach (e.g. `http://<LAN_IP>:3010` for LAN dev, `https://captcha.example.com` for prod).
+
+Setting it to `http://fcaptcha:3000` works for the faucet but the phone WebView can't resolve `fcaptcha`. Setting it to the LAN IP works for the phone, and it ALSO works for the faucet container because Docker's bridge allows outbound. So in dev, the LAN IP is the only value that satisfies both.
+
+In production, this is fine because the public URL is reachable from both sides. In dev, it's a footgun.
+
+→ **Issue (faucet)**: split into `FAUCET_FCAPTCHA_INTERNAL_URL` (server-to-server, defaults to public URL) and `FAUCET_FCAPTCHA_PUBLIC_URL` (returned to browser). Or just document the dev quirk loudly in `packages/abuse-fcaptcha/`.
+
+### 🔴 `@nimiq/core` WASM panics intermittently on startup with `time not implemented on this platform`
+
+When booting `nimiq-faucet:dev` (built from `deploy/docker/Dockerfile`) with `FAUCET_SIGNER_DRIVER=wasm`, ~30% of starts crash with:
+
+```
+ERROR panic | thread '<unnamed>' panicked at 'time not implemented on this platform':
+/rustc/.../library/std/src/sys/time/unsupported.rs:35
+```
+
+…shortly after the `Requesting zkp from peer` log line. The Fastify HTTP server is up and responsive in the surviving 70%; one minute later it can also crash mid-flight. This is independent of fcaptcha or our env.
+
+The image is `node:22-bookworm-slim` — Linux x86_64, glibc — should not be missing any common time syscalls. Likely an interaction between `@nimiq/core` 2.4.0 WASM and the network conditions during testnet handshake.
+
+**Workaround for our PR**: the README documents the option to switch to `FAUCET_SIGNER_DRIVER=rpc` + the `local-node` profile. Smoke-build + per-service health checks are the gate; full claim flow needs a real phone anyway.
+
+→ **Issue (faucet / @nimiq/core)**: investigate the WASM time-syscall panic. May be a known issue worth pinning a different `@nimiq/core` version or a sysconf override. Worth adding a CI smoke-up of the WASM driver since this is the default in `quick start`.
+
+### 🟡 `pnpm install` in Docker — workspace filter trims correctly
+
+`pnpm install --filter @nimiq-faucet/example-mini-app-vue... --frozen-lockfile=false` installs only the example + its workspace deps (sdk-ts, sdk-vue, mini-app-claim-shared) rather than the full graph. Cuts the image size meaningfully (no Nimiq-WASM blob, no Postgres client, no playwright browsers).
+
+### 🟡 Vite HMR over Docker requires `VITE_HMR_HOST`
+
+Without it, the HMR client tries `localhost:5173` from inside the phone WebView and silently fails. Setting `VITE_HMR_HOST=<LAN_IP>` in the dev compose fixes it. Worth a one-liner in `mini-apps-scaffold`.
+
+→ **Issue (developer-center)**: add to scaffold skill — when generating a Vite-based Mini App, set `VITE_HMR_HOST` from env or document the manual config.
+
+### 🟡 Per-example Compose port mappings collide on common ports
+
+Default `8080` (faucet), `3000` (fcaptcha) — almost everyone running this on a dev machine has SOMETHING bound to those. Our compose uses `${FAUCET_HOST_PORT:-28080}` etc. with `ports: !override` to remap host-side without touching the included compose fragment.
+
+→ **Issue (faucet)**: in `deploy/compose/docker-compose.yml`, default to `${FAUCET_HOST_PORT:-8080}` / `${FCAPTCHA_HOST_PORT:-3000}` instead of hardcoded ports. Lets contributors run multiple stacks side-by-side without forking.
+
+### 🟢 Faucet `/v1/config` exposes everything a Mini App needs
+
+Network, claim amount, abuse layers, captcha config (with `serverUrl` for fcaptcha) — one call gives the mini app everything it needs to render the right widget and set expectations. Good shape.
+
+---
+
+## Decisions baked into this PR (recap)
+
+- **Self-contained per-example compose**: `include:` pulls `deploy/compose/docker-compose.yml` + `deploy/compose/fcaptcha.yml`, then overrides what's broken (image, ports, env). One command per example, zero duplication.
+- **fcaptcha as the demo captcha** (your pick): self-hosted, no third-party iframe. WebView-friendly. Required upstream patches noted above.
+- **Shared module local, not a published package**: graduates to `packages/mini-app-core/` → `@nimiq-faucet/mini-app` once a third framework example exists.
+- **Mini App SDK return type narrowed** in `bridge.ts:getUserAddress` so call sites never see `ErrorResponse`.
+- **Testnet only**: examples never default to mainnet. README explicitly calls this out plus the `FAUCET_TLS_REQUIRED=false` / `FAUCET_CORS_ORIGINS=*` dev-only warning.
+
+## What was validated
+
+- ✅ `pnpm turbo run build --filter @nimiq-faucet/example-mini-app-vue` (inside Docker) → 72 KB JS / 28 KB gz, 0 errors.
+- ✅ `pnpm turbo run build --filter @nimiq-faucet/example-mini-app-react` (inside Docker) → 153 KB JS / 50 KB gz, 0 errors.
+- ✅ `docker compose up -d` (Vue stack) → faucet, fcaptcha, vite all start, all health endpoints return HTTP 200.
+- ✅ `/v1/config` returns the right `fcaptcha` provider block with a LAN-reachable `serverUrl`.
+- ✅ `/fcaptcha.js` serves the 98 KB widget bundle from the LAN URL.
+- ✅ `/api/challenge` issues PoW challenges from the LAN URL.
+- ❓ Full claim against real Nimiq Pay WebView — manual phone test, can't be CI'd.
+- ❓ WASM consensus stability — intermittent panic upstream, see finding above.
+
+## Issues to file
+
+Counting per upstream:
+
+**Against `PanoramicRum/nimiq-simple-faucet`** (8):
+1. `.dockerignore` breaks plain `docker build` of any example.
+2. `examples/{vue-claim-page,nextjs-claim-page}/Dockerfile` deps-only-cache pattern is broken; rewrite or test in CI.
+3. `deploy/compose/fcaptcha.yml` image (`ghcr.io/webdecoy/fcaptcha:latest`) doesn't exist publicly.
+4. `FAUCET_FCAPTCHA_URL` conflates server-side and browser-side URLs.
+5. `@nimiq/core` WASM `time not implemented` panic; investigate and pin.
+6. Hardcoded host ports in `deploy/compose/docker-compose.yml` collide; allow env overrides.
+7. Document WebView `Origin` header behaviour (Android + iOS) once empirically tested.
+8. Add CORS-wildcard subdomain support to `FAUCET_CORS_ORIGINS` for staging Mini App deploys.
+
+**Against `nimiq/developer-center`** (7):
+9. Add "Faucet" to the Mini Apps ideas page; link this PR once merged.
+10. Add `/mini-apps/sdk-reference` documenting the `@nimiq/mini-app-sdk` API.
+11. Standardise NimiqProvider error returns across all wallet methods (`listAccounts`, `sign`, `sendBasicTransaction`, etc.).
+12. Pin a tested `@nimiq/mini-app-sdk` version in `mini-apps-scaffold` skill.
+13. Reconcile `Eligioo/nimiq-mini-app-demo` with the published `@nimiq/mini-app-sdk` package name.
+14. Add CORS / backend-API section to `mini-apps-best-practices` skill.
+15. Add `VITE_HMR_HOST` guidance to `mini-apps-scaffold` skill.
+
+**Against `WebDecoy/FCaptcha`** (1):
+16. server-node should serve `client/fcaptcha.js` by default, or its README should document that operators must.
+
+I'll open these as draft issues against the maintainer's repo when the PR is filed (or include them in the PR description as a follow-up checklist if you'd prefer).

--- a/audits/PR-113-rebase-handoff.md
+++ b/audits/PR-113-rebase-handoff.md
@@ -1,0 +1,154 @@
+# PR #113 rebase hand-off — upstream fixes have landed
+
+Hi! 👋 Thanks for the very thorough integration write-up in [`audits/INTEGRATION_NOTES.md`](./INTEGRATION_NOTES.md). All 7 of the issues you filed (#115–#122 minus the still-pending #119 and #121) now have upstream fixes on `main`. PR #113 should rebase cleanly with significantly fewer files — the workarounds you wrote can be dropped because the upstream paths now do the right thing.
+
+This doc walks through:
+
+1. Which upstream PRs landed and what each one closes.
+2. Which workaround files in your branch become redundant.
+3. The exact rebase steps.
+4. The two issues that intentionally stayed open (and why) plus how to help close them.
+
+---
+
+## What landed upstream
+
+All against `main`, between 2026-04-26 ~22:00 and ~02:00 UTC.
+
+| Upstream PR | Issues closed | Summary |
+|---|---|---|
+| [#136](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/136) | #115, #116 | Root `.dockerignore` trimmed to universal excludes; server-image-only excludes moved to `deploy/docker/Dockerfile.dockerignore`. Both `examples/{vue,nextjs}-claim-page/Dockerfile` rewritten to "copy full workspace, filter install" — same pattern your mini-app Dockerfiles use. New CI `examples-build` job runs `docker buildx build` on each example so this can't regress. |
+| [#137](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/137) | #117, #118 | New `deploy/compose/fcaptcha/Dockerfile` builds WebDecoy/FCaptcha v1.7.0 from source and `sed`-patches `server.js` to expose `/fcaptcha.js` — same shape as your `examples/mini-app-claim-shared/fcaptcha/Dockerfile`. The compose overlay now uses `build:` instead of the unpullable `image:`. Server config split into `FAUCET_FCAPTCHA_INTERNAL_URL` (server-to-server) + `FAUCET_FCAPTCHA_PUBLIC_URL` (browser-facing); legacy `FAUCET_FCAPTCHA_URL` honoured for one minor with a deprecation warning. |
+| [#138](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/138) | #120 | `${FAUCET_HOST_PORT:-8080}` and `${NIMIQ_P2P_HOST_PORT:-8443}` in `deploy/compose/docker-compose.yml`. Tranche B already added `FCAPTCHA_HOST_PORT` to `fcaptcha.yml`. |
+| [#139](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/139) | #122 | `FAUCET_CORS_ORIGINS` accepts `*.example.com` patterns. Both Fastify CORS and the browser-only `Origin` enforcement match the new shape. New `docs/mini-apps-integration.md` covers CORS + FCaptcha URL placement + the WebView `Origin` test plan. |
+| [#140](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/140) | tracks #119 | README + production docs flipped to recommend `FAUCET_SIGNER_DRIVER=rpc` for production (your call in the example READMEs is now the project-wide recommendation). CI smoke distinguishes the upstream WASM panic from real regressions and downgrades it to a `::warning::` instead of failing the build. New `docs/quality/wasm-time-panic-upstream-report.md` is a maintainer-ready draft we'll file against `nimiq/core-rs-albatross`. |
+
+Server test count went from 115 → 123 across these PRs (+5 fcaptcha-url-split, +8 cors-wildcard). All CI green per PR.
+
+---
+
+## Workarounds in PR #113 that can be dropped
+
+Each of these files landed in your branch as a local workaround for an upstream gap. With the upstream fix in place, they're redundant — keeping them creates two sources of truth that drift.
+
+### After rebasing onto `main`, delete:
+
+| File in PR #113 | Replaced upstream by | Why |
+|---|---|---|
+| `examples/mini-app-claim-vue/Dockerfile.dockerignore` | (not needed) | Root `.dockerignore` no longer excludes `examples/`. |
+| `examples/mini-app-claim-vue/Dockerfile.dev.dockerignore` | (not needed) | Same. |
+| `examples/mini-app-claim-react/Dockerfile.dockerignore` | (not needed) | Same. |
+| `examples/mini-app-claim-react/Dockerfile.dev.dockerignore` | (not needed) | Same. |
+| `examples/mini-app-claim-shared/fcaptcha/Dockerfile` | [`deploy/compose/fcaptcha/Dockerfile`](../deploy/compose/fcaptcha/Dockerfile) | Identical pattern, pinned to v1.7.0. Reference the upstream one from your example compose files. |
+
+### After rebasing, simplify:
+
+#### `examples/mini-app-claim-{vue,react}/docker-compose.yml`
+
+- **Drop the `ports: !override` block** under the included `faucet` and `fcaptcha` services. The upstream compose now reads `${FAUCET_HOST_PORT:-8080}` / `${FCAPTCHA_HOST_PORT:-3000}` directly, so you set those env vars (in the per-example `.env` or as `environment:` keys on the compose file) instead of an override block.
+- **Remove the local fcaptcha build context** (the line that points at `examples/mini-app-claim-shared/fcaptcha/`). The included `deploy/compose/fcaptcha.yml` now ships its own working `build:` block.
+- **Optionally swap `FAUCET_FCAPTCHA_URL` → `FAUCET_FCAPTCHA_PUBLIC_URL`**. Your existing `FAUCET_FCAPTCHA_URL=http://<LAN_IP>:3010` keeps working (deprecation warning at boot), but the cleaner shape is to set:
+  - `FAUCET_FCAPTCHA_PUBLIC_URL=http://<LAN_IP>:3010` (the phone hits this)
+  - leave `FAUCET_FCAPTCHA_INTERNAL_URL` unset (server uses `http://fcaptcha:3000` automatically when the overlay is included)
+
+#### CORS
+
+If your dev compose still sets `FAUCET_CORS_ORIGINS=*` but you'd like a slightly tighter allow-list, the new wildcard syntax accepts:
+
+```env
+# Single LAN IP
+FAUCET_CORS_ORIGINS=http://192.168.1.50:5173,http://192.168.1.50:5174
+
+# Or staging-deploy wildcards
+FAUCET_CORS_ORIGINS=*.staging.example.com
+```
+
+This is purely optional; `*` is fine for LAN dev.
+
+---
+
+## Rebase steps
+
+```bash
+# In your local clone of the repo
+git fetch origin
+git checkout mini-app-claim-examples
+git rebase origin/main
+```
+
+Conflicts will be on the workaround files only (they're effectively "removed" upstream because the new upstream paths obviate them). Resolve each by **deleting** the workaround file:
+
+```bash
+# Example: when git complains about Dockerfile.dockerignore
+git rm examples/mini-app-claim-vue/Dockerfile.dockerignore
+git rm examples/mini-app-claim-vue/Dockerfile.dev.dockerignore
+git rm examples/mini-app-claim-react/Dockerfile.dockerignore
+git rm examples/mini-app-claim-react/Dockerfile.dev.dockerignore
+git rm examples/mini-app-claim-shared/fcaptcha/Dockerfile
+
+# Then continue
+git rebase --continue
+```
+
+If the per-example `docker-compose.yml` files conflict (because of port-override blocks or the local fcaptcha build path), follow the "After rebasing, simplify" notes above to resolve.
+
+### Verify after rebase
+
+```bash
+# 1. Build both examples cleanly from a vanilla `docker build`
+docker buildx build -f examples/mini-app-claim-vue/Dockerfile -t mini-vue:test .
+docker buildx build -f examples/mini-app-claim-react/Dockerfile -t mini-react:test .
+
+# 2. Boot each per-example stack
+cd examples/mini-app-claim-vue
+docker compose up -d --build
+curl -fsS http://localhost:${FAUCET_HOST_PORT:-28080}/healthz   # → 200
+curl -fsS http://localhost:${FCAPTCHA_HOST_PORT:-3010}/fcaptcha.js | head -c 80
+docker compose down
+
+# 3. Workspace builds + tests
+pnpm install --frozen-lockfile
+pnpm turbo run build --filter '@nimiq-faucet/example-mini-app-vue' --filter '@nimiq-faucet/example-mini-app-react'
+```
+
+If anything fails, ping back — the most likely cause is a stale `node_modules` from the pre-rebase state (`rm -rf node_modules apps/*/node_modules packages/*/node_modules examples/*/node_modules && pnpm install --frozen-lockfile` clears it).
+
+---
+
+## Two issues we deliberately kept open
+
+### #119 — `@nimiq/core` WASM `'time not implemented on this platform'` panic
+
+**Status**: tracking ticket open in this repo; ready to file upstream.
+
+We have a maintainer-ready draft against `nimiq/core-rs-albatross` at [`docs/quality/wasm-time-panic-upstream-report.md`](../docs/quality/wasm-time-panic-upstream-report.md). It includes:
+
+- **Diagnosis**: most likely the WASM build target is `wasm32-unknown-unknown` without a JS shim wiring `Instant::now()` to `performance.now()`/`Date.now()`, so the stdlib's `unsupported` time backend gets linked. Section "What `core-rs-albatross` likely needs to look at" walks through the build-target / feature-flag possibilities.
+- **Standalone Docker repro**: 10 boots, ~3 panic. Single `docker run` command.
+- **Node-only minimal repro**: `npm install @nimiq/core@2.4.0` + 8 lines of JS, no faucet code in the path.
+- **"What we'd like to know"**: triage list to send to upstream — build target, JS shim location, known-good pin candidate.
+- **Working-with-the-maintainers section**: tone notes, ongoing-collaboration plan, close-the-loop tracking.
+
+**Action**: Ricardo (project maintainer) will file this against [`nimiq/core-rs-albatross`](https://github.com/nimiq/core-rs-albatross). Once filed, we update the doc's "Tracking" section with the upstream URL and link from #119. If you want to coordinate or be CC'd on the upstream thread, just say so.
+
+CI is now tolerant of the panic: when our `docker` smoke job sees the exact `'time not implemented on this platform'` string in the logs, it emits a CI `::warning::` and exits 0 instead of failing. So #119 doesn't red-flag your PR's CI run anymore.
+
+### #121 — WebView `Origin` header empirical test
+
+**Status**: open, tagged for a real-phone test.
+
+The test plan lives in [`docs/mini-apps-integration.md`](../docs/mini-apps-integration.md) under "Capturing the `Origin` value (for the phone test)". It's exact log-tail steps:
+
+1. Boot the faucet with `FAUCET_DEV=1` (request logs unredacted).
+2. Run a mini-app against it on a real phone inside Nimiq Pay → Mini Apps.
+3. Tail the faucet logs while the phone fires `POST /v1/claim` and grab `req.headers.origin`.
+4. Record the value for Android Chrome WebView, iOS WKWebView, and Nimiq Pay on each.
+5. Comment on [#121](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/121) with the result.
+
+This is the one piece that genuinely needed your hands on a phone — we can't CI it. If you've got bandwidth to run it during your next round of mini-app work, that closes the last open follow-up. If not, no rush; the doc currently recommends `FAUCET_REQUIRE_BROWSER=false` for Mini App callers, which is a safe-by-default until we know the answer.
+
+---
+
+## Anything else?
+
+If the rebase hits something not covered above (compose include semantics, a workaround we missed, etc.) just ping back. Thanks again — the integration notes were genuinely the most useful contribution we've had this quarter.

--- a/audits/findings-2026-05/022-stats-summary-leaks-rejection-attribution.md
+++ b/audits/findings-2026-05/022-stats-summary-leaks-rejection-attribution.md
@@ -1,0 +1,97 @@
+# /v1/stats/summary leaks abuse-layer attribution despite #176's uniformity contract
+
+**Severity:** Medium
+**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N (4.3)
+**Component:** apps/server/src/routes/claim.ts
+**Affected versions:** main @ 855868a (introduced before the audit; #176 missed it)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+PR #176 collapsed `POST /v1/claim` reject responses to `403 { id, status: "rejected" }` (no `decision`, no `reason`) and removed `decision`/`rejectionReason` from `GET /v1/claim/:id`'s public shape. The contract is documented in [`SECURITY.md` "Public-API silence on rejection"](../../SECURITY.md). However, the public `GET /v1/stats/summary` endpoint surfaces the exact same abuse-layer attribution that the contract is designed to hide — `topRejectionReasons` carries strings like `"rateLimit: exceeded"` / `"geoip: denied"` / `"hashcash: invalid"`, and `recentClaims` / `recentBlocked` arrays expose `decision` and `rejectionReason` per row.
+
+An attacker can poll this single public endpoint to learn:
+1. Which abuse layers fired in the last 24h, ranked by frequency.
+2. Per-claim `decision` (`deny` vs `review` vs `allow`) for every row in `recentClaims` + `recentBlocked`.
+3. Per-claim `rejectionReason` strings for every row in `recentBlocked`.
+
+This collapses the entire purpose of the uniformity contract. An attacker doesn't need to A/B-test their own claims — the operator's recent-rejections leaderboard is the answer key.
+
+## Location
+
+- [`apps/server/src/routes/claim.ts:465-471`](../../apps/server/src/routes/claim.ts#L465-L471) — `topReasons` query, no auth gate
+- [`apps/server/src/routes/claim.ts:480-481`](../../apps/server/src/routes/claim.ts#L480-L481) — `decision` and `rejectionReason` in `claimFields`
+- [`apps/server/src/routes/claim.ts:484-498`](../../apps/server/src/routes/claim.ts#L484-L498) — `recentClaims` and `recentBlocked` queries
+- [`apps/server/src/routes/claim.ts:514`](../../apps/server/src/routes/claim.ts#L514) — `topRejectionReasons` returned in public response
+
+The endpoint is registered with no `preHandler` for auth (compare with `/v1/admin/*` which goes through `requireAdminSession`). It's gated only by a 30-second in-memory cache (line 434).
+
+## Reproduction
+
+```bash
+# Against a faucet with at least one rejected claim in the last 24h
+curl -s http://localhost:8080/v1/stats/summary | jq '.topRejectionReasons, .recentBlocked[0]'
+```
+
+Expected output (per current code) — abuse-layer attribution is leaked:
+
+```json
+[
+  { "reason": "rateLimit: exceeded", "count": 12 },
+  { "reason": "geoip: denied (KP)", "count": 5 },
+  { "reason": "hashcash: invalid", "count": 3 }
+]
+{
+  "id": "...",
+  "decision": "deny",
+  "rejectionReason": "fingerprint: too many uids",
+  ...
+}
+```
+
+Compare with the contract-compliant response shape from `POST /v1/claim`:
+
+```bash
+curl -i -X POST http://localhost:8080/v1/claim -H 'Content-Type: application/json' -d '{}'
+# 403 { "id": "...", "status": "rejected" } — no leak
+```
+
+## Impact
+
+An attacker can:
+
+1. **Skip the A/B-test phase.** Instead of probing the abuse pipeline by submitting claims and observing response variance, they read the leaderboard directly. This trims hours-to-days of probing to a single GET request.
+2. **Enumerate operator thresholds.** `topRejectionReasons` returns concrete strings that include the layer's own classifier output (e.g., `"abuse-ai: score=0.87"`, `"onchain: sweeper detected"`). An attacker tunes their inputs against the specific layer's stated triggers.
+3. **Identify dormant layers.** A layer that's enabled but never appears in the top-5 reasons is either rarely-tripped (legitimate users don't fail it) or misconfigured (always allows). Either inference is useful intelligence.
+4. **Time the operator's response.** `recentBlocked` shows the most recent 10 rejections with timestamps; an attacker who just submitted a claim can confirm whether their attempt is in the leaderboard, and which layer caught it, near-real-time.
+
+Caveat: severity is capped at Medium because the existing `claimAmountLuna` cap, per-IP rate limit, and abuse-pipeline weighted scoring still bound treasury drain. This finding is "removes a defence-in-depth layer", not "directly drains the wallet".
+
+## Recommended fix
+
+Two options, in order of preference:
+
+### Option A (recommended) — gate the granular fields behind admin auth
+
+Move `topRejectionReasons`, the per-row `decision`, and the per-row `rejectionReason` to an admin-only response shape. Public response keeps:
+- `balance` (already public)
+- `claims.{1h,24h,7d}` aggregate counts (already public, no change)
+- `blocked.{1h,24h,7d}` aggregate counts (no change — total counts don't leak attribution)
+- `successRate` (no change)
+- `recentClaims`: keep `id`, `createdAt`, `address`, `amountLuna`, `status`, `txId`. Drop `decision` and `rejectionReason`.
+- `recentBlocked`: keep `id`, `createdAt`, `address`, `amountLuna`, `status`. Drop `decision`, `rejectionReason`, `txId` (txId on a blocked row is meaningless and may leak driver state).
+
+Admin endpoint `/v1/admin/stats/summary` retains the full shape for operator dashboards.
+
+### Option B — drop the granular fields entirely
+
+If admin tooling already pulls `recentBlocked` from `/v1/admin/claims` (which it does, per [`apps/server/src/routes/admin/claims.ts`](../../apps/server/src/routes/admin/claims.ts)), the public `/v1/stats/summary` doesn't need granular attribution at all. Drop `topRejectionReasons` and the granular per-row fields without adding an admin variant.
+
+Option B is simpler; Option A preserves the operator UX. Either way, regenerate the OpenAPI to match.
+
+## References
+
+- [`SECURITY.md` "Public-API silence on rejection"](../../SECURITY.md) — the contract this endpoint contradicts
+- [PR #176](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/176) — the contract's introduction (which missed this endpoint)
+- Related CWE: CWE-200 (Exposure of Sensitive Information to an Unauthorized Actor)

--- a/audits/findings-2026-05/023-claims-recent-leaks-decision-and-reason.md
+++ b/audits/findings-2026-05/023-claims-recent-leaks-decision-and-reason.md
@@ -1,0 +1,85 @@
+# /v1/claims/recent exposes decision + rejectionReason despite "no sensitive fields" comment
+
+**Severity:** Medium
+**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N (4.3)
+**Component:** apps/server/src/routes/claim.ts
+**Affected versions:** main @ 855868a (introduced before the audit; #176 missed it)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+The public `GET /v1/claims/recent` endpoint returns a paginated list of recent claims and includes `decision` + `rejectionReason` per row. Worse, the section header at line 520 reads `"// ── /v1/claims/recent — public paginated claims (no sensitive fields) ──"` while the code immediately below selects exactly those sensitive fields. The comment is a misleading invariant claim that the code does not honour.
+
+This is the same contract violation as finding 022 (the [`SECURITY.md` "Public-API silence on rejection"](../../SECURITY.md) contract), but on a different endpoint. The endpoint is parameterised (`?status=rejected&limit=100&offset=...`), which makes it more dangerous than `/v1/stats/summary`'s fixed top-10: an attacker can paginate the *entire* rejected-claims history at 100 rows per page.
+
+## Location
+
+- [`apps/server/src/routes/claim.ts:520`](../../apps/server/src/routes/claim.ts#L520) — misleading "no sensitive fields" comment
+- [`apps/server/src/routes/claim.ts:537-539`](../../apps/server/src/routes/claim.ts#L537-L539) — `decision` and `rejectionReason` selected and returned
+- [`apps/server/src/routes/claim.ts:522-554`](../../apps/server/src/routes/claim.ts#L522-L554) — handler registered with no `preHandler` (no auth gate, no rate limit beyond the global Fastify one)
+
+## Reproduction
+
+```bash
+# Page through every rejected claim, learning the abuse layer that fired for each
+curl -s "http://localhost:8080/v1/claims/recent?status=rejected&limit=100&offset=0" | \
+  jq '.items[] | {id, decision, rejectionReason}'
+```
+
+Expected output:
+
+```json
+{ "id": "abc123", "decision": "deny", "rejectionReason": "rateLimit: exceeded" }
+{ "id": "def456", "decision": "deny", "rejectionReason": "geoip: denied (KP)" }
+{ "id": "ghi789", "decision": "review", "rejectionReason": "abuse-ai: score=0.78" }
+...
+```
+
+The maximum `limit` is clamped to 100 at [line 524](../../apps/server/src/routes/claim.ts#L524), but `offset` is unbounded — an attacker can walk the full history.
+
+## Impact
+
+Same as finding 022 plus:
+
+1. **Long-tail enumeration.** `/v1/stats/summary` shows only the top 5 reasons by count; `/v1/claims/recent` exposes every individual rejection. Rare layer triggers (e.g., one user tripped `onchain: sweeper detected`) become visible.
+2. **Targeting victims.** The endpoint also returns `address` (line 534). An attacker can map: "address X had its claim denied by `onchain: heuristic-Y`" — a privacy/profiling concern beyond just abuse-layer enumeration. (Addresses in faucets are often pseudonymously linked to one wallet.)
+3. **Operator misled by the comment.** A future maintainer reading line 520 would conclude the endpoint is hardened. They might add MORE sensitive fields, mistakenly believing the gate is somewhere upstream.
+
+## Recommended fix
+
+Same shape as finding 022's Option A or B. Concrete changes:
+
+```ts
+// apps/server/src/routes/claim.ts L530-545 (BEFORE)
+const rowsRaw = await ctx.db.select({
+  id: claims.id,
+  createdAt: claims.createdAt,
+  address: claims.address,
+  amountLuna: claims.amountLuna,
+  status: claims.status,
+  decision: claims.decision,         // DROP
+  txId: claims.txId,
+  rejectionReason: claims.rejectionReason,  // DROP
+}).from(claims).where(conds).orderBy(...).limit(...);
+
+// AFTER
+const rowsRaw = await ctx.db.select({
+  id: claims.id,
+  createdAt: claims.createdAt,
+  address: claims.address,           // see note below
+  amountLuna: claims.amountLuna,
+  status: claims.status,
+  txId: claims.txId,                 // null on rejected rows; OK to keep
+}).from(claims).where(conds).orderBy(...).limit(...);
+```
+
+Also fix the line-520 comment to actually describe what's exposed, or delete it entirely.
+
+**Note on `address`**: leaving `address` in the public response is consistent with `/v1/claim/:id` and keeps the explorer UX (operators want to confirm "did this address get a claim?"). The privacy concern in §Impact item 2 is genuine but separable; defer to a future hardening pass.
+
+## References
+
+- [Finding 022](022-stats-summary-leaks-rejection-attribution.md) — same contract violation on a different endpoint; share the fix
+- [`SECURITY.md` "Public-API silence on rejection"](../../SECURITY.md)
+- Related CWE: CWE-200, CWE-359 (Exposure of Private Personal Information)

--- a/audits/findings-2026-05/024-pipeline-short-circuit-timing-attribution.md
+++ b/audits/findings-2026-05/024-pipeline-short-circuit-timing-attribution.md
@@ -1,0 +1,142 @@
+# Pipeline short-circuits on hard `deny` — timing side-channel attribution
+
+**Severity:** Medium
+**CVSS v3.1:** AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N (3.7)
+**Component:** packages/core/src/pipeline.ts
+**Affected versions:** main @ 855868a (since the pipeline was introduced; not specifically a #176 regression)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+PR #176 made every `/v1/claim` reject body byte-shape-identical so an attacker can't tell which abuse layer fired by reading the response. But the pipeline that decides the rejection still **short-circuits** on the first hard `deny`: [`packages/core/src/pipeline.ts:74-77`](../../packages/core/src/pipeline.ts#L74-L77) breaks out of the loop, and [line 58](../../packages/core/src/pipeline.ts#L58) does the same on a check error. As a result, the response time correlates strongly with the *position* of the firing layer in the pipeline — a side-channel that defeats the body-uniformity contract.
+
+Approximate latencies (per-layer, rough order of magnitude, depends on operator config):
+
+| Pipeline position | Layer | Typical latency | Why |
+|---|---|---|---|
+| 1 | `rateLimit` | ~5 ms | DB lookup |
+| 2 | `blocklist` | ~10 ms | DB lookup |
+| 3 | `hashcash` | ~1 ms | HMAC verify, replay-cache lookup |
+| 4 | `geoip` | ~15 ms | DB lookup (MaxMind / DB-IP) |
+| 5 | `fingerprint` | ~30 ms | DB query (UID counting) |
+| 6 | `captcha` | ~600–1500 ms | HTTP fetch to Cloudflare/hCaptcha/FCaptcha |
+| 7 | `onchain` | ~200–500 ms | RPC call to Nimiq node |
+| 8 | `abuse-ai` | ~1000–2000 ms | ONNX inference (or HTTP to model server) |
+
+A 5ms response is rate-limit; a 1500ms response is captcha. The body says nothing, but the wire speaks.
+
+## Location
+
+- [`packages/core/src/pipeline.ts:74-77`](../../packages/core/src/pipeline.ts#L74-L77) — `if (result.decision === 'deny') { hardDecision = 'deny'; break; }`
+- [`packages/core/src/pipeline.ts:58`](../../packages/core/src/pipeline.ts#L58) — `break;` on per-check error path
+- [`apps/server/src/routes/claim.ts:254`](../../apps/server/src/routes/claim.ts#L254) — `await ctx.pipeline.evaluate(claimReq)` is the only awaitable between request receipt and reject body
+
+## Reproduction
+
+```bash
+# 1. Boot the faucet with a real abuse pipeline (turnstile + geoip + rateLimit at minimum)
+# 2. Submit claims in three different rejection profiles and time them:
+
+# Profile A: rate-limit (burn quota first, then submit)
+for i in {1..6}; do curl -s -o /dev/null -w "%{time_total}\n" \
+  -X POST http://localhost:8080/v1/claim \
+  -H 'Content-Type: application/json' \
+  -d '{"address":"NQ00 ..."}' ; done
+# 6th request: ~5–15 ms (rate-limit fires immediately)
+
+# Profile B: bad captcha token (rate-limit passes, captcha rejects)
+curl -s -o /dev/null -w "%{time_total}\n" \
+  -X POST http://localhost:8080/v1/claim \
+  -H 'Content-Type: application/json' \
+  -d '{"address":"NQ00 ...","captchaToken":"INVALID"}'
+# Response: ~600–1500 ms (captcha provider HTTP fetch)
+
+# Profile C: blocked country (rate-limit + captcha pass, geoip rejects)
+curl -s -o /dev/null -w "%{time_total}\n" \
+  -X POST http://localhost:8080/v1/claim \
+  -H 'Content-Type: application/json' \
+  -H 'X-Forwarded-For: <IP-in-blocked-country>' \
+  -d '{"address":"NQ00 ...","captchaToken":"<valid>"}'
+# Response: ~30–60 ms (geoip lookup after rate-limit + blocklist + hashcash)
+```
+
+The response BODIES are identical (`403 { id, status: "rejected" }`); only the wall-clock differs. With ~10 samples per profile an attacker can rank-order the layers they tripped.
+
+## Impact
+
+Defence-in-depth on top of body uniformity. The body contract (#176) closes the dictionary-attack channel; this finding closes the timing-side-channel attack. Without this fix, the body uniformity is *necessary but not sufficient*.
+
+A motivated attacker who has already shipped one client and watches their response times can:
+
+1. Distinguish "rate-limited" (cheap) from "AI-flagged" (expensive) — and time-multiplex their probe accordingly.
+2. Detect when the operator changes pipeline config (a layer's typical latency changes; the timing distribution shifts).
+3. Identify which layers are enabled at all (a layer that's never seen in the timing distribution is likely off).
+
+Severity is Medium with high-attack-complexity (AC:H) because it requires multiple samples and statistical analysis, and the existing body uniformity already takes a real bite out of the original attack.
+
+## Recommended fix
+
+Three options, each with tradeoffs:
+
+### Option A — always run all checks; aggregate at the end
+
+Stop breaking on `deny`. Run every check, accumulate results, then compute the cumulative decision. Code sketch:
+
+```ts
+async evaluate(req: ClaimRequest): Promise<PipelineResult> {
+  const perCheck = await Promise.all(
+    this.checks.map(async (c) => {
+      try {
+        const result = await c.check(req);
+        return { id: c.id, ...result };
+      } catch (err) {
+        return {
+          id: c.id, score: 1,
+          signals: { error: err instanceof Error ? err.message : String(err) },
+          decision: 'deny' as const,
+        };
+      }
+    }),
+  );
+  // Collapse to cumulative decision: any deny → deny; else weighted score.
+  const decision = perCheck.some((r) => r.decision === 'deny')
+    ? 'deny'
+    : this.decisionFromScore(weightedScore(perCheck));
+  // ... build other PipelineResult fields
+}
+```
+
+Cost: every claim now pays the slowest layer's latency (~2s with AI enabled), even if rate-limit would have fired in 5ms. That's a real UX regression for legitimate rate-limit hits ("retry in 24h"), and a DoS-amplification risk if AI inference is expensive.
+
+### Option B — pad the response to a constant target latency
+
+Keep the existing short-circuit but add a `setTimeout`/`sleep` after the pipeline call so every reject takes at least `T_min` (e.g., 1500ms — the slowest typical layer's latency). Code sketch:
+
+```ts
+// Inside the deny branch in claim.ts
+const startedAt = Date.now();
+// ... existing pipeline + DB write ...
+const elapsed = Date.now() - startedAt;
+const PADDING_MS = 1500;
+if (elapsed < PADDING_MS) {
+  await new Promise((r) => setTimeout(r, PADDING_MS - elapsed));
+}
+return reply.code(403).send({ id, status: 'rejected' });
+```
+
+Cost: doubles the rate-limit-deny latency from 5ms to 1500ms, but only for rejected claims (allowed claims are unaffected). DoS-resistant because the padding is server-side `setTimeout`, not blocking.
+
+Important nuance: padding must apply to **all** reject paths, not just deny — otherwise the existence of a 1500ms-padded response vs an unpadded 30ms response itself signals "you tripped the abuse pipeline" vs "you tripped a pre-pipeline check". Also pad the `invalid request` (Zod), `invalid address`, and `integrator auth failed` paths to the same `T_min`.
+
+### Option C — randomised jitter
+
+Add `setTimeout(rng() * 2000)` to every reject. Cheaper than B but only buys statistical noise — with enough samples the underlying distribution still leaks. Not recommended over B.
+
+**Recommendation: Option B with `T_min = 1500ms` applied to every public reject path** (deny, review, Zod-invalid, integrator-auth-failed, invalid-address). Option A's "run everything" is theoretically cleaner but the UX cost is real for legitimate rate-limit hits. Option B is what every modern login form does for the same reason.
+
+## References
+
+- [`SECURITY.md` "Public-API silence on rejection"](../../SECURITY.md) — the contract this finding extends with timing concerns
+- [PR #176 "Out of scope" section](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/176) — explicitly flagged "constant-time response delivery" as orthogonal hardening; this finding makes the case for prioritising it
+- Related CWE: CWE-208 (Observable Timing Discrepancy)

--- a/audits/findings-2026-05/025-stats-byDecision-aggregate-leak.md
+++ b/audits/findings-2026-05/025-stats-byDecision-aggregate-leak.md
@@ -1,0 +1,70 @@
+# /v1/stats `byDecision` aggregate counts publicly exposed
+
+**Severity:** Low
+**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N (4.3) — but information content is low; capping at Low
+**Component:** apps/server/src/routes/claim.ts
+**Affected versions:** main @ 855868a (introduced before the audit)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+`GET /v1/stats` returns aggregate counts of `decision` values from the most-recent 100 claims:
+
+```json
+{ "total": 100, "byStatus": { "broadcast": 60, "rejected": 40 }, "byDecision": { "allow": 60, "deny": 35, "review": 5 } }
+```
+
+The `byStatus` map is fine — `broadcast`/`confirmed`/`rejected` are observable to anyone who watches the chain anyway. The `byDecision` map leaks pipeline-effectiveness intelligence: an attacker can compare the deny:review:allow ratio over time and infer whether the operator has tightened or loosened the pipeline.
+
+Lower information density than findings 022 / 023 (this is aggregates, not per-row attribution), so severity is Low. But it's the same root cause — `decision` is operator-internal data that shouldn't reach the public.
+
+## Location
+
+- [`apps/server/src/routes/claim.ts:411-426`](../../apps/server/src/routes/claim.ts#L411-L426) — `/v1/stats` handler
+- [`apps/server/src/routes/claim.ts:417`](../../apps/server/src/routes/claim.ts#L417) — `decision: claims.decision` in the SELECT
+- [`apps/server/src/routes/claim.ts:424`](../../apps/server/src/routes/claim.ts#L424) — `byDecision: groupBy(recent.map((r) => r.decision))` returned
+
+The endpoint has no auth gate; relies on the global Fastify rate-limit only.
+
+## Reproduction
+
+```bash
+curl -s http://localhost:8080/v1/stats | jq '.byDecision'
+# { "allow": 60, "deny": 35, "review": 5 }
+```
+
+Then poll daily and compute the deny ratio. A 35→60% jump in deny ratio over a week tells the attacker the operator just tightened a layer.
+
+## Impact
+
+- **Operator threshold inference.** Plotting `byDecision` over time reveals when the operator changes pipeline config (e.g., bumping AI deny threshold from 0.85 to 0.75 manifests as a sudden deny-ratio jump).
+- **Pipeline-load telemetry.** A `review` count > 0 tells the attacker the review queue is in use; an attacker probing for `review`-bound payloads gets confirmation.
+
+Cap at Low: the operator's deploy timeline is usually visible from GitHub commits anyway, and the abuse pipeline's effectiveness is bounded by the existing `claimAmountLuna` cap. This finding is "remove a small intelligence leak," not "fix an exploit."
+
+## Recommended fix
+
+Drop `byDecision` from the public response. Replace with admin-only `/v1/admin/stats` if operator dashboards need it (they likely already pull from `/v1/admin/claims`).
+
+```ts
+// Before
+return {
+  total: recent.length,
+  byStatus: groupBy(recent.map((r) => r.status)),
+  byDecision: groupBy(recent.map((r) => r.decision)),
+};
+
+// After
+return {
+  total: recent.length,
+  byStatus: groupBy(recent.map((r) => r.status)),
+};
+```
+
+Drop the `decision: claims.decision` from the SELECT too — there's no other use of that field in the handler post-fix.
+
+## References
+
+- [Finding 022](022-stats-summary-leaks-rejection-attribution.md) and [023](023-claims-recent-leaks-decision-and-reason.md) — same root cause, higher-information siblings
+- Related CWE: CWE-200

--- a/audits/findings-2026-05/026-cross-theme-asset-probe-leakage.md
+++ b/audits/findings-2026-05/026-cross-theme-asset-probe-leakage.md
@@ -1,0 +1,83 @@
+# Cross-theme asset probe serves any bundled theme's `dist/`
+
+**Severity:** Low
+**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N (4.3)
+**Component:** apps/server/src/ui.ts
+**Affected versions:** main @ 855868a (introduced when the multi-theme system shipped)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+When the theme picker is enabled, the SPA fall-through handler at [`apps/server/src/ui.ts:161-190`](../../apps/server/src/ui.ts#L161-L190) probes *every* bundled theme's `dist/` for a missing asset before falling back to `index.html`. This means a request for `/some-asset.css` is served from the first non-active theme that has a file at that path, regardless of which theme the caller actually selected (or the operator deployed).
+
+Practical consequence: if the operator includes any non-public file in any theme's `dist/` (e.g., a `staging.config.json` accidentally bundled, a `team-notes.txt` left over from development), it becomes reachable from every other theme. The cross-theme isolation that operators might assume the theme registry provides is *not* enforced for hashed assets.
+
+This is path-traversal-adjacent (the directory boundary is permeable) but not classic traversal (no escape from `dist/` itself). Severity Low because it requires the operator to bundle sensitive files into a `dist/` — generally something the build pipeline doesn't do — and the assets are still scoped to the union of all bundled themes' `dist/`.
+
+## Location
+
+- [`apps/server/src/ui.ts:175-185`](../../apps/server/src/ui.ts#L175-L185) — the cross-theme probe loop:
+  ```ts
+  if (pathOnly && !pathOnly.includes('..') && /\.[a-zA-Z0-9]+$/.test(pathOnly)) {
+    for (const altDir of altThemeDirs) {
+      const candidate = resolve(altDir, pathOnly);
+      if (existsSync(candidate)) {
+        return reply.sendFile(pathOnly, altDir);
+      }
+    }
+  }
+  ```
+
+The intent (per the comment at lines 157-160) is to make hashed assets resolve when `?theme=<slug>` serves a different theme's `index.html`. The implementation matches that intent for hashed JS/CSS, but doesn't restrict to known asset patterns.
+
+## Reproduction
+
+1. Bundle two themes: `porcelain-vault` (active, default) and `nimiq-pow`.
+2. In `apps/nimiq-pow-ui/dist/`, place a file `internal-notes.txt` (simulates operator footgun).
+3. Request `http://faucet/internal-notes.txt`.
+4. Active theme is `porcelain-vault`; its `dist/` doesn't have the file. Fallback handler probes `nimiq-pow`'s `dist/`, finds it, serves it.
+5. Anyone on the public internet has now read `internal-notes.txt`.
+
+## Impact
+
+- Operator must bundle a sensitive file into a theme's `dist/` for this to bite, which is bad practice but happens (e.g., source maps with comment-stripped secrets, dev-only JSON configs, README leftovers).
+- The `\.[a-zA-Z0-9]+$` regex constrains exposure to extensioned files only — `internal-notes` (no extension) wouldn't match. So `*.txt`, `*.json`, `*.md`, `*.map` are reachable; bare-name files are not.
+- Severity Low because (a) requires operator misconfiguration, (b) constrained to extensioned files, (c) bound to bundled-theme `dist/` directories specifically (no escape).
+
+## Recommended fix
+
+Two complementary mitigations:
+
+### Fix 1 — only probe the *requested* theme
+
+When the request includes `?theme=<slug>`, only probe that theme's `dist/`. When no `?theme=` is set, only probe the active theme's `dist/` (the SPA shell already covers the active theme's hashed assets via the static handler upstream of this fallback). Code sketch:
+
+```ts
+// Before
+for (const altDir of altThemeDirs) {
+  const candidate = resolve(altDir, pathOnly);
+  ...
+}
+
+// After
+const requested = themeForRequest(req, config, fallbackSlug, themeDirs);
+const candidate = resolve(requested.dir, pathOnly);
+if (existsSync(candidate)) {
+  return reply.sendFile(pathOnly, requested.dir);
+}
+// No cross-theme fallback. Asset must live in the requested theme's dist/.
+```
+
+### Fix 2 — restrict asset-extension regex to known UI extensions
+
+Change `\.[a-zA-Z0-9]+$` to a narrow allow-list: `\.(js|mjs|css|svg|png|jpe?g|gif|webp|woff2?|ttf|map)$`. This won't fix the leak class (a `.json` is still allowed because Vite emits `manifest.json`), but reduces the surface to what the SPA actually consumes.
+
+Recommend Fix 1 alone — it's the principled fix. Fix 2 is a defence-in-depth nice-to-have.
+
+## References
+
+- [`apps/server/src/themes.ts`](../../apps/server/src/themes.ts) — the registry that the probe iterates
+- [`apps/server/src/ui.ts:144-149`](../../apps/server/src/ui.ts#L144-L149) — `altThemeDirs` construction (every non-active theme's resolved `dist/`)
+- [`docs/contributing-a-frontend.md`](../../docs/contributing-a-frontend.md) — should add a "don't bundle sensitive files in dist/" note
+- Related CWE: CWE-200, CWE-552 (Files or Directories Accessible to External Parties)

--- a/audits/findings-2026-05/027-mcp-static-token-default-true-no-expiry.md
+++ b/audits/findings-2026-05/027-mcp-static-token-default-true-no-expiry.md
@@ -1,0 +1,103 @@
+# adminMcpAllowStaticToken defaults to `true` indefinitely; no boot-time warning, no expiry
+
+**Severity:** Low
+**CVSS v3.1:** AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:H (5.6) — capped at Low because exploitation requires prior token leak
+**Component:** apps/server/src/config.ts
+**Affected versions:** main @ 855868a (introduced as part of the #88 fix's compat layer)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+The original audit's finding [#88](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/88) replaced the static MCP bearer token with a session+TOTP auth path. To avoid breaking existing deployments, the fix introduced a feature flag `adminMcpAllowStaticToken` that defaults to `true`, with a comment promising "flip to `false` once you've migrated":
+
+```ts
+// apps/server/src/config.ts:106-110
+/** When false, the static `adminMcpToken` is ignored and the only way to
+ *  invoke admin MCP tools is a valid admin session cookie + TOTP step-up.
+ *  Default `true` for one minor so current deployments keep working; flip
+ *  to `false` once you've migrated to the session path. */
+adminMcpAllowStaticToken: z.coerce.boolean().default(true),
+```
+
+The "one minor" promise is a comment, not a constraint. There is:
+- No boot-time `WARN` when `adminMcpAllowStaticToken=true` and `adminMcpToken` is set.
+- No deprecation timestamp in the comment.
+- No CI check that the default flips.
+- No mechanism to surface to operators that they're still on the legacy auth path.
+
+In practice, operators upgrade through versions, never see a breakage, and stay on the static-token path indefinitely. If the static token leaks (logs, CI artifacts, env-var dumps in error reports), an attacker retains MCP access — re-opening the original #88 attack window.
+
+## Location
+
+- [`apps/server/src/config.ts:110`](../../apps/server/src/config.ts#L110) — `default(true)`
+- [`apps/server/src/mcp/index.ts`](../../apps/server/src/mcp/index.ts) — `resolveAdminPrincipal()` reads `config.adminMcpAllowStaticToken` (per Agent A's exploration); honours legacy path when `true`
+
+## Reproduction
+
+```bash
+# Operator deploys v3.0.17 (or whatever version landed the #88 fix), keeps env unchanged:
+FAUCET_ADMIN_MCP_TOKEN=xxxxxxxx (legacy, still in env)
+# adminMcpAllowStaticToken (env var FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN) — unset → defaults to true
+
+# Months pass. Operator forgets the migration TODO.
+# Token leaks via:
+# - GitHub Actions log secret-redaction failure
+# - Operator error-tracking system (Sentry/Bugsnag) capturing env in a stack trace
+# - Old deploy-config repo with the secret committed pre-rotation
+
+# Attacker uses leaked token:
+curl -X POST http://faucet/mcp \
+  -H 'Authorization: Bearer xxxxxxxx' \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"send","arguments":{"address":"NQ00 ATTACKER","amountLuna":"100000000"}}}'
+# Static-token path still works → tools/call succeeds → wallet drained at the rate-limit cap
+```
+
+The original #88 fix didn't make this attack impossible; it made it opt-out, then forgot to flip the opt-out.
+
+## Impact
+
+This is a regression-of-spirit, not a regression-of-code. The fix landed; the spirit was "force operators onto session auth"; the implementation parked at "make session auth optional". Severity Low because:
+
+1. Exploitation requires the static token to leak — same precondition as the original #88 finding.
+2. Mitigations exist: operators *can* set `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=false`. They just don't, because no signal tells them to.
+3. The blast radius is bounded by `claimAmountLuna` per call + per-IP rate limit; an attacker can drain over hours, not seconds.
+
+## Recommended fix
+
+Three layers of mitigation, in order of preference:
+
+### Fix 1 (recommended) — flip the default to `false` in the next minor
+
+Two-step:
+
+1. **This release**: emit a boot-time `WARN` log whenever `adminMcpToken` is set AND `adminMcpAllowStaticToken` is `true` (its default), naming the flag and the deprecation timeline:
+   ```
+   [DEPRECATION] FAUCET_ADMIN_MCP_TOKEN is set with FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN
+   defaulting to true. The static-token path will be DISABLED by default in the next
+   minor release. Migrate to session+TOTP auth (see docs/admin-mcp.md) and set
+   FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=false to silence this warning.
+   ```
+2. **Next minor**: change `default(true)` to `default(false)`. Document in CHANGELOG as a breaking change with the migration path.
+
+### Fix 2 — alternatively, keep the default but add hard-stop on absence of session
+
+If flipping the default is too disruptive, at minimum require operators to *explicitly* opt-in:
+- Treat `adminMcpAllowStaticToken=true` as ambiguous; require operators to set it explicitly (e.g., schema fails to parse if `adminMcpToken` is set without an explicit `adminMcpAllowStaticToken`).
+- This forces a deliberate decision per deployment.
+
+### Fix 3 — log every static-token use as a deprecation warning
+
+In `resolveAdminPrincipal()` (per Agent A's notes, [`apps/server/src/mcp/index.ts:55-100`](../../apps/server/src/mcp/index.ts#L55-L100)), when the static-token branch wins, log:
+```
+[DEPRECATION] Admin MCP request authenticated via legacy static token. Migrate to session auth.
+```
+Sample at 1-in-100 to avoid log floods. This makes the legacy path *visible* to operators monitoring their logs, even if they don't read the boot warning.
+
+Recommend **Fix 1 + Fix 3 together**: boot warning for visibility, per-call deprecation log for operators who only check during incidents, default-flip in the next minor for the actual hardening.
+
+## References
+
+- [Original audit finding #88](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/88) — the static-token vulnerability this fix addressed
+- [`SECURITY.md` "Trust-boundary model"](../../SECURITY.md) — admin auth section
+- Related CWE: CWE-672 (Use of Expired or Released Resource), CWE-285 (Improper Authorization)

--- a/audits/findings-2026-05/028-sdk-capacitor-fingerprint-not-signed.md
+++ b/audits/findings-2026-05/028-sdk-capacitor-fingerprint-not-signed.md
@@ -1,0 +1,89 @@
+# sdk-capacitor injects `Device.getId()` as `visitorId` without HMAC signing — parity gap with closed #104
+
+**Severity:** Low
+**CVSS v3.1:** AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N (3.7)
+**Component:** packages/sdk-capacitor
+**Affected versions:** main @ 855868a (introduced when sdk-capacitor shipped, after the original audit)
+
+> _The maintainer of this repository has waived the SECURITY.md private-disclosure policy for the duration of this audit; this finding is therefore filed publicly. Downstream forks should NOT inherit this disclosure channel._
+
+## Summary
+
+The original audit's [#104](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/104) flagged that `sdk-go` and `sdk-flutter` did not implement `hostContext` HMAC signing — a gap closed by [PR #134](https://github.com/PanoramicRum/nimiq-simple-faucet/pull/134) (which brought all SDKs to parity). The new `sdk-capacitor` package, added after the audit, has the same gap: it auto-injects `Device.getId()` as `fingerprint.visitorId` on every claim, but does not invoke `FaucetClient.signHostContext()`. The injected `visitorId` is therefore an *unsigned* client claim — exactly the trust-boundary problem #96/#104 closed for other SDKs.
+
+If the server's fingerprint abuse-layer treats `visitorId` as a meaningful signal (it does, per [`packages/abuse-fingerprint/`](../../packages/abuse-fingerprint/)), an attacker:
+1. Modifies the Capacitor app or the device's Capacitor plugin to return arbitrary `visitorId` values.
+2. Submits each claim from a fresh fake `visitorId` to bypass per-device correlation.
+3. Sees the same per-IP rate-limit they'd see without the SDK — fingerprint correlation contributes 0 to the abuse score.
+
+## Location
+
+- [`packages/sdk-capacitor/src/index.ts:20-57`](../../packages/sdk-capacitor/src/index.ts#L20-L57) — `claim()` and `solveAndClaim()` wrappers inject `visitorId` from `Device.getId()` directly
+- Compare with the parity reference: [`packages/sdk-flutter/`](../../packages/sdk-flutter/) and [`packages/sdk-go/`](../../packages/sdk-go/) implement `signHostContext()` per the closed #104.
+
+## Reproduction
+
+Modify `packages/sdk-capacitor/src/index.ts` (or any clone of the published package) to mock `Device.getId()`:
+
+```ts
+// Pretend to be a different device on every claim
+const fakeIds = ['device-a', 'device-b', 'device-c'];
+let i = 0;
+const Device = {
+  getId: () => Promise.resolve({ identifier: fakeIds[i++ % fakeIds.length] }),
+};
+```
+
+Submit 100 claims from the same IP. The server's fingerprint layer sees 100 distinct `visitorId`s and registers 1 visit per UID — well below any per-UID threshold. The per-IP rate-limit still fires, so the attack is bounded by IP quota; but if the operator was relying on fingerprint correlation to lift the per-IP cap (e.g., shared NAT scenarios), this bypass quietly defeats that.
+
+## Impact
+
+- **Trust boundary**: a client-side device identifier is treated by the abuse pipeline as if it had origin-of-trust. It doesn't.
+- **Same shape as closed #104**: not a new class of vulnerability, just a new instance. Severity Low because:
+  - Per-IP rate-limit + claim-amount cap are unchanged; this finding only weakens fingerprint correlation, one of 10 abuse layers.
+  - Most operator deployments don't lean heavily on fingerprint scoring.
+  - The integrator HMAC signing path (for backends that proxy claims) does sign hostContext, so server-to-server integrations are unaffected.
+
+## Recommended fix
+
+Two options, depending on Capacitor's expected usage model:
+
+### Option A — sign on the device using a baked-in secret (BAD; documented for completeness)
+
+Don't do this. A Capacitor app's APK/IPA can be reverse-engineered; any baked-in HMAC secret is harvestable. The integrator-HMAC model assumes the secret lives on a *backend* the integrator controls.
+
+### Option B (recommended) — document that `visitorId` from sdk-capacitor is unsigned client input
+
+Update [`packages/sdk-capacitor/README.md`](../../packages/sdk-capacitor/README.md) and inline JSDoc on the `claim()` wrapper:
+
+```ts
+/**
+ * Submits a claim with the current device identifier auto-attached as
+ * `fingerprint.visitorId`.
+ *
+ * SECURITY NOTE: `visitorId` is UNSIGNED client input. The faucet's
+ * fingerprint abuse-layer uses it for correlation, not authentication —
+ * an attacker who controls the Capacitor app can spoof this value. Do
+ * not weight it heavily in abuse scoring; rely on per-IP rate-limit
+ * and signed `hostContext` (via `FaucetClient.signHostContext()` from
+ * a backend) for trust.
+ *
+ * If the integrator runs a backend, sign hostContext there and pass
+ * the signed envelope through to this SDK's `claim()` via the
+ * `hostContext` option.
+ */
+```
+
+Plus add a runtime warning in dev mode: if `Device.getId()` is the only signal and there's no signed hostContext, emit `console.warn('[sdk-capacitor] visitorId is unsigned client input ...')`.
+
+### Option C — surface a signing path through the integrator HMAC
+
+If integrators have a backend, they can mint a signed hostContext server-side using `FaucetClient.signHostContext()` (already in sdk-ts) and pass the resulting object to the Capacitor SDK's claim call. Document this pattern explicitly in the Capacitor README — it's how the existing `mini-app-claim-{vue,react}` examples handle the same trust boundary.
+
+Recommend **Option B + C together**: B prevents footgun usage, C points integrators at the correct hardening pattern.
+
+## References
+
+- [Original audit finding #104](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/104) — same gap, closed for sdk-go and sdk-flutter via PR #134
+- [`SECURITY.md` "Trust boundary model" → "Client-supplied claim payload"](../../SECURITY.md) — defines `hostContext.{trust-claims}` as unsigned-by-default
+- Related CWE: CWE-345 (Insufficient Verification of Data Authenticity)


### PR DESCRIPTION
## Summary

Two security-audit cycles' worth of working documents have been kept local-only. With both audits' findings now closed (#108-#134 for the original 21, and #177/#178/#179 for the May 7), put the historical record on main next to the code it audited. **No code change** — pure documentation.

## What lands

| File | Purpose |
|---|---|
| [audits/AUDIT-REPORT.md](audits/AUDIT-REPORT.md) | First edition (2026-04-23 @ `ee34d1e`), 21 findings #87-#107, all closed via #108-#134 |
| [audits/AUDIT-REPORT-2026-05.md](audits/AUDIT-REPORT-2026-05.md) | Second edition (2026-05-04 @ `855868a`), 7 follow-up findings (3 Med, 4 Low), all closed via #177/#178/#179. Includes regression matrix for #87-#107 |
| [audits/findings-2026-05/022..028.md](audits/findings-2026-05/) | Per-finding markdown drafts in the skill's standard issue-body shape |
| [audits/INTEGRATION_NOTES.md](audits/INTEGRATION_NOTES.md) | Mini App ↔ faucet integration friction log from PR #113 (working stack confirmation, SDK shape gaps, FCaptcha upstream patches, WASM panic) |
| [audits/PR-113-rebase-handoff.md](audits/PR-113-rebase-handoff.md) | Rebase guide when upstream fixes #136-#140 made PR #113's workarounds redundant — useful if the mini-app branch ever needs another rebase |

## Excluded

- `audits/PR_DESCRIPTION.md` — one-shot draft of PR #113's description; the real description is on GitHub already.

## Test plan

- [x] No code change → CI runs only on doc-affecting workflows (gitleaks, codeql, etc.)
- [ ] CI green
- [ ] After merge: `git log --oneline audits/AUDIT-REPORT.md` shows the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)