### PR TITLE
chore: add `pnpm pre-merge` target — full local verification before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "turbo run test --filter=!@nimiq-faucet/e2e",
     "test:e2e": "pnpm --filter @nimiq-faucet/e2e test",
     "test:e2e:install": "cd tests/e2e && npx playwright install --with-deps",
+    "pre-merge": "turbo run typecheck build test --filter=!@nimiq-faucet/e2e",
     "presmoke:testnet": "pnpm build",
     "smoke:testnet": "tsx scripts/smoke-testnet.mts",
     "generate:wallet": "tsx scripts/generate-wallet.mts",


### PR DESCRIPTION
## Summary

Add a single \`pnpm pre-merge\` script that runs the same chain CI exercises (minus the multi-browser Playwright e2e, available separately as \`pnpm test:e2e\`):

\`\`\`
turbo run typecheck build test --filter=!@nimiq-faucet/e2e
\`\`\`

## Why

The past three CI failures on \`main\` (#181, #182, #183) all came from contract-affecting changes (PR #176 / #177 dropping fields from public \`ClaimResponse\`) where the verification I'd been running locally — \`pnpm --filter @faucet/server test\` + \`pnpm -r typecheck\` — missed four consumer classes:

1. **Next.js's \`tsc\`-in-build** — \`next build\` runs its own typecheck inside; not covered by the workspace \`typecheck\` task.
2. **Example app vitest suites** — \`examples/mini-app-claim-{vue,react}/test/\` aren't run by the server filter.
3. **Vue templates rendering dropped fields** — TS allows \`undefined\` in templates, only manual grep catches it (silent runtime degradation otherwise).
4. **Playwright e2e assertions on response body shape** — handled by the existing \`pnpm test:e2e\` script.

The first three are caught by \`pnpm pre-merge\`; the fourth stays a separate target because Playwright takes ~3min across chromium/firefox/webkit and isn't worth on every push.

## Verified

- \`pnpm pre-merge\` runs 58 tasks on the current \`main\`, all pass, takes ~3-4 min — same order of magnitude as CI's \`build\` job.

## Companion

A memory entry now captures the rule (see \`~/.claude/projects/-home-richy-Projects-Nimiq-Simple-Faucet/memory/feedback_pre_merge_verification.md\`): "For any change that touches \`packages/sdk-*/src/index.ts\` types, OpenAPI schemas, or any public route's response shape, run \`pnpm pre-merge\` before pushing."

🤖 Generated with [Claude Code](https://claude.com/claude-code)