### PR TITLE
feat(themes): make nimiq-pow the default Claim UI theme

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -131,12 +131,12 @@ export const ServerConfigSchema = z.object({
   claimUiDir: z.string().optional(),
   /**
    * Slug of a bundled Claim UI theme to serve when `claimUiDir` is unset.
-   * Default: `porcelain-vault`. Unknown values fall back to the default
-   * with a warning log so a typo in deployment env doesn't break the UI.
+   * Default: `nimiq-pow`. Unknown values fall back to the default with a
+   * warning log so a typo in deployment env doesn't break the UI.
    * See `apps/server/src/themes.ts` for the registry. Adding a new theme
    * is documented in `docs/contributing-a-frontend.md`.
    */
-  claimUiTheme: z.string().default('porcelain-vault'),
+  claimUiTheme: z.string().default('nimiq-pow'),
   /**
    * §3.0.16: when true, /v1/config exposes the bundled-theme list and
    * the server honours `?theme=<slug>` in the URL (in addition to the

--- a/apps/server/src/themes.ts
+++ b/apps/server/src/themes.ts
@@ -30,25 +30,25 @@ export interface ThemeManifest {
 }
 
 export const THEMES = {
-  'porcelain-vault': {
-    displayName: 'Porcelain Vault',
-    description:
-      'The default — clean, off-white, Material 3 palette. Vue 3 + Tailwind. Shipped in v2.2.1.',
-    distFromRepoRoot: 'apps/claim-ui/dist',
-    distInImage: '/app/themes/porcelain-vault/dist',
-  },
   'nimiq-pow': {
     displayName: 'Nimiq PoW',
     description:
-      'Visual tribute to the original nimiq/web-miner — world-dot map + peer-pulse animation, dark navy. Decorative; the claim is plain HTTP.',
+      'The default — visual tribute to the original nimiq/web-miner with hex world map + dark navy palette. Vue 3.',
     distFromRepoRoot: 'apps/nimiq-pow-ui/dist',
     distInImage: '/app/themes/nimiq-pow/dist',
+  },
+  'porcelain-vault': {
+    displayName: 'Porcelain Vault',
+    description:
+      'Clean, off-white, Material 3 palette. Vue 3 + Tailwind. Shipped in v2.2.1.',
+    distFromRepoRoot: 'apps/claim-ui/dist',
+    distInImage: '/app/themes/porcelain-vault/dist',
   },
 } as const satisfies Record<string, ThemeManifest>;
 
 export type ThemeSlug = keyof typeof THEMES;
 
-export const DEFAULT_THEME: ThemeSlug = 'porcelain-vault';
+export const DEFAULT_THEME: ThemeSlug = 'nimiq-pow';
 
 /**
  * Type guard: is the given string a slug we know about? Tolerates


### PR DESCRIPTION
## Summary
- Promotes the Nimiq PoW theme (hex world map + dark navy chrome, polished in #186) to the default Claim UI.
- `porcelain-vault` stays bundled — operators can still pick it via `FAUCET_CLAIM_UI_THEME=porcelain-vault` or the theme picker.

## Changes
- `apps/server/src/themes.ts`: reorder THEMES (nimiq-pow first), flip `DEFAULT_THEME` to `'nimiq-pow'`, swap the "default" tag in description blurbs.
- `apps/server/src/config.ts`: change Zod default for `claimUiTheme` from `'porcelain-vault'` → `'nimiq-pow'`.

## Test plan
- [x] `pnpm --filter @faucet/server build` — typecheck clean
- [ ] Manual: deploy without `FAUCET_CLAIM_UI_THEME` set, confirm nimiq-pow is served at `/`. Then set `FAUCET_CLAIM_UI_THEME=porcelain-vault` and confirm porcelain-vault is served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)