### PR TITLE
fix(nextjs-example): drop result.reason / final.reason references

### DIFF
--- a/examples/nextjs-claim-page/app/page.tsx
+++ b/examples/nextjs-claim-page/app/page.tsx
@@ -140,20 +140,22 @@ export default function Home() {
       setPhase('submitting');
       setTxId(result.txId ?? null);
       if (result.status === 'rejected') {
+        // Public reject body has no reason — uniform shape for all denials.
+        // See SECURITY.md "Public-API silence on rejection".
         setPhase('rejected');
-        setErrorMessage(result.reason ?? 'Claim rejected');
+        setErrorMessage('Claim rejected');
         return;
       }
       if (result.status === 'challenged') {
         setPhase('rejected');
-        setErrorMessage(result.reason ?? 'Captcha challenge required');
+        setErrorMessage('Captcha challenge required');
         return;
       }
       setPhase('broadcast');
       const final = await client.waitForConfirmation(result.id);
       setTxId((prev) => final.txId ?? prev);
       setPhase(final.status === 'confirmed' ? 'confirmed' : 'rejected');
-      if (final.status === 'rejected' && final.reason) setErrorMessage(final.reason);
+      if (final.status === 'rejected') setErrorMessage('Claim rejected');
     } catch (err) {
       setPhase('error');
       setErrorMessage(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

Hotfix for the CI failure on \`main\` after PR #180. The Next.js claim-page example still read \`result.reason\` and \`final.reason\` from the SDK's \`ClaimResponse\`. PR #176 dropped those fields from the type definition (uniform reject contract), but Next.js's \`tsc\` runs inside \`next build\` and isn't covered by the workspace \`pnpm -r typecheck\` task — so the type error never showed locally and the typecheck-passes-but-build-fails state landed on main.

CI's \`build\` job flagged it:

\`\`\`
./app/page.tsx:144:32
Type error: Property 'reason' does not exist on type 'ClaimResponse'.
\`\`\`

## Fix

Mirrors what #176 already did for the other UIs (claim-ui, nimiq-pow-ui, mini-app-claim-{vue,react}, vue-claim-page, capacitor-mobile-app): show a static \`'Claim rejected'\` / \`'Captcha challenge required'\` string on the reject paths instead of surfacing a server-supplied reason.

## Test plan

- [x] \`pnpm --filter @nimiq-faucet/example-nextjs build\` runs clean (Next compiles + tsc + page generation all pass).
- [x] Sweep across all examples + apps + sdks for any remaining \`.reason\` / \`.decision\` references on \`ClaimResponse\` shapes — clean.
- [ ] CI green

## Follow-up (separate PR worth considering)

The \`pnpm -r typecheck\` task should include the Next.js examples — running \`tsc --noEmit\` on the Next.js source would have caught this locally. Out of scope for the hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)