### PR TITLE
fix(fcaptcha): forward user IP via X-Real-IP so verify matches token ip_hash

### DIFF
--- a/packages/abuse-fcaptcha/src/index.ts
+++ b/packages/abuse-fcaptcha/src/index.ts
@@ -36,11 +36,23 @@ export function fcaptchaCheck(config: FCaptchaCheckConfig): AbuseCheck {
         };
       }
       const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      // FCaptcha binds the issued token to the requester's IP (token field
+      // `ip_hash`). At verify time it reads the client IP from `X-Real-IP`
+      // (preferred) or `X-Forwarded-For` headers, falling back to
+      // `req.socket.remoteAddress` — which on a server-to-server verify
+      // call is the faucet container's docker IP, NOT the user's. Without
+      // forwarding the user's IP, every real claim trips `ip_mismatch`.
+      // We pass `X-Real-IP`; FCaptcha matches that against the token's
+      // hashed IP and the verification succeeds.
+      const verifyHeaders: Record<string, string> = {
+        'content-type': 'application/json',
+      };
+      if (req.ip) verifyHeaders['x-real-ip'] = req.ip;
       let body: FCaptchaVerifyResponse;
       try {
         const res = await request(verifyUrl, {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: verifyHeaders,
           body: JSON.stringify({ token: req.captchaToken, secret: config.secret }),
           headersTimeout: timeoutMs,
           bodyTimeout: timeoutMs,

--- a/packages/abuse-fcaptcha/test/check.test.ts
+++ b/packages/abuse-fcaptcha/test/check.test.ts
@@ -131,4 +131,19 @@ describe('fcaptchaCheck', () => {
     expect(captured).toBeDefined();
     expect(JSON.parse(captured as string)).toEqual({ token: 'tok-123', secret: 'super-secret' });
   });
+
+  it('forwards the user IP via X-Real-IP so FCaptcha can match the token ip_hash', async () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    mockAgent
+      .get(SERVER_URL)
+      .intercept({ path: '/api/token/verify', method: 'POST' })
+      .reply(200, (opts) => {
+        capturedHeaders = opts.headers as Record<string, string>;
+        return { valid: true };
+      });
+
+    const check = fcaptchaCheck({ secret: 's', serverUrl: SERVER_URL });
+    await check.check(req('tok-123'));
+    expect(capturedHeaders?.['x-real-ip']).toBe('203.0.113.7');
+  });
 });


### PR DESCRIPTION
## Context

End-to-end FCaptcha rollout on a real VPS produced a 403 on every claim. The reject DB row showed:

\`\`\`
rejection_reason: \"fcaptcha: captcha rejected\"
signals.error: null
\`\`\`

A direct verify call against the upstream FCaptcha v1.7.0 service surfaced the actual reason: **\`ip_mismatch\`**.

## Root cause

FCaptcha v1.7.0 binds each issued token to the requester's IP via a hashed field (\`ip_hash = sha256(ip).slice(0, 8)\`). At verify time \`server-node/server.js:1128–1143\` extracts the client IP from \`X-Real-IP\` (preferred), then \`X-Forwarded-For\`, then \`req.socket.remoteAddress\`.

\`@faucet/abuse-fcaptcha\` only sent \`token\` + \`secret\`. The verify call from inside the faucet container reached FCaptcha over the docker network, so \`req.socket.remoteAddress\` resolved to the faucet container's docker-network IP (e.g. 172.19.0.4), never the user's. ip_hash mismatch → every real claim 403'd.

## Fix
- \`packages/abuse-fcaptcha/src/index.ts\`: forward the user IP (already on \`req.ip\` per the AbuseCheck contract) as the \`X-Real-IP\` header on the verify request.
- New unit test asserts the header is forwarded with the right value.

## Test plan
- [x] \`pnpm --filter @faucet/abuse-fcaptcha test\` — 9/9 passing (was 8/8)
- [ ] Manual on the VPS deploy: claim succeeds end-to-end, fcaptcha verify body shows \`valid: true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)