### PR TITLE
fix(fcaptcha+ux): allow 'unsafe-eval' for FCaptcha + clearer hashcash status text

### DIFF
--- a/apps/nimiq-pow-ui/src/components/StatusBar.vue
+++ b/apps/nimiq-pow-ui/src/components/StatusBar.vue
@@ -13,7 +13,7 @@ const message = computed(() => {
   switch (props.phase) {
     case 'idle': return 'Ready to mine your free NIM.';
     case 'loading-config': return 'Reading server config…';
-    case 'solving-hashcash': return `Proof-of-work: ${props.hashcashAttempts.toLocaleString()} attempts…`;
+    case 'solving-hashcash': return `Verifying you're human… (${props.hashcashAttempts.toLocaleString()} attempts)`;
     case 'submitting': return 'Submitting claim to the faucet…';
     case 'broadcast': return 'Broadcast — waiting for confirmation…';
     case 'confirmed': return 'Confirmed! Welcome to Nimiq.';

--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -50,6 +50,13 @@ function cspDirectives(
 ): CspDirectives | false {
   if (profile === 'off') return false;
   const fcaptchaOrigin = fcaptchaPublicUrl ? originOf(fcaptchaPublicUrl) : null;
+  // FCaptcha's challenge runtime evaluates dynamic JS at solve time
+  // (Function/eval) so the widget needs `'unsafe-eval'` in script-src.
+  // We only add it when the operator actually configured FCaptcha — no
+  // relaxation for deployments using only Turnstile / hCaptcha / hashcash.
+  const fcaptchaScriptExtras: string[] = fcaptchaOrigin
+    ? [fcaptchaOrigin, "'unsafe-eval'"]
+    : [];
   const base: CspDirectives = {
     'default-src': ["'self'"],
     'script-src': ["'self'"],
@@ -62,7 +69,7 @@ function cspDirectives(
   };
   if (profile === 'strict') {
     if (fcaptchaOrigin) {
-      base['script-src'] = [...base['script-src'], fcaptchaOrigin];
+      base['script-src'] = [...base['script-src'], ...fcaptchaScriptExtras];
       base['connect-src'] = [...base['connect-src'], fcaptchaOrigin];
     }
     return base;
@@ -73,7 +80,7 @@ function cspDirectives(
       "'self'",
       'https://challenges.cloudflare.com',
       'https://js.hcaptcha.com',
-      ...(fcaptchaOrigin ? [fcaptchaOrigin] : []),
+      ...fcaptchaScriptExtras,
     ],
     'frame-src': [
       "'self'",


### PR DESCRIPTION
## Context

Real-deploy claim attempt on a stack with FCaptcha enabled produced two issues:

1. **403 on `/v1/claim`** because FCaptcha's challenge runtime calls `Function(string)` / `eval` to execute the per-request challenge script, which the strict CSP blocked. Widget never emitted a token, claim arrived empty, abuse pipeline rejected it.
2. **End-user confusion** at the "Proof-of-work: 12,345 attempts…" status — readers assumed the faucet itself ran a PoW chain.

## Changes
- `apps/server/src/hardening.ts`: when `fcaptchaPublicUrl` is set, append `'unsafe-eval'` to `script-src` (alongside the FCaptcha origin). Only added when FCaptcha is configured — Turnstile / hCaptcha / hashcash-only deployments stay strict.
- `apps/nimiq-pow-ui/src/components/StatusBar.vue`: reword the `solving-hashcash` phase message — `"Verifying you're human… (N attempts)"` instead of `"Proof-of-work: N attempts…"`.

## Test plan
- [x] `pnpm --filter @faucet/server build` — typecheck clean
- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui build` — vue-tsc + vite build clean
- [ ] Manual on a deploy with FCaptcha: confirm `script-src` header now contains `'unsafe-eval'` and the widget completes the challenge end-to-end, claim succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)