### PR TITLE
fix(e2e+claim-ui): align rate-limit Playwright test + claim-ui views with uniform-rejection contract

### DIFF
--- a/apps/claim-ui/src/components/ClaimDetailModal.vue
+++ b/apps/claim-ui/src/components/ClaimDetailModal.vue
@@ -2,15 +2,16 @@
 import { computed } from 'vue';
 import { lunaToNim } from '../lib/format';
 
+// Mirrors the public `/v1/claims/recent` row shape. `decision` and
+// `rejectionReason` are intentionally absent — see SECURITY.md
+// "Public-API silence on rejection".
 interface ClaimDetail {
   id: string;
   createdAt: string | number;
   address: string;
   amountLuna?: string;
   status: string;
-  decision: string | null;
   txId: string | null;
-  rejectionReason: string | null;
 }
 
 const props = defineProps<{ claim: ClaimDetail }>();
@@ -112,13 +113,13 @@ function copyToClipboard(text: string) {
             <span class="font-mono text-lg text-primary font-semibold">{{ lunaToNim(claim.amountLuna) }} NIM</span>
           </div>
 
-          <!-- Decision -->
-          <div class="bg-surface-container-low rounded-[16px] p-6 flex flex-col gap-2">
-            <span class="font-label text-xs uppercase tracking-wider text-on-surface-variant font-medium">Decision</span>
-            <span class="font-mono text-sm text-on-surface">{{ claim.decision ?? '—' }}</span>
-          </div>
-
           <!-- TX Hash (if exists) -->
+          <!-- Per SECURITY.md "Public-API silence on rejection": the
+               public claim-status response no longer carries `decision`
+               or `rejectionReason`. Operators see those fields via the
+               admin dashboard's claims-list view.
+               This modal renders only fields the public endpoint exposes. -->
+
           <div v-if="claim.txId" class="col-span-1 md:col-span-2 bg-surface-container-low rounded-[16px] p-6 flex flex-col gap-3">
             <span class="font-label text-xs uppercase tracking-wider text-on-surface-variant font-medium">Transaction Hash</span>
             <div class="flex items-center justify-between">
@@ -127,12 +128,6 @@ function copyToClipboard(text: string) {
                 📋
               </button>
             </div>
-          </div>
-
-          <!-- Rejection Reason (if exists) -->
-          <div v-if="claim.rejectionReason" class="col-span-1 md:col-span-2 bg-surface-container-low rounded-[16px] p-6 flex flex-col gap-3">
-            <span class="font-label text-xs uppercase tracking-wider text-on-surface-variant font-medium">Rejection Reason</span>
-            <span class="font-mono text-sm text-error">{{ claim.rejectionReason }}</span>
           </div>
 
           <!-- Claim ID -->

--- a/apps/claim-ui/src/views/ActivityLog.vue
+++ b/apps/claim-ui/src/views/ActivityLog.vue
@@ -3,15 +3,16 @@ import { onMounted, ref, watch } from 'vue';
 import ClaimDetailModal from '../components/ClaimDetailModal.vue';
 import { timeAgo, lunaToNim } from '../lib/format';
 
+// Mirrors the public `/v1/claims/recent` row shape. `decision` and
+// `rejectionReason` are intentionally absent — see SECURITY.md
+// "Public-API silence on rejection".
 interface ClaimRow {
   id: string;
   createdAt: string | number;
   address: string;
   amountLuna: string;
   status: string;
-  decision: string | null;
   txId: string | null;
-  rejectionReason: string | null;
 }
 
 const items = ref<ClaimRow[]>([]);
@@ -25,8 +26,9 @@ const pageSize = 20;
 function entryTitle(c: ClaimRow): string {
   if (c.status === 'confirmed') return 'Claim Successful';
   if (c.status === 'broadcast') return 'Faucet Sent';
-  if (c.status === 'rejected' && c.decision === 'deny') return 'Abuse Attempt Blocked';
-  if (c.status === 'rejected') return 'Rate Limit Exceeded';
+  // Public reject body is uniform — we no longer distinguish 'deny' vs
+  // other reject reasons in the activity log title. See SECURITY.md.
+  if (c.status === 'rejected') return 'Claim Rejected';
   if (c.status === 'challenged') return 'Processing Transaction';
   if (c.status === 'timeout') return 'Processing Transaction';
   return 'Claim ' + c.status;

--- a/apps/claim-ui/src/views/StatusPage.vue
+++ b/apps/claim-ui/src/views/StatusPage.vue
@@ -9,15 +9,16 @@ interface StatsSummary {
   claims: Record<string, number>;
   blocked: Record<string, number>;
   successRate: number;
+  // Mirrors the public `/v1/stats/summary` response shape. `decision`,
+  // `rejectionReason`, and `topRejectionReasons` are intentionally
+  // absent — see SECURITY.md "Public-API silence on rejection".
   recentClaims: {
     id: string;
     createdAt: string | number;
     address: string;
     amountLuna: string;
     status: string;
-    decision: string;
     txId: string | null;
-    rejectionReason: string | null;
   }[];
   recentBlocked: {
     id: string;
@@ -25,11 +26,8 @@ interface StatsSummary {
     address: string;
     amountLuna: string;
     status: string;
-    decision: string;
     txId: string | null;
-    rejectionReason: string | null;
   }[];
-  topRejectionReasons: { reason: string; count: number }[];
 }
 
 interface SystemEvent {
@@ -157,7 +155,7 @@ onUnmounted(() => clearInterval(pollTimer));
               <div class="col-span-6 font-mono text-on-surface font-medium truncate pr-4">{{ truncateAddress(c.address) }}</div>
               <div class="col-span-3 text-on-surface-variant font-mono">{{ timeAgo(c.createdAt) }}</div>
               <div class="col-span-3 text-right font-mono font-semibold" :class="c.status === 'rejected' ? 'text-error' : 'text-primary'">
-                {{ c.status === 'rejected' ? c.rejectionReason ?? 'Blocked' : `+${lunaToNim(c.amountLuna)} NIM` }}
+                {{ c.status === 'rejected' ? 'Blocked' : `+${lunaToNim(c.amountLuna)} NIM` }}
               </div>
             </div>
           </div>
@@ -184,7 +182,7 @@ onUnmounted(() => clearInterval(pollTimer));
               <div class="col-span-5 font-mono text-on-surface font-medium truncate pr-4">{{ truncateAddress(c.address) }}</div>
               <div class="col-span-3 text-on-surface-variant font-mono">{{ timeAgo(c.createdAt) }}</div>
               <div class="col-span-4 text-right font-mono font-semibold text-error truncate">
-                {{ c.rejectionReason ?? 'Blocked' }}
+                Blocked
               </div>
             </div>
           </div>

--- a/tests/e2e/claim.spec.ts
+++ b/tests/e2e/claim.spec.ts
@@ -95,9 +95,10 @@ test.describe('claim ui — homepage', () => {
 
   test('rate limit: sixth claim from the same IP hits the daily cap', async ({ request }) => {
     // The per-IP per-day cap is 5. Five same-IP claims should succeed, the
-    // sixth must be rejected with decision=deny & a rate-limit reason. We use
-    // distinct addresses so only the IP cap (not duplicate-address guards)
-    // fires.
+    // sixth must be rejected. We use distinct addresses so only the IP cap
+    // (not duplicate-address guards) fires. The reject body itself is
+    // uniform (`{id, status: 'rejected'}`) per SECURITY.md "Public-API
+    // silence on rejection" — granular attribution is admin-only.
     const addrs = Array.from(
       { length: 6 },
       (_v, i) => `NQ00 ${String(i).repeat(4)} 5555 5555 5555 5555 5555 5555 5555`,
@@ -122,10 +123,21 @@ test.describe('claim ui — homepage', () => {
     }
 
     const last = responses[responses.length - 1];
+    // Per SECURITY.md "Public-API silence on rejection": the public
+    // reject body collapses to `403 { id, status: 'rejected' }` with
+    // no abuse-layer attribution. We can no longer assert on a
+    // rate-limit-specific reason string from the body — confirm only
+    // the uniform shape + the 403 / 429 status code. The 429 path is
+    // for `claim_in_progress` (legitimate concurrency signal); 403 is
+    // the abuse-pipeline deny path.
     expect([403, 429]).toContain(last!.status);
-    const body = last!.body as { decision?: string; reason?: string; error?: string } | null;
-    const reasonBlob = `${body?.decision ?? ''} ${body?.reason ?? ''} ${body?.error ?? ''}`.toLowerCase();
-    expect(reasonBlob).toMatch(/cap|rate|limit|too many/);
+    const body = last!.body as Record<string, unknown> | null;
+    expect(body).not.toBeNull();
+    if (last!.status === 403) {
+      // Uniform reject shape — only id + status.
+      expect(Object.keys(body!).sort()).toEqual(['id', 'status']);
+      expect(body!['status']).toBe('rejected');
+    }
   });
 });
 

--- a/tests/e2e/globalSetup.ts
+++ b/tests/e2e/globalSetup.ts
@@ -70,6 +70,11 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     uiEnabled: 'true',
     dev: 'true',
     corsOrigins: '*',
+    // Disable reject-delay padding in e2e tests — the production
+    // default (1500ms) compounds with Playwright's per-test timeout
+    // budget and adds ~9s to the rate-limit test alone. Padding
+    // correctness is exercised by apps/server/test/claim-reject-timing-padding.e2e.test.ts.
+    rejectDelayMsMin: '0',
   });
 
   const driver = new StubDriver();


### PR DESCRIPTION
## Summary

Third hotfix layer for the rejection-uniformity contract rollout (after #181 fixed the Next.js \`tsc\`-in-build failure and #182 fixed the mini-app unit tests). CI on \`1a382dd\` failed on:

1. **Playwright \`rate limit\` test** — 9 failures across chromium/firefox/webkit × 3 retries
2. **claim-ui views still typed/rendered the dropped fields** — surfaced by my own grep sweep, not yet by CI but inevitable next failure layer

## Changes

### Playwright e2e ([tests/e2e/claim.spec.ts:96](tests/e2e/claim.spec.ts#L96))

The rate-limit test built a \`reasonBlob\` from \`body.decision + body.reason + body.error\` and matched \`/cap|rate|limit/\`. After PR #176, those fields are gone from the public reject body — the blob is empty; \`toMatch\` fails. Fix: assert the new uniform shape directly:
- 403 status code
- response body keys are exactly \`['id', 'status']\`
- \`body.status === 'rejected'\`

The 429 (\`claim_in_progress\`) path stays an accepted alternative since it's a legitimate concurrency signal.

Also: add \`rejectDelayMsMin: '0'\` to the e2e harness config in [tests/e2e/globalSetup.ts](tests/e2e/globalSetup.ts) so the production-default 1500ms padding doesn't compound with Playwright's per-test timeout budget.

### claim-ui ([apps/claim-ui/](apps/claim-ui/))

StatusPage, ActivityLog, and ClaimDetailModal still typed and rendered \`decision\` / \`rejectionReason\` / \`topRejectionReasons\` from the public endpoints. PR #177 stripped those fields, so:
- The type-level shape is wrong (TS allows it because the runtime shape just becomes \`undefined\`).
- The UI silently renders blanks instead of useful text.

Fix:
- Drop the type-level fields from \`ClaimDetail\`, \`ClaimRow\`, and \`StatusPage.stats\`
- ClaimDetailModal: drop the "Decision" and "Rejection Reason" detail rows
- StatusPage rendering: replace \`c.rejectionReason ?? 'Blocked'\` with literal \`'Blocked'\`
- ActivityLog \`entryTitle\`: collapse "Abuse Attempt Blocked" / "Rate Limit Exceeded" → "Claim Rejected"
- Anchor comments at each interface pointing back at [SECURITY.md](SECURITY.md)

## Test plan

- [x] \`pnpm --filter @nimiq-faucet/claim-ui build\` clean
- [x] \`pnpm -r typecheck\` green across 19 packages
- [ ] CI green (Playwright is the canary; can't run the full multi-browser stack locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)