### PR TITLE
feat(nimiq-pow-ui): wire FCaptcha widget into the abuse-slot

### DIFF
--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -6,14 +6,24 @@ import ClaimButton from './components/ClaimButton.vue';
 import StatusBar from './components/StatusBar.vue';
 import FooterBar from './components/FooterBar.vue';
 import ThemePicker from './components/ThemePicker.vue';
+import FCaptchaWidget from './components/FCaptchaWidget.vue';
 import { useClaim } from './composables/useClaim';
 import { isValidNimiqAddress } from './lib/nimiqAddress';
 
 const address = ref('');
 const connectedLabel = ref<string | null>(null);
+const captchaToken = ref('');
 const { config, state, claim, reset } = useClaim();
 
 const isAddressValid = computed(() => isValidNimiqAddress(address.value));
+
+// Captcha is required if the server config exposes a provider. Today
+// only fcaptcha is wired into this UI — turnstile / hcaptcha can be
+// added later by mounting their widgets in the same `.abuse-slot`.
+const captchaProvider = computed(() => config.value?.captcha?.provider ?? null);
+const needsCaptcha = computed(() => captchaProvider.value !== null);
+const fcaptchaServerUrl = computed(() => config.value?.captcha?.serverUrl ?? null);
+const fcaptchaSiteKey = computed(() => config.value?.captcha?.siteKey ?? null);
 
 // Ref to ConnectWallet so the top-right "Ready to mine…" pill can
 // trigger the same Hub-connect flow as the bottom-strip Connect button.
@@ -24,6 +34,7 @@ function triggerConnect(): void {
 
 const canClaim = computed(() => {
   if (!isAddressValid.value) return false;
+  if (needsCaptcha.value && !captchaToken.value) return false;
   return state.phase === 'idle' || state.phase === 'rejected' || state.phase === 'error' || state.phase === 'confirmed';
 });
 
@@ -36,7 +47,12 @@ function handleClaim() {
   if (state.phase === 'confirmed' || state.phase === 'rejected' || state.phase === 'error') {
     reset();
   }
-  void claim(address.value);
+  void claim(address.value, captchaToken.value || undefined).then(() => {
+    // Reset the captcha after every submission — most providers (FCaptcha
+    // included) emit a single-use token, so the next claim attempt needs
+    // a fresh challenge.
+    captchaToken.value = '';
+  });
 }
 </script>
 
@@ -89,8 +105,19 @@ function handleClaim() {
            messages today, and any future captcha widgets (turnstile /
            hcaptcha / fcaptcha iframes) when this UI integrates them. -->
       <div class="abuse-slot">
+        <FCaptchaWidget
+          v-if="
+            state.phase === 'idle' &&
+            captchaProvider === 'fcaptcha' &&
+            fcaptchaServerUrl &&
+            fcaptchaSiteKey
+          "
+          v-model="captchaToken"
+          :server-url="fcaptchaServerUrl"
+          :site-key="fcaptchaSiteKey"
+        />
         <StatusBar
-          v-if="state.phase !== 'idle'"
+          v-else-if="state.phase !== 'idle'"
           class="strip-status"
           :phase="state.phase"
           :tx-id="state.txId"

--- a/apps/nimiq-pow-ui/src/components/FCaptchaWidget.vue
+++ b/apps/nimiq-pow-ui/src/components/FCaptchaWidget.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+/**
+ * FCaptcha widget for the nimiq-pow theme. Loads the FCaptcha runtime
+ * from `serverUrl/fcaptcha.js`, renders the challenge into a local div,
+ * and surfaces the resulting token via `v-model`.
+ *
+ * Mirrors `apps/claim-ui/src/components/FCaptchaWidget.vue` so the
+ * abuse-pipeline contract is identical across themes. Diffs from the
+ * claim-ui version: no i18n dep (English literal), dark-theme styling.
+ */
+import { onMounted, onBeforeUnmount, ref, watch } from 'vue';
+
+interface Props {
+  siteKey: string;
+  serverUrl: string;
+  modelValue: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>();
+
+const container = ref<HTMLDivElement | null>(null);
+const containerId = `fcaptcha-${Math.random().toString(36).slice(2, 10)}`;
+const loadError = ref<string | null>(null);
+
+interface FCaptchaApi {
+  configure: (opts: { serverUrl: string }) => void;
+  render: (
+    elementId: string,
+    opts: { siteKey: string; callback: (token: string) => void; 'error-callback'?: () => void },
+  ) => void;
+  reset?: (elementId: string) => void;
+  remove?: (elementId: string) => void;
+}
+
+declare global {
+  interface Window {
+    FCaptcha?: FCaptchaApi;
+  }
+}
+
+function scriptUrl(serverUrl: string): string {
+  return `${serverUrl.replace(/\/$/, '')}/fcaptcha.js`;
+}
+
+function ensureScript(serverUrl: string): Promise<FCaptchaApi> {
+  if (typeof window === 'undefined') return Promise.reject(new Error('no window'));
+  if (window.FCaptcha) return Promise.resolve(window.FCaptcha);
+  const src = scriptUrl(serverUrl);
+  const existing = document.querySelector<HTMLScriptElement>(`script[src="${src}"]`);
+  if (existing) {
+    return new Promise((resolve, reject) => {
+      existing.addEventListener('load', () => {
+        if (window.FCaptcha) resolve(window.FCaptcha);
+        else reject(new Error('fcaptcha load failed'));
+      });
+      existing.addEventListener('error', () => reject(new Error('fcaptcha load failed')));
+    });
+  }
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.async = true;
+    s.defer = true;
+    s.addEventListener('load', () => {
+      if (window.FCaptcha) resolve(window.FCaptcha);
+      else reject(new Error('fcaptcha load failed'));
+    });
+    s.addEventListener('error', () => reject(new Error('fcaptcha load failed')));
+    document.head.appendChild(s);
+  });
+}
+
+onMounted(async () => {
+  try {
+    const api = await ensureScript(props.serverUrl);
+    api.configure({ serverUrl: props.serverUrl });
+    if (!container.value) return;
+    api.render(containerId, {
+      siteKey: props.siteKey,
+      callback: (token: string) => emit('update:modelValue', token),
+      'error-callback': () => emit('update:modelValue', ''),
+    });
+  } catch (err) {
+    loadError.value = (err as Error).message;
+  }
+});
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (!v && window.FCaptcha?.reset) window.FCaptcha.reset(containerId);
+  },
+);
+
+onBeforeUnmount(() => {
+  if (window.FCaptcha?.remove) window.FCaptcha.remove(containerId);
+});
+</script>
+
+<template>
+  <div class="fcaptcha-shell">
+    <div :id="containerId" ref="container" class="fcaptcha-host" aria-label="FCaptcha challenge" />
+    <p v-if="loadError" class="error">{{ loadError }}</p>
+  </div>
+</template>
+
+<style scoped>
+.fcaptcha-shell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.fcaptcha-host {
+  /* FCaptcha renders its own widget chrome; we just give it room. */
+  min-width: 18rem;
+}
+
+.error {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--error);
+}
+</style>

