### PR TITLE
feat(scripts): add rotate-secrets.sh — in-place credential rotation for compose

### DIFF
--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -134,7 +134,23 @@ docker cp compose-faucet-1:/data/faucet.db.backup /secure-backup/$(date +%F).db
 docker cp compose-faucet-1:/data/faucet.key /secure-backup/$(date +%F).key
 ```
 
-Rotation and offsite replication are your responsibility.
+Rotation and offsite replication are your responsibility. For docker-compose
+deploys, the [`scripts/rotate-secrets.sh`](../scripts/rotate-secrets.sh) helper
+covers the in-place credential rotation:
+
+```bash
+# rotate the four passphrase/password values (admin, hashcash, key, wallet)
+./scripts/rotate-secrets.sh --simple
+
+# additionally generate a fresh wallet keypair, sweep the on-chain balance
+# from the OLD address to the NEW one, and restart the container
+./scripts/rotate-secrets.sh --with-wallet
+```
+
+The script backs up `.env` to `.env.backup-<timestamp>` before any write,
+prints new secrets only on `/dev/tty` (never stdout/log), and re-creates
+the faucet container with the canonical compose flags. See the script's
+header comment for layout assumptions.
 
 ---
 

--- a/scripts/_rotate-wallet.mts
+++ b/scripts/_rotate-wallet.mts
@@ -1,0 +1,152 @@
+/**
+ * Internal helper for `scripts/rotate-secrets.sh --with-wallet`.
+ *
+ * Two subcommands:
+ *
+ *   tsx scripts/_rotate-wallet.mts generate
+ *     → emits a fresh Nimiq Albatross keypair (address + 64-char hex
+ *       private key) on stdout, one shell-friendly export per line:
+ *
+ *           NEW_FAUCET_WALLET_ADDRESS=NQ.. .... ....
+ *           NEW_FAUCET_PRIVATE_KEY=<64-char hex>
+ *
+ *   tsx scripts/_rotate-wallet.mts sweep
+ *     → reads the following env vars:
+ *
+ *           FAUCET_RPC_URL          (e.g. http://localhost:8648)
+ *           FAUCET_RPC_USERNAME     (optional)
+ *           FAUCET_RPC_PASSWORD     (optional)
+ *           OLD_FAUCET_WALLET_ADDRESS
+ *           NEW_FAUCET_WALLET_ADDRESS
+ *           FEE_LUNA                (optional, default 0)
+ *
+ *       Sends every available luna from OLD → NEW and waits up to
+ *       ~3 minutes for confirmation. Exits non-zero on any failure
+ *       (including timeout) so the bash wrapper can abort.
+ *
+ * Why a separate file instead of inlining in the bash script:
+ * keypair generation needs `@nimiq/core`'s WASM, and the RPC sweep
+ * mirrors the contract `NimiqRpcDriver` already speaks (so we keep
+ * one canonical encoding of `sendBasicTransaction` + confirmation
+ * polling instead of forking it into shell).
+ *
+ * Secrets are NEVER passed via argv — only stdin/stdout/env. argv is
+ * world-readable in `ps`, so handing the private key on the command
+ * line would leak it to any local user during the run.
+ */
+type RpcId = number;
+
+interface RpcError {
+  code: number;
+  message: string;
+}
+
+async function rpc<T>(method: string, params: unknown[]): Promise<T> {
+  const url = process.env.FAUCET_RPC_URL;
+  if (!url) {
+    throw new Error('FAUCET_RPC_URL is required');
+  }
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  const user = process.env.FAUCET_RPC_USERNAME;
+  const pass = process.env.FAUCET_RPC_PASSWORD;
+  if (user && pass) {
+    headers.authorization = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+  }
+  const id: RpcId = Math.floor(Math.random() * 2 ** 32);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+  const body = (await res.json()) as { result?: T; error?: RpcError };
+  if (body.error) {
+    throw new Error(`${method} → ${body.error.code}: ${body.error.message}`);
+  }
+  return body.result as T;
+}
+
+async function generate(): Promise<void> {
+  const nimiq = (await import('@nimiq/core')) as typeof import('@nimiq/core');
+  const keyPair = nimiq.KeyPair.generate();
+  const address = keyPair.toAddress().toUserFriendlyAddress();
+  const privateKey = keyPair.privateKey.toHex();
+  process.stdout.write(`NEW_FAUCET_WALLET_ADDRESS=${address}\n`);
+  process.stdout.write(`NEW_FAUCET_PRIVATE_KEY=${privateKey}\n`);
+}
+
+async function sweep(): Promise<void> {
+  const oldAddr = process.env.OLD_FAUCET_WALLET_ADDRESS;
+  const newAddr = process.env.NEW_FAUCET_WALLET_ADDRESS;
+  if (!oldAddr || !newAddr) {
+    throw new Error('OLD_FAUCET_WALLET_ADDRESS and NEW_FAUCET_WALLET_ADDRESS are required');
+  }
+  const fee = Number.parseInt(process.env.FEE_LUNA ?? '0', 10);
+  if (Number.isNaN(fee) || fee < 0) {
+    throw new Error(`FEE_LUNA must be a non-negative integer, got ${process.env.FEE_LUNA}`);
+  }
+
+  // Sanity: confirm the node is reachable and on the network we expect.
+  const networkId = await rpc<string>('getNetworkId', []);
+  process.stderr.write(`[sweep] connected to RPC; network=${networkId}\n`);
+
+  // Read balance from the old wallet.
+  const account = await rpc<{ balance: number | string }>('getAccountByAddress', [oldAddr]);
+  const balance = typeof account.balance === 'string' ? Number.parseInt(account.balance, 10) : account.balance;
+  if (!Number.isFinite(balance) || balance <= 0) {
+    throw new Error(`old wallet has no spendable balance (got ${balance} luna)`);
+  }
+  const value = balance - fee;
+  if (value <= 0) {
+    throw new Error(`fee (${fee}) >= balance (${balance}); refusing to send a zero/negative tx`);
+  }
+  process.stderr.write(`[sweep] balance=${balance} luna; fee=${fee}; sending ${value} luna\n`);
+
+  const validityStartHeight = await rpc<number>('getBlockNumber', []);
+  const txHash = await rpc<string>('sendBasicTransaction', [
+    oldAddr,
+    newAddr,
+    value,
+    fee,
+    validityStartHeight,
+  ]);
+  process.stderr.write(`[sweep] tx submitted: ${txHash}\n`);
+
+  // Poll for confirmation. Mirrors NimiqRpcDriver#waitForConfirmation:
+  // ~120-block validity window @ 1s blocks, plus a small buffer.
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    try {
+      const receipt = await rpc<{ confirmations?: number } | null>(
+        'getTransactionByHash',
+        [txHash],
+      );
+      if (receipt && typeof receipt.confirmations === 'number' && receipt.confirmations > 0) {
+        process.stderr.write(`[sweep] confirmed (${receipt.confirmations} confirmations)\n`);
+        process.stdout.write(`SWEEP_TX_HASH=${txHash}\n`);
+        return;
+      }
+    } catch {
+      // Still in mempool — retry.
+    }
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`tx ${txHash} not confirmed within 180s`);
+}
+
+const cmd = process.argv[2];
+if (cmd === 'generate') {
+  await generate();
+} else if (cmd === 'sweep') {
+  await sweep();
+} else {
+  process.stderr.write('usage: tsx _rotate-wallet.mts <generate|sweep>\n');
+  process.exit(2);
+}

--- a/scripts/rotate-secrets.sh
+++ b/scripts/rotate-secrets.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Rotate the faucet's sensitive secrets in-place on a docker-compose deploy.
+#
+# Usage:
+#
+#   scripts/rotate-secrets.sh                # default: --simple
+#   scripts/rotate-secrets.sh --simple       # rotate the four passphrase/password values
+#   scripts/rotate-secrets.sh --with-wallet  # ALSO rotate the wallet keypair (sweeps balance)
+#   scripts/rotate-secrets.sh --help
+#
+# What gets rotated
+# -----------------
+#
+# --simple (always):
+#     FAUCET_ADMIN_PASSWORD       (admin dashboard auth)
+#     FAUCET_HASHCASH_SECRET      (hashcash HMAC secret)
+#     FAUCET_KEY_PASSPHRASE       (encrypts wallet key inside the Nimiq node)
+#     FAUCET_WALLET_PASSPHRASE    (unlocks the wallet at runtime)
+#
+# --with-wallet (additionally):
+#     FAUCET_WALLET_ADDRESS       (new on-chain address)
+#     FAUCET_PRIVATE_KEY          (new 64-char hex private key)
+#     A balance sweep tx from the OLD wallet to the NEW one. Operator
+#     confirms the on-chain step interactively before it fires.
+#
+# Safety properties
+# -----------------
+# * The .env file is backed up to .env.backup-<timestamp> before any write.
+# * New secret values are printed once on /dev/tty (the controlling terminal),
+#   never on stdout/stderr, so they don't end up in pipes / logs / scrollback
+#   captures of the parent ssh session.
+# * `set -x` is never enabled (would leak secrets via xtrace).
+# * The Node helper takes secrets via env, not argv (argv is visible in `ps`).
+# * The helper runs from the repo root with `tsx` (already a workspace dep).
+#
+# Layout assumptions
+# ------------------
+# * The compose stack lives at deploy/compose/ with docker-compose.yml,
+#   docker-compose.override.yml, and fcaptcha.yml (the canonical operator
+#   layout used by this repo's deployment guide).
+# * The stack is started with `--profile local-node` (the documented
+#   default for self-hosted Albatross node deployments). Override via the
+#   COMPOSE_PROFILE env var.
+# * The faucet's HTTP entrypoint is reachable at FAUCET_HEALTH_URL
+#   (default: https://faucet.wevpage.com/healthz). Override per-deploy.
+#
+# Exit codes:
+#   0  rotation finished, faucet healthy
+#   1  rotation aborted by operator or runtime error
+
+set -euo pipefail
+
+# ────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ────────────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_DIR="${REPO_ROOT}/deploy/compose"
+ENV_FILE="${COMPOSE_DIR}/.env"
+HELPER="${SCRIPT_DIR}/_rotate-wallet.mts"
+
+COMPOSE_PROFILE="${COMPOSE_PROFILE:-local-node}"
+HEALTH_URL="${FAUCET_HEALTH_URL:-}"
+
+trap 'rc=$?; if [[ $rc -ne 0 ]]; then printf >&2 "\n[rotate-secrets] failed at line %s (exit %s)\n" "$LINENO" "$rc"; fi' ERR
+
+err() { printf >&2 "[rotate-secrets] error: %s\n" "$*"; }
+log() { printf >&2 "[rotate-secrets] %s\n" "$*"; }
+tty_print() { printf "%s\n" "$*" > /dev/tty; }
+
+usage() {
+  sed -n '3,/^# Exit codes/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+read_env_value() {
+  # Returns the value of $1 from $ENV_FILE, or empty if absent.
+  awk -F= -v key="$1" '$1 == key { sub(/^[^=]+=/, ""); print; exit }' "${ENV_FILE}"
+}
+
+write_env_value() {
+  # Replace (or insert) `KEY=VALUE` in $ENV_FILE atomically. Uses a tmp
+  # file + rename so a SIGINT mid-rewrite doesn't leave the file partial.
+  local key="$1" val="$2" tmp
+  tmp="$(mktemp "${ENV_FILE}.XXXXXX")"
+  if grep -q "^${key}=" "${ENV_FILE}"; then
+    awk -v key="${key}" -v val="${val}" \
+      'BEGIN{re="^"key"="} $0 ~ re { print key"="val; next } { print }' \
+      "${ENV_FILE}" > "${tmp}"
+  else
+    cat "${ENV_FILE}" > "${tmp}"
+    printf "%s=%s\n" "${key}" "${val}" >> "${tmp}"
+  fi
+  chmod 600 "${tmp}"
+  mv "${tmp}" "${ENV_FILE}"
+}
+
+rand_password() {
+  # 24 bytes of entropy → ~32 base64 chars; strip URL/shell-trouble chars.
+  openssl rand -base64 24 | tr -d '/+='
+}
+
+rand_hex32() {
+  # 32 bytes hex = 64-char string; satisfies the ≥16-char hashcash check.
+  openssl rand -hex 32
+}
+
+compose() {
+  ( cd "${COMPOSE_DIR}" \
+    && docker compose \
+      -f docker-compose.yml \
+      -f docker-compose.override.yml \
+      -f fcaptcha.yml \
+      --profile "${COMPOSE_PROFILE}" \
+      "$@" )
+}
+
+restart_faucet() {
+  log "recreating faucet container…"
+  compose up -d faucet >/dev/null
+}
+
+wait_for_health() {
+  if [[ -z "${HEALTH_URL}" ]]; then
+    log "FAUCET_HEALTH_URL not set; skipping post-restart health probe"
+    return 0
+  fi
+  log "polling ${HEALTH_URL} for up to 60s…"
+  local deadline=$(( $(date +%s) + 60 ))
+  while (( $(date +%s) < deadline )); do
+    if curl -fsS -o /dev/null --max-time 5 "${HEALTH_URL}"; then
+      log "faucet is healthy"
+      return 0
+    fi
+    sleep 2
+  done
+  err "faucet did not report healthy within 60s"
+  return 1
+}
+
+confirm() {
+  # confirm "<prompt>" — reads y/N from /dev/tty. Defaults to N.
+  local prompt="$1" reply
+  printf "%s [y/N] " "${prompt}" > /dev/tty
+  read -r reply < /dev/tty || reply=""
+  case "${reply}" in
+    [Yy]|[Yy][Ee][Ss]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Pre-flight
+# ────────────────────────────────────────────────────────────────────────────
+
+mode="simple"
+case "${1:-}" in
+  ""|--simple)       mode="simple" ;;
+  --with-wallet)     mode="with-wallet" ;;
+  -h|--help|help)    usage; exit 0 ;;
+  *) err "unknown flag: $1"; usage >&2; exit 2 ;;
+esac
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  err "${ENV_FILE} not found — are you running from the repo root on the deploy host?"
+  exit 1
+fi
+if ! command -v openssl >/dev/null 2>&1; then
+  err "openssl not on PATH; install it first"
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  err "docker not on PATH"
+  exit 1
+fi
+
+log "mode: ${mode}; .env: ${ENV_FILE}"
+
+# Snapshot the current .env. .env permissions are preserved.
+backup="${ENV_FILE}.backup-$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "${ENV_FILE}" "${backup}"
+chmod 600 "${backup}"
+log "backed up .env → ${backup}"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Generate fresh simple-rotation values
+# ────────────────────────────────────────────────────────────────────────────
+
+new_admin_password="$(rand_password)"
+new_hashcash_secret="$(rand_hex32)"
+new_key_passphrase="$(rand_password)"
+new_wallet_passphrase="$(rand_password)"
+
+tty_print ""
+tty_print "==[ NEW SECRETS — save these in your password manager NOW ]=="
+tty_print "FAUCET_ADMIN_PASSWORD     = ${new_admin_password}"
+tty_print "FAUCET_HASHCASH_SECRET    = ${new_hashcash_secret}"
+tty_print "FAUCET_KEY_PASSPHRASE     = ${new_key_passphrase}"
+tty_print "FAUCET_WALLET_PASSPHRASE  = ${new_wallet_passphrase}"
+tty_print ""
+
+if ! confirm "Saved them? Continue and rewrite .env?"; then
+  err "aborted before writing .env; backup left at ${backup}"
+  exit 1
+fi
+
+write_env_value "FAUCET_ADMIN_PASSWORD"    "${new_admin_password}"
+write_env_value "FAUCET_HASHCASH_SECRET"   "${new_hashcash_secret}"
+write_env_value "FAUCET_KEY_PASSPHRASE"    "${new_key_passphrase}"
+write_env_value "FAUCET_WALLET_PASSPHRASE" "${new_wallet_passphrase}"
+log ".env updated (4 simple values)"
+
+# ────────────────────────────────────────────────────────────────────────────
+# --with-wallet path
+# ────────────────────────────────────────────────────────────────────────────
+
+if [[ "${mode}" == "with-wallet" ]]; then
+  log "wallet rotation requested; generating fresh keypair…"
+  if [[ ! -f "${HELPER}" ]]; then
+    err "helper missing: ${HELPER}"
+    exit 1
+  fi
+
+  # The helper emits two `KEY=VALUE` lines on stdout. We capture into shell
+  # vars without ever putting the private key in a file or argv.
+  pushd "${REPO_ROOT}" >/dev/null
+  helper_out="$(pnpm exec tsx "${HELPER}" generate)"
+  popd >/dev/null
+
+  new_wallet_address="$(printf "%s" "${helper_out}" | awk -F= '$1=="NEW_FAUCET_WALLET_ADDRESS"{ sub(/^[^=]+=/,""); print }')"
+  new_private_key="$(printf "%s" "${helper_out}" | awk -F= '$1=="NEW_FAUCET_PRIVATE_KEY"{ sub(/^[^=]+=/,""); print }')"
+  if [[ -z "${new_wallet_address}" || -z "${new_private_key}" ]]; then
+    err "helper did not emit a valid keypair"
+    exit 1
+  fi
+
+  tty_print ""
+  tty_print "==[ NEW WALLET — record BOTH lines in your password manager ]=="
+  tty_print "FAUCET_WALLET_ADDRESS = ${new_wallet_address}"
+  tty_print "FAUCET_PRIVATE_KEY    = ${new_private_key}"
+  tty_print ""
+  if ! confirm "Saved them? Continue with the on-chain balance sweep?"; then
+    err "aborted before sweep; .env reverted to keep the OLD wallet active"
+    cp -a "${backup}" "${ENV_FILE}"
+    exit 1
+  fi
+
+  old_wallet_address="$(read_env_value "FAUCET_WALLET_ADDRESS")"
+  rpc_url="$(read_env_value "FAUCET_RPC_URL")"
+  rpc_user="$(read_env_value "FAUCET_RPC_USERNAME" || true)"
+  rpc_pass="$(read_env_value "FAUCET_RPC_PASSWORD" || true)"
+  if [[ -z "${old_wallet_address}" || -z "${rpc_url}" ]]; then
+    err "FAUCET_WALLET_ADDRESS or FAUCET_RPC_URL missing in .env"
+    exit 1
+  fi
+
+  log "sweeping balance from ${old_wallet_address} → ${new_wallet_address} via ${rpc_url}"
+  pushd "${REPO_ROOT}" >/dev/null
+  FAUCET_RPC_URL="${rpc_url}" \
+  FAUCET_RPC_USERNAME="${rpc_user}" \
+  FAUCET_RPC_PASSWORD="${rpc_pass}" \
+  OLD_FAUCET_WALLET_ADDRESS="${old_wallet_address}" \
+  NEW_FAUCET_WALLET_ADDRESS="${new_wallet_address}" \
+    pnpm exec tsx "${HELPER}" sweep
+  popd >/dev/null
+
+  write_env_value "FAUCET_WALLET_ADDRESS" "${new_wallet_address}"
+  write_env_value "FAUCET_PRIVATE_KEY"    "${new_private_key}"
+  log ".env updated (wallet keypair)"
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Restart and verify
+# ────────────────────────────────────────────────────────────────────────────
+
+restart_faucet
+wait_for_health
+
+log "done. backup retained at ${backup}; delete it once you've confirmed the new credentials work."


### PR DESCRIPTION
## Summary

Adds a single operator script for rotating the faucet's sensitive secrets on a docker-compose deploy. Two modes:

- `./scripts/rotate-secrets.sh` (default `--simple`) — rotate the four passphrase/password secrets only.
- `./scripts/rotate-secrets.sh --with-wallet` — also generate a fresh Nimiq Albatross keypair, sweep the on-chain balance from OLD → NEW via the same `sendBasicTransaction` RPC contract `NimiqRpcDriver` already speaks, and recreate the faucet container.

## Why
Earlier several operator secrets briefly ended up in shell scrollback. Manual rotation is fiddly — this makes it one command.

## Files
- new `scripts/rotate-secrets.sh` — bash entrypoint. Backs up `.env`, prints new values on `/dev/tty` only, requires confirmation.
- new `scripts/_rotate-wallet.mts` — Node helper using `@nimiq/core` `KeyPair.generate()` and Node 22 built-in `fetch` for the RPC sweep.
- updated `docs/deployment-production.md` to point at the script.

## Test plan
- [x] `bash -n scripts/rotate-secrets.sh`
- [x] `pnpm exec tsx scripts/_rotate-wallet.mts generate`
- [ ] Manual end-to-end on a throwaway compose stack against testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)