### PR TITLE
fix(mini-app-tests): align with new uniform-rejection contract

### DIFF
--- a/examples/mini-app-claim-react/test/useMiniAppFaucet.test.tsx
+++ b/examples/mini-app-claim-react/test/useMiniAppFaucet.test.tsx
@@ -75,26 +75,29 @@ describe('useMiniAppFaucet (React) — state machine', () => {
   it('rejected at submit', async () => {
     setupReady();
     mockClient.config.mockResolvedValue({});
-    mockClient.claim.mockResolvedValue({ id: 'cid-2', status: 'rejected', reason: 'rate limited' });
+    // Public reject body shape per SECURITY.md "Public-API silence on
+    // rejection": no `reason` field. The hook surfaces a static
+    // 'Claim rejected' fallback.
+    mockClient.claim.mockResolvedValue({ id: 'cid-2', status: 'rejected' });
 
     const { result } = renderHook(() => useMiniAppFaucet(FAUCET_URL));
     await waitFor(() => expect(result.current.state.phase).toBe('ready'));
     await act(async () => { await result.current.claim(); });
     expect(result.current.state.phase).toBe('rejected');
-    expect(result.current.state.errorMessage).toBe('rate limited');
+    expect(result.current.state.errorMessage).toBe('Claim rejected');
     expect(mockClient.waitForConfirmation).not.toHaveBeenCalled();
   });
 
   it('challenged response', async () => {
     setupReady();
     mockClient.config.mockResolvedValue({});
-    mockClient.claim.mockResolvedValue({ id: 'cid-3', status: 'challenged', reason: 'captcha required' });
+    mockClient.claim.mockResolvedValue({ id: 'cid-3', status: 'challenged' });
 
     const { result } = renderHook(() => useMiniAppFaucet(FAUCET_URL));
     await waitFor(() => expect(result.current.state.phase).toBe('ready'));
     await act(async () => { await result.current.claim(); });
     expect(result.current.state.phase).toBe('challenged');
-    expect(result.current.state.errorMessage).toBe('captcha required');
+    expect(result.current.state.errorMessage).toBe('Captcha required');
   });
 
   it('network error during claim → error phase', async () => {

--- a/examples/mini-app-claim-vue/test/useMiniAppFaucet.test.ts
+++ b/examples/mini-app-claim-vue/test/useMiniAppFaucet.test.ts
@@ -99,14 +99,17 @@ describe('useMiniAppFaucet (Vue) — state machine', () => {
   it('rejected at submit', async () => {
     setupReady();
     mockClient.config.mockResolvedValue({});
-    mockClient.claim.mockResolvedValue({ id: 'cid-2', status: 'rejected', reason: 'rate limited' });
+    // Public reject body shape per SECURITY.md "Public-API silence on
+    // rejection": no `reason` field. The composable surfaces a static
+    // 'Claim rejected' fallback.
+    mockClient.claim.mockResolvedValue({ id: 'cid-2', status: 'rejected' });
 
     const scope = effectScope();
     const result = scope.run(() => useMiniAppFaucet(FAUCET_URL))!;
     await flushMicrotasks();
     await result.claim();
     expect(result.state.phase).toBe('rejected');
-    expect(result.state.errorMessage).toBe('rate limited');
+    expect(result.state.errorMessage).toBe('Claim rejected');
     expect(mockClient.waitForConfirmation).not.toHaveBeenCalled();
     scope.stop();
   });
@@ -114,14 +117,14 @@ describe('useMiniAppFaucet (Vue) — state machine', () => {
   it('challenged response', async () => {
     setupReady();
     mockClient.config.mockResolvedValue({});
-    mockClient.claim.mockResolvedValue({ id: 'cid-3', status: 'challenged', reason: 'captcha required' });
+    mockClient.claim.mockResolvedValue({ id: 'cid-3', status: 'challenged' });
 
     const scope = effectScope();
     const result = scope.run(() => useMiniAppFaucet(FAUCET_URL))!;
     await flushMicrotasks();
     await result.claim();
     expect(result.state.phase).toBe('challenged');
-    expect(result.state.errorMessage).toBe('captcha required');
+    expect(result.state.errorMessage).toBe('Captcha required');
     scope.stop();
   });
 


### PR DESCRIPTION
## Summary

Second hotfix for the rejection-uniformity contract rollout. The Vue and React mini-app state-machine tests still asserted on server-supplied reject reasons that the contract removed back in PR #176.

CI's per-example test job flagged it on \`ab1b130\` (after PR #181 fixed the Next.js \`tsc\` failure):

\`\`\`
AssertionError: expected 'Claim rejected' to be 'rate limited'
AssertionError: expected 'Captcha required' to be 'captcha required'
\`\`\`

## Fix

- Drop \`reason: '...'\` from mocked \`ClaimResponse\` payloads (the field no longer exists on the type per #176)
- Update assertions to match the static fallback strings the composable/hook surfaces (\`'Claim rejected'\` / \`'Captcha required'\`)
- Add a comment pointing back at the SECURITY.md contract

## Test plan

- [x] \`pnpm --filter @nimiq-faucet/example-mini-app-vue test\` → 6/6 pass
- [x] \`pnpm --filter @nimiq-faucet/example-mini-app-react test\` → 6/6 pass
- [ ] CI green

## Why this wasn't caught earlier

The example tests aren't part of the workspace \`pnpm --filter @faucet/server test\` task that I ran during PR #176 (and that I keep running locally). They run via \`turbo run test\` which CI exercises but I'd been skipping locally. Adding the example tests to a faster local-feedback target is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)