### PR TITLE
fix(hardening): set COOP same-origin-allow-popups so Hub chooseAddress works

### DIFF
--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -224,6 +224,15 @@ export async function applyHardening(app: FastifyInstance, config: ServerConfig)
   await app.register(helmet, {
     contentSecurityPolicy: cspWithUpgrade,
     crossOriginEmbedderPolicy: false,
+    // The claim UI opens the Nimiq Hub (hub.nimiq.com / hub.nimiq-testnet.com)
+    // in a popup and talks to it via window.opener.postMessage. Helmet's
+    // default 'same-origin' severs that opener relationship for cross-origin
+    // popups, so the Hub never receives the chooseAddress request, hits its
+    // RPC client timeout, and renders 'Invalid request'. 'same-origin-allow-popups'
+    // keeps cross-origin attackers out (they still can't reach into us via
+    // window.opener) while preserving the bidirectional channel for popups
+    // we explicitly open.
+    crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     hsts: { maxAge: 15_552_000, includeSubDomains: true },
   });


### PR DESCRIPTION
## Summary

- The claim UI opens the Nimiq Hub (`hub.nimiq.com` / `hub.nimiq-testnet.com`) in a popup and exchanges `chooseAddress` with it via `window.opener.postMessage`. `@fastify/helmet` defaults `Cross-Origin-Opener-Policy: same-origin`, which severs that opener relationship for cross-origin popups. The Hub popup's `RpcServer` waits for the parent's ping, never gets one, hits its 1-second client-timeout, and renders `RequestError.vue` — surfaced to the user as **"Invalid request"** from the Hub.
- Switch the COOP directive to `same-origin-allow-popups`: cross-origin attackers still can't reach into the faucet's window via `window.opener`, but popups the faucet explicitly opens (the Hub) keep their bidirectional postMessage channel.

## Changes

- `apps/server/src/hardening.ts`: pass `crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' }` to the `helmet` plugin registration. No other directives changed.

## Reproduction

Against any TLS-fronted deployment of the faucet on `main`:

```
curl -sI https://your-faucet.example/ | grep -i opener
# cross-origin-opener-policy: same-origin    ← buggy
```

Click **Connect** in the claim UI → Hub popup → "Invalid request".

Headless Chromium probe (Playwright) against the **patched** build, picking up the full successful sequence:

```
Connect click
  -> window.open(https://hub.nimiq-testnet.com/)
  -> RpcClient REQUEST ping (id=1)
  -> RpcServer REPLY pong → "RpcClient: Connection established"
  -> RpcClient REQUEST choose-address (id=…)
  -> RpcServer ACCEPT → /choose-address?rpcId=…
  -> /onboard?rpcId=…  (when the test profile has no Nimiq account)
```

No `pageerror`, no `requestfailed`, no "Invalid request".

## Why not just disable COOP

`crossOriginOpenerPolicy: false` would remove the header and weaken cross-origin isolation against the [Spectre-class side-channel attacks](https://web.dev/articles/coop-coep) COOP defends against. `same-origin-allow-popups` is the documented HTML-spec value for this exact case (host page wants COOP enforcement, but explicitly opens trusted cross-origin popups).

## Note on local validation

Browsers ignore COOP on plain-HTTP origins ("untrustworthy origin"), so the local `docker compose` stack at `http://localhost:8080` reaches the Hub regardless of which value is set. The bug only manifests on TLS-fronted deployments. Verified end-to-end against a TLS reverse proxy in front of the patched image.

## Test plan

- [x] `pnpm --filter @faucet/server build` — typecheck clean
- [x] Manual: rebuilt image, `curl -sI` confirms `cross-origin-opener-policy: same-origin-allow-popups`
- [x] Manual: headless Chromium probe drives Connect → Hub popup → choose-address handshake → no errors
- [ ] CI: build + typecheck + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)