### PR TITLE
fix(fcaptcha+ui): worker-src allowlist + abuse-slot gap + address input id/name

### DIFF
--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -300,7 +300,9 @@ function handleClaim() {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
+  /* Larger gap so the FCaptcha widget (when mounted in `.abuse-slot`)
+     visually breathes above the address row, instead of touching it. */
+  gap: 1.1rem;
   padding: 0.8rem 1.5rem 1rem;
   background: linear-gradient(180deg, rgba(20, 23, 46, 0) 0%, rgba(20, 23, 46, 0.85) 70%, rgba(20, 23, 46, 0.92) 100%);
 }

--- a/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
+++ b/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
@@ -96,10 +96,13 @@ defineExpose({ connect });
     </button>
     <div class="paste-row" :class="{ valid: isValidPasteShape, dirty: modelValue.length > 0 }">
       <input
+        id="nimiq-address"
+        name="nimiq-address"
         type="text"
         spellcheck="false"
         autocomplete="off"
         autocorrect="off"
+        aria-label="Nimiq address"
         placeholder="Or paste an address: NQ00 0000 0000 …"
         :value="modelValue"
         :disabled="disabled"

--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -17,6 +17,7 @@ interface CspDirectives {
   'style-src': string[];
   'img-src': string[];
   'connect-src': string[];
+  'worker-src'?: string[];
   'frame-src'?: string[];
   'frame-ancestors': string[];
   'base-uri': string[];
@@ -67,10 +68,19 @@ function cspDirectives(
     'base-uri': ["'self'"],
     'form-action': ["'self'"],
   };
+  // FCaptcha runs the per-request challenge inside a Web Worker. The
+  // worker source is fetched from the FCaptcha origin (a regular URL on
+  // the captcha host) and/or constructed from a `blob:` URL. With our
+  // explicit `default-src 'self'` neither would load — we add an
+  // explicit `worker-src` allowlist when FCaptcha is configured.
+  const fcaptchaWorkerSources: string[] = fcaptchaOrigin
+    ? ["'self'", 'blob:', fcaptchaOrigin]
+    : [];
   if (profile === 'strict') {
     if (fcaptchaOrigin) {
       base['script-src'] = [...base['script-src'], ...fcaptchaScriptExtras];
       base['connect-src'] = [...base['connect-src'], fcaptchaOrigin];
+      base['worker-src'] = fcaptchaWorkerSources;
     }
     return base;
   }
@@ -97,6 +107,7 @@ function cspDirectives(
       'https://*.hcaptcha.com',
       ...(fcaptchaOrigin ? [fcaptchaOrigin] : []),
     ],
+    ...(fcaptchaOrigin ? { 'worker-src': fcaptchaWorkerSources } : {}),
   };
 }
 


### PR DESCRIPTION
## Context
Follow-ups from a real-deploy claim attempt against the FCaptcha-enabled stack landed in #190.

## Changes
1. **CSP `worker-src`** — FCaptcha runs the per-request challenge in a Web Worker. Browser console: \`FCaptcha error: Event {target: Worker}\` + \"verification failed\". With \`default-src 'self'\` workers from \`https://captcha.example.com\` (or \`blob:\` URLs) were blocked. Server now emits \`worker-src 'self' blob: <fcaptcha-origin>\` whenever \`fcaptchaPublicUrl\` is set. Strict CSP for non-FCaptcha deployments unchanged.
2. **Bottom-strip gap** — widget rendered flush against the address row. Column gap bumped from 0.55rem → 1.1rem.
3. **Address input id/name** — accessibility audit warned about missing \`id\`/\`name\`, which can break browser autofill. Added both plus an \`aria-label\`.

## Test plan
- [x] \`pnpm --filter @faucet/server build\` — typecheck clean
- [x] \`pnpm --filter @nimiq-faucet/nimiq-pow-ui build\` — clean
- [ ] Manual on the FCaptcha-enabled deploy: confirm no console error from the Web Worker, claim succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)