### PR TITLE
fix(deps): bump @nimiq/core 2.4.0 → 2.5.0 + drop #119 workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,23 +119,10 @@ jobs:
               docker stop smoke >/dev/null
               exit 0
             fi
-            # Fail fast if the container is dead. Issue #119: the
-            # `@nimiq/core` WASM client panics intermittently with
-            # `'time not implemented on this platform'` shortly after
-            # the testnet handshake (~30% of boots). That's an upstream
-            # bug, not a regression in this repo, so when we see exactly
-            # that panic in the logs we downgrade to a CI warning instead
-            # of failing the build. Other crashes (missing native bindings,
-            # DB init failure) still fail hard — those ARE our problem.
+            # Fail fast if the container is dead.
             if ! docker ps --format '{{.Names}}' | grep -q '^smoke$'; then
-              logs="$(docker logs smoke 2>&1 || true)"
-              if printf '%s' "$logs" | grep -q "time not implemented on this platform"; then
-                echo "::warning::WASM signer hit the upstream #119 panic during testnet handshake. Tracking issue: https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119"
-                printf '%s\n' "$logs" | tail -40
-                exit 0
-              fi
               echo "::error::container exited early — this is the regression we care about"
-              printf '%s\n' "$logs"
+              docker logs smoke 2>&1 || true
               exit 1
             fi
             sleep 2

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ docker run -d --name nimiq-faucet -p 8080:8080 -v faucet-data:/data \
 
 Boots a self-contained WASM faucet. The WASM client reaches TestAlbatross consensus within ~15 seconds (fixed in v1.1.4); `/healthz` and `/admin` are reachable immediately (v1.1.0). For a full end-to-end demo with a local RPC node, use the compose path above.
 