--- a/apps/nimiq-pow-ui/src/components/StatusBar.vue
+++ b/apps/nimiq-pow-ui/src/components/StatusBar.vue
@@ -13,7 +13,7 @@ const message = computed(() => {
   switch (props.phase) {
     case 'idle': return 'Ready to mine your free NIM.';
     case 'loading-config': return 'Reading server config…';
-    case 'solving-hashcash': return `Verifying you're human… (${props.hashcashAttempts.toLocaleString()} attempts)`;
+    case 'solving-hashcash': return "Verifying you're human…";
     case 'submitting': return 'Submitting claim to the faucet…';
     case 'broadcast': return 'Broadcast — waiting for confirmation…';
     case 'confirmed': return 'Confirmed! Welcome to Nimiq.';

--- a/apps/nimiq-pow-ui/src/composables/useClaim.ts
+++ b/apps/nimiq-pow-ui/src/composables/useClaim.ts
@@ -50,7 +50,7 @@ export function useClaim() {
     },
   );
 
-  async function claim(address: string): Promise<void> {
+  async function claim(address: string, captchaToken?: string): Promise<void> {
     if (inFlight) return;
     if (!address.trim()) return;
     inFlight = true;
@@ -65,6 +65,7 @@ export function useClaim() {
         result = await client.solveAndClaim(address.trim(), {
           uid: 'nimiq-pow-ui',
           hostContext: { uid: 'nimiq-pow-ui' },
+          captchaToken,
           onProgress: (n) => {
             state.hashcashAttempts = n;
           },
@@ -73,6 +74,7 @@ export function useClaim() {
         state.phase = 'submitting';
         result = await client.claim(address.trim(), {
           hostContext: { uid: 'nimiq-pow-ui' },
+          captchaToken,
         });
       }
       state.phase = 'submitting';


### PR DESCRIPTION
## Summary
Without this, the nimiq-pow theme could only complete claims against a faucet whose only abuse layer was hashcash. Anything stricter (FCaptcha in particular) returned 403 because no captcha token reached the server.

This PR ports the FCaptcha widget contract from `claim-ui` into `nimiq-pow-ui` and mounts it in the existing `.abuse-slot` (the slot was already designed to host this — see comment that landed in #186).

## Changes
- **New** [`apps/nimiq-pow-ui/src/components/FCaptchaWidget.vue`](apps/nimiq-pow-ui/src/components/FCaptchaWidget.vue) — mirrors the claim-ui contract (script-tag bootstrap, single-use token via `v-model`). No i18n dep (English literal), dark-theme styling.
- [`App.vue`](apps/nimiq-pow-ui/src/App.vue) — mount widget when `/v1/config` reports `captcha.provider === 'fcaptcha'`. StatusBar still takes over once the claim moves off `idle`. `canClaim` gates on a non-empty captcha token; reset token after each submission (single-use).
- [`useClaim.ts`](apps/nimiq-pow-ui/src/composables/useClaim.ts) — `claim()` accepts optional `captchaToken`, forwards through `solveAndClaim` / `claim` to the SDK.
- [`StatusBar.vue`](apps/nimiq-pow-ui/src/components/StatusBar.vue) — drop "(N attempts)" suffix from the verifying-human state (operators reported it confused users into thinking the faucet itself ran a PoW chain).

## Test plan
- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui build` — vue-tsc + vite build clean (43.46 KB gzipped, +0.62 KB vs. previous)
- [ ] Manual on a deploy with FCaptcha + hashcash: confirm the widget renders before the address strip, claim button stays disabled until token, claim succeeds end-to-end.
- [ ] Manual on a deploy with hashcash only: confirm the widget does NOT render and the claim flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)