### PR TITLE
chore: drop unused mkdirSync import (closes CodeQL #331)

### DIFF
--- a/apps/server/test/themes.e2e.test.ts
+++ b/apps/server/test/themes.e2e.test.ts
@@ -16,7 +16,7 @@
  *      and don't get caught by the SPA fallback.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';


### PR DESCRIPTION
Closes CodeQL alert [#331](https://github.com/PanoramicRum/nimiq-simple-faucet/security/code-scanning/331) — \`js/unused-local-variable\`. \`mkdirSync\` was imported but never referenced in [\`apps/server/test/themes.e2e.test.ts:19\`](apps/server/test/themes.e2e.test.ts#L19).

## Test plan
- [x] \`pnpm --filter @faucet/server build\` clean
- [x] \`vitest run test/themes.e2e.test.ts\` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)