-> ⚠️ **Known issue (#119) — WASM signer panics intermittently.** `@nimiq/core` 2.4.0 panics with `'time not implemented on this platform'` ~30% of the time during the testnet handshake. The faucet HTTP server stays up in the surviving 70%, but the signer is unusable until the panic is investigated upstream. **For anything beyond a smoke test, use the RPC driver:** `FAUCET_SIGNER_DRIVER=rpc` with the `local-node` profile in the compose path. Track the upstream investigation at [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119); a draft report ready to file against `nimiq/core-rs-albatross` lives in [`docs/quality/wasm-time-panic-upstream-report.md`](docs/quality/wasm-time-panic-upstream-report.md).
-
 ## Integrate into your app
 
 | Framework     | Package                           | One-liner                                                  |

--- a/apps/nimiq-pow-ui/src/components/StatusBar.vue
+++ b/apps/nimiq-pow-ui/src/components/StatusBar.vue
@@ -38,7 +38,7 @@ const tone = computed<'idle' | 'busy' | 'good' | 'bad'>(() => {
     <span v-if="txId" class="tx">
       tx
       <a
-        :href="`https://nimiq-testnet.observer/transactions/${txId}`"
+        :href="`https://test.nimiq.watch/#${txId}`"
         target="_blank"
         rel="noopener"
       >{{ txId.slice(0, 16) }}…</a>

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -31,22 +31,12 @@ transactions; you pick *where the private key lives*.
 
 | Mode | `FAUCET_SIGNER_DRIVER` | Key location | When to use |
 |------|------------------------|--------------|-------------|
-| RPC  | `rpc`  | In a separate `core-rs-albatross` node with the wallet pre-unlocked | **Recommended for production.** Centralises key custody; the faucet process never holds the key. |
-| WASM | `wasm` | In the faucet process, from `FAUCET_PRIVATE_KEY` env var (and encrypted to disk at `/data/faucet.key` via `FAUCET_KEY_PASSPHRASE`) | Simplest, smoke tests / local trials only — see the WASM panic note below. |
+| WASM | `wasm` | In the faucet process, from `FAUCET_PRIVATE_KEY` env var (and encrypted to disk at `/data/faucet.key` via `FAUCET_KEY_PASSPHRASE`) | Default. Simplest. Faucet connects directly to testnet/mainnet seed peers. |
+| RPC | `rpc` | In a separate `core-rs-albatross` node with the wallet pre-unlocked | You already run a Nimiq node and want to centralise key custody. |
 
 **For either mode**, the address is `FAUCET_WALLET_ADDRESS`. The faucet
 will refuse to start if this is unset or if it can't produce the same
 address from the supplied key.
-
-> ⚠️ **WASM panic (#119).** `@nimiq/core` 2.4.0's WASM client panics
-> with `'time not implemented on this platform'` ~30% of the time
-> during the testnet handshake. The faucet HTTP server stays up in the
-> surviving 70%, but the signer is unusable until the panic is
-> investigated upstream. We recommend `FAUCET_SIGNER_DRIVER=rpc` for
-> production deployments and the WASM driver only for local smoke
-> tests. See [issue #119](https://github.com/PanoramicRum/nimiq-simple-faucet/issues/119)
-> and [`docs/quality/wasm-time-panic-upstream-report.md`](./quality/wasm-time-panic-upstream-report.md)
-> — a draft upstream report ready to file against `nimiq/core-rs-albatross`.
 
 > **RPC security note:** When using `FAUCET_SIGNER_DRIVER=rpc`, the faucet
 > sends the private key and wallet passphrase to the Nimiq node via

--- a/examples/mini-app-claim-react/src/App.tsx
+++ b/examples/mini-app-claim-react/src/App.tsx
@@ -3,7 +3,7 @@ import { useMiniAppFaucet } from './hooks/useMiniAppFaucet';
 import { FcaptchaWidgetView } from './components/FcaptchaWidget';
 
 const FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
-const EXPLORER_BASE = import.meta.env.VITE_EXPLORER_URL ?? 'https://nimiq-testnet.observer/#tx/';
+const EXPLORER_BASE = import.meta.env.VITE_EXPLORER_URL ?? 'https://test.nimiq.watch/#';
 
 export function App() {
   const { state, captchaPrompt, claim, reset, canClaim } = useMiniAppFaucet(FAUCET_URL);

--- a/examples/mini-app-claim-vue/src/App.vue
+++ b/examples/mini-app-claim-vue/src/App.vue
@@ -5,7 +5,7 @@ import { useMiniAppFaucet } from './composables/useMiniAppFaucet';
 import FcaptchaWidget from './components/FcaptchaWidget.vue';
 
 const faucetUrl = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
-const explorerBase = import.meta.env.VITE_EXPLORER_URL ?? 'https://nimiq-testnet.observer/#tx/';
+const explorerBase = import.meta.env.VITE_EXPLORER_URL ?? 'https://test.nimiq.watch/#';
 
 const { state, captchaPrompt, claim, reset, canClaim } = useMiniAppFaucet(faucetUrl);
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@faucet/abuse-hashcash": "workspace:*",
-    "@nimiq/core": "^2.4.0",
+    "@nimiq/core": "^2.5.0",
     "@types/node": "^25.6.0",
     "prettier": "^3.8.3",
     "tsx": "^4.19.0",

--- a/packages/driver-nimiq-wasm/package.json
+++ b/packages/driver-nimiq-wasm/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@faucet/core": "workspace:*",
-    "@nimiq/core": "^2.4.0"
+    "@nimiq/core": "^2.5.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: workspace:*
         version: link:packages/abuse-hashcash
       '@nimiq/core':
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^2.5.0
+        version: 2.5.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -614,8 +614,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@nimiq/core':
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^2.5.0
+        version: 2.5.0
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -1926,8 +1926,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@nimiq/core@2.4.0':
-    resolution: {integrity: sha512-tkcvQTTy0tbOLEBQDOxDAcCv7KRS+riuEcd4gWulwyRU2rLziiTKOXD1WNszikHFKQ6S3zmbq1RQpJGTjQVBIg==}
+  '@nimiq/core@2.5.0':
+    resolution: {integrity: sha512-8kqIBwatzvyXyCcfn1hI8BlLKaH3adx9c7RUJNoQl1i7uuZDyj8chs4xwnrmzbYMQlBVnHV2SVd8eo596VAMUQ==}
 
   '@nimiq/fastspot-api@1.10.3':
     resolution: {integrity: sha512-CUkIAcF7R3OlN45idB+yC9Wnuz2YXTPx25xYswCdmbMGu/EGZFNnGHLIe6HkbHd8Eh+uBrwqBmLZGm8jyQ9+6A==}
@@ -7023,7 +7023,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@nimiq/core@2.4.0':
+  '@nimiq/core@2.5.0':
     dependencies:
       comlink: 4.4.2
       websocket: 1.0.35
@@ -7034,7 +7034,7 @@ snapshots:
 
   '@nimiq/hub-api@1.13.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@nimiq/core': 2.4.0
+      '@nimiq/core': 2.5.0
       '@nimiq/fastspot-api': 1.10.3
       '@nimiq/rpc': 0.4.1
       '@nimiq/utils': 0.5.2


### PR DESCRIPTION
## Summary

`@nimiq/core@2.5.0` ships upstream PR [nimiq/core-rs-albatross#3729](https://github.com/nimiq/core-rs-albatross/pull/3729) ("OffsetTime: use `instant::SystemTime` to avoid wasm32 panic"), which fixes the intermittent `'time not implemented on this platform'` panic that affected ~30% of WASM-driver boots during the testnet handshake. This PR bumps the dep and drops every in-repo workaround.

Closes #119.

## Changes

- **`@nimiq/core` 2.4.0 → 2.5.0** in `package.json` + `packages/driver-nimiq-wasm/package.json`; `pnpm-lock.yaml` refreshed. Verified: 2.5.0 gitHead (`a3df2732`) is 39 commits ahead of the fix merge commit (`9789c532`), 0 behind.
- **CI smoke job** (`.github/workflows/ci.yml`): removed the `'time not implemented on this platform'` string filter that was downgrading the panic to a `::warning::`. Any future occurrence is now a hard CI failure again.
- **README.md**: dropped the `⚠️ Known issue (#119)` callout after the smoke-test snippet.
- **docs/deployment-production.md**: dropped the `⚠️ WASM panic (#119)` block; restored the signer-driver table to its pre-#119 wording (WASM = default/simplest, RPC = "you already run a Nimiq node and want to centralise key custody").
- **Broken explorer URL fix**: replaced `https://nimiq-testnet.observer/` (host does not resolve) with the project's canonical `https://test.nimiq.watch/#<txid>` (already used by `apps/claim-ui/src/lib/explorer.ts`) in:
  - `apps/nimiq-pow-ui/src/components/StatusBar.vue`
  - `examples/mini-app-claim-vue/src/App.vue` (the `VITE_EXPLORER_URL` default)
  - `examples/mini-app-claim-react/src/App.tsx` (same)

The `audits/INTEGRATION_NOTES.md`, `audits/PR-113-rebase-handoff.md`, and three `docs/quality/wasm-time-panic-*.md` files are intentionally untouched — they are point-in-time records of the incident.

## Test plan

- [x] `pnpm build` passes (via `pnpm pre-merge` — 58/58 turbo tasks successful locally)
- [x] `pnpm typecheck` passes (same)
- [x] `pnpm test` (unit) passes (same)
- [ ] `pnpm test:e2e` passes — n/a (no UI behaviour changed beyond a static URL default)
- [ ] Manual smoke against a local container — see "CI smoke job" below; with the panic filter removed, a clean smoke run on this PR is the in-CI confirmation that 2.5.0 fixes the panic.

## Security checklist

- [x] No secrets in diff
- [x] New inputs validated at boundary — n/a (no new inputs)
- [x] No stack traces in user-facing errors — n/a
- [x] Admin mutations go through `/admin/*` — n/a
- [x] New env vars added to `.env.example` — n/a (no new env vars)
- [x] Timing-safe comparisons where user input meets secrets — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)