### PR TITLE
fix(hardening): COOP=same-origin-allow-popups so Hub popups can postMessage back

### DIFF
--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -224,6 +224,15 @@ export async function applyHardening(app: FastifyInstance, config: ServerConfig)
   await app.register(helmet, {
     contentSecurityPolicy: cspWithUpgrade,
     crossOriginEmbedderPolicy: false,
+    // helmet's default `same-origin` severs `window.opener` for popups
+    // opened from the page, which breaks any cross-origin popup-based
+    // login flow that needs to postMessage back to its opener — the
+    // Nimiq Hub (`hub.nimiq.com` / `hub.nimiq-testnet.com`) being the
+    // motivating case here. `same-origin-allow-popups` keeps the
+    // anti-side-channel isolation for the page itself but lets popups
+    // communicate with their opener; this is exactly the policy spec'd
+    // for sites that act as identity-provider clients.
+    crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     hsts: { maxAge: 15_552_000, includeSubDomains: true },
   });


### PR DESCRIPTION
## Summary
A user reported the wallet-connect flow on the public deploy redirected to \`https://hub.nimiq-testnet.com/request-error\` with **"Invalid request"** the instant they clicked Connect — never reached the address picker.

## Cause
helmet 8 defaults \`Cross-Origin-Opener-Policy: same-origin\`, which severs \`window.opener\` for popups the page opens. The Nimiq Hub popup loaded but couldn't postMessage its result back to the opener — Hub treats that as a malformed handshake and bails to \`/request-error\`.

## Fix
Opt into \`same-origin-allow-popups\` in [\`apps/server/src/hardening.ts\`](apps/server/src/hardening.ts). The page itself stays isolated against cross-origin side-channel attacks (helmet's default goal), but popups the page opens can communicate with their opener again. Spec-defined policy for IdP-client sites (Nimiq Hub, OAuth popup flows). No CSP change needed.

## Test plan
- [x] \`pnpm --filter @faucet/server build\` — typecheck clean
- [ ] Manual on the deploy: open faucet in incognito, click Connect, address picker should now load (and \`Connect Wallet\` finishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)