### PR TITLE
fix(hardening): COOP=same-origin-allow-popups + ignore unreachable MCP-SDK advisories (closes #197 #198)

### DIFF
--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -224,6 +224,15 @@ export async function applyHardening(app: FastifyInstance, config: ServerConfig)
   await app.register(helmet, {
     contentSecurityPolicy: cspWithUpgrade,
     crossOriginEmbedderPolicy: false,
+    // The claim UI opens the Nimiq Hub (hub.nimiq.com / hub.nimiq-testnet.com)
+    // in a popup and talks to it via window.opener.postMessage. Helmet's
+    // default 'same-origin' severs that opener relationship for cross-origin
+    // popups, so the Hub never receives the chooseAddress request, hits its
+    // RPC client timeout, and renders 'Invalid request'. 'same-origin-allow-popups'
+    // keeps cross-origin attackers out (they still can't reach into us via
+    // window.opener) while preserving the bidirectional channel for popups
+    // we explicitly open.
+    crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     hsts: { maxAge: 15_552_000, includeSubDomains: true },
   });

--- a/package.json
+++ b/package.json
@@ -65,10 +65,15 @@
       "//2": "Re-evaluate quarterly: if a new esbuild/vite advisory crosses into runtime reachability, drop the ignore and accept the vitest churn.",
       "//3": "GHSA-w5hq-g745-h8pq (uuid <14.0.0 buffer bounds check) is reachable only when calling uuid.v3/v5/v6 with a `buf` argument. The path is `apps/nimiq-pow-ui > @nimiq/hub-api > @opengsn/common > web3-eth (>>) ethers@4.0.0-beta.3 > uuid@2.0.1` — OpenGSN/USDC code that this app's chooseAddress-only Hub flow never executes. Forcing uuid >=14 (ESM-only) breaks the upstream OpenGSN install graph. Ignore until @nimiq/hub-api drops the OpenGSN bundle for non-USDC consumers.",
       "//4": "Re-evaluate when @nimiq/hub-api ships a slim build without @opengsn or when @opengsn updates its web3 chain.",
+      "//5": "GHSA-v2v4-37r5-5v8g (ip-address <=10.1.0 XSS in Address6 HTML-emitting methods), GHSA-9vqf-7f2p-gf9v (hono <4.12.16 bodyLimit bypass for chunked / unknown-length requests) and GHSA-69xw-7hcm-h432 (hono/jsx unvalidated tag-name HTML injection) all reach us only via @modelcontextprotocol/sdk@1.29.0's hono-bound HTTP transport (and its express-rate-limit / @hono/node-server transitives). The faucet's MCP integration imports ONLY `StreamableHTTPServerTransport` (apps/server/src/mcp/index.ts:27); the hono transport, JSX renderer, and Address6 HTML methods are never executed. Forcing patched versions before MCP SDK ships an update would require workspace-wide overrides that the lockfile resolver can't satisfy without churn. Drop these ignores once @modelcontextprotocol/sdk publishes >1.29.0 with patched transitives.",
+      "//6": "Re-evaluate weekly while these are open (advisories were filed 2026-05): once the MCP SDK bumps, remove these three GHSAs and run `pnpm install` to refresh the lockfile.",
       "ignoreGhsas": [
         "GHSA-67mh-4wv8-2f99",
         "GHSA-4w7w-66w2-5vf9",
-        "GHSA-w5hq-g745-h8pq"
+        "GHSA-w5hq-g745-h8pq",
+        "GHSA-v2v4-37r5-5v8g",
+        "GHSA-9vqf-7f2p-gf9v",
+        "GHSA-69xw-7hcm-h432"
       ]
     }
   }


### PR DESCRIPTION
## Why both in one PR

Each was blocking the other:

- **COOP fix** (the Hub Connect Wallet bug): one-line change to `apps/server/src/hardening.ts`. Identical to the diff in #197 (NimiqToolbox) and #198 (mine, since closed).
- **Audit ignore for three new MCP-SDK transitive advisories**: without this, every PR (including #197) fails `pnpm audit --audit-level=moderate` and CI blocks the merge.

## COOP fix

A user on the public deploy reported that clicking Connect Wallet redirected to \`https://hub.nimiq-testnet.com/request-error\` with **"Invalid request"** the moment the popup opened.

Cause: helmet 8 defaults \`Cross-Origin-Opener-Policy: same-origin\`, which severs \`window.opener\` for popups the page opens. Hub-api's RpcClient never receives the parent's ping, hits its 1-second client timeout, and renders \`RequestError.vue\`.

Switch to \`same-origin-allow-popups\` — same-origin attackers still can't reach into us via \`window.opener\`, but popups we explicitly open keep their postMessage channel. This is the spec-defined COOP value for IdP-client sites (Hub, OAuth popup flows).

## Audit ignores

Three GHSAs were filed against \`@modelcontextprotocol/sdk@1.29.0\`'s transitive deps. All flow through the SDK's hono-bound HTTP transport (and its \`express-rate-limit\` / \`@hono/node-server\` transitives). The faucet's MCP integration imports **only** \`StreamableHTTPServerTransport\` ([apps/server/src/mcp/index.ts:27](apps/server/src/mcp/index.ts#L27)) — the hono transport, JSX renderer, and Address6 HTML methods are never executed.

| GHSA | Package | Path | Reachable in faucet? |
|---|---|---|---|
| [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) | ip-address ≤10.1.0 | mcp-sdk → express-rate-limit → ip-address | No (hono transport unused) |
| [GHSA-9vqf-7f2p-gf9v](https://github.com/advisories/GHSA-9vqf-7f2p-gf9v) | hono <4.12.16 | mcp-sdk → @hono/node-server → hono | No |
| [GHSA-69xw-7hcm-h432](https://github.com/advisories/GHSA-69xw-7hcm-h432) | hono/jsx <4.12.16 | mcp-sdk → hono | No (JSX never rendered) |

Pattern matches the existing \`pnpm.auditConfig.ignoreGhsas\` block (esbuild/vite/uuid) — full justification + revisit cadence in the package.json comment.

## Closes
- #197 (NimiqToolbox) — covered by the COOP change in this PR; can be closed once this lands.
- #198 (already closed by me as duplicate of #197).

## Test plan
- [x] \`pnpm --filter @faucet/server build\` — typecheck clean
- [x] \`pnpm audit --audit-level=moderate\` — exits 0 locally (3 remaining advisories are \`low\` and below the threshold)
- [ ] CI: full build + audit pipeline
- [ ] Manual on the public deploy: \`curl -sI / | grep cross-origin-opener-policy\` returns \`same-origin-allow-popups\`, click Connect → Hub address picker (or Hub onboarding for new accounts) instead of \`/request-error\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)