### PR TITLE
fix(deps): patch fast-uri + hono via overrides, bump nextjs example (5 new 2026-05-11 advisories)

### DIFF
--- a/examples/nextjs-claim-page/package.json
+++ b/examples/nextjs-claim-page/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@nimiq-faucet/react": "workspace:*",
     "@nimiq-faucet/sdk": "workspace:*",
-    "next": "^16.2.4",
+    "next": "^16.2.5",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   ],
   "pnpm": {
     "overrides": {
-      "hono@<4.12.14": ">=4.12.14",
+      "hono@<4.12.18": ">=4.12.18",
+      "fast-uri@<3.1.2": ">=3.1.2",
       "postcss@<8.5.10": ">=8.5.10",
       "happy-dom@<20.8.9": ">=20.8.9",
       "elliptic@<6.6.1": ">=6.6.1",
@@ -65,15 +66,13 @@
       "//2": "Re-evaluate quarterly: if a new esbuild/vite advisory crosses into runtime reachability, drop the ignore and accept the vitest churn.",
       "//3": "GHSA-w5hq-g745-h8pq (uuid <14.0.0 buffer bounds check) is reachable only when calling uuid.v3/v5/v6 with a `buf` argument. The path is `apps/nimiq-pow-ui > @nimiq/hub-api > @opengsn/common > web3-eth (>>) ethers@4.0.0-beta.3 > uuid@2.0.1` — OpenGSN/USDC code that this app's chooseAddress-only Hub flow never executes. Forcing uuid >=14 (ESM-only) breaks the upstream OpenGSN install graph. Ignore until @nimiq/hub-api drops the OpenGSN bundle for non-USDC consumers.",
       "//4": "Re-evaluate when @nimiq/hub-api ships a slim build without @opengsn or when @opengsn updates its web3 chain.",
-      "//5": "GHSA-v2v4-37r5-5v8g (ip-address <=10.1.0 XSS in Address6 HTML-emitting methods), GHSA-9vqf-7f2p-gf9v (hono <4.12.16 bodyLimit bypass for chunked / unknown-length requests) and GHSA-69xw-7hcm-h432 (hono/jsx unvalidated tag-name HTML injection) all reach us only via @modelcontextprotocol/sdk@1.29.0's hono-bound HTTP transport (and its express-rate-limit / @hono/node-server transitives). The faucet's MCP integration imports ONLY `StreamableHTTPServerTransport` (apps/server/src/mcp/index.ts:27); the hono transport, JSX renderer, and Address6 HTML methods are never executed. Forcing patched versions before MCP SDK ships an update would require workspace-wide overrides that the lockfile resolver can't satisfy without churn. Drop these ignores once @modelcontextprotocol/sdk publishes >1.29.0 with patched transitives.",
-      "//6": "Re-evaluate weekly while these are open (advisories were filed 2026-05): once the MCP SDK bumps, remove these three GHSAs and run `pnpm install` to refresh the lockfile.",
+      "//5": "GHSA-v2v4-37r5-5v8g (ip-address <=10.1.0 XSS in Address6 HTML-emitting methods) reaches us only via @modelcontextprotocol/sdk@1.29.0's hono-bound HTTP transport transitives. The faucet's MCP integration imports ONLY `StreamableHTTPServerTransport` (apps/server/src/mcp/index.ts), so the Address6 HTML-emitting methods are never executed. ip-address has no patched release at the time of writing (vuln range `<=10.1.0`, lockfile pin 10.1.0). Drop once a patched ip-address ships and propagates through the transitive graph.",
+      "//6": "Hono advisories (GHSA-9vqf-7f2p-gf9v bodyLimit bypass, GHSA-69xw-7hcm-h432 hono/jsx tag-name HTML injection, GHSA-qp7p-654g-cw7p hono/jsx CSS injection, GHSA-p77w-8qqv-26rm cache Vary leakage) and the two fast-uri advisories (GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc) are all now resolved via `pnpm.overrides` above (hono >=4.12.18, fast-uri >=3.1.2) — patches that work cleanly through the MCP SDK / Fastify graphs without churn. No ignore entry needed.",
       "ignoreGhsas": [
         "GHSA-67mh-4wv8-2f99",
         "GHSA-4w7w-66w2-5vf9",
         "GHSA-w5hq-g745-h8pq",
-        "GHSA-v2v4-37r5-5v8g",
-        "GHSA-9vqf-7f2p-gf9v",
-        "GHSA-69xw-7hcm-h432"
+        "GHSA-v2v4-37r5-5v8g"
       ]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono@<4.12.14: '>=4.12.14'
+  hono@<4.12.18: '>=4.12.18'
+  fast-uri@<3.1.2: '>=3.1.2'
   postcss@<8.5.10: '>=8.5.10'
   happy-dom@<20.8.9: '>=20.8.9'
   elliptic@<6.6.1: '>=6.6.1'
@@ -422,8 +423,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk-ts
       next:
-        specifier: ^16.2.4
-        version: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^16.2.5
+        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1654,7 +1655,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.18'
 
   '@iconify-json/simple-icons@1.2.78':
     resolution: {integrity: sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==}
@@ -1874,53 +1875,53 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.4':
-    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.4':
-    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.4':
-    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
-    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.4':
-    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.4':
-    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.4':
-    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
-    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.4':
-    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2603,6 +2604,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -3672,8 +3674,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -3904,8 +3906,8 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -4479,8 +4481,8 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  next@16.2.4:
-    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6723,7 +6725,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/cookie@11.0.2':
     dependencies:
@@ -6789,9 +6791,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@hono/node-server@1.19.14(hono@4.12.15)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
 
   '@iconify-json/simple-icons@1.2.78':
     dependencies:
@@ -6968,7 +6970,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6978,7 +6980,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6995,30 +6997,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.4': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.4':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.4':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.4':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.4':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.4':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.4':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@nimiq/core@2.4.0':
@@ -7941,7 +7943,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8911,7 +8913,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -8919,7 +8921,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -9199,7 +9201,7 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  hono@4.12.15: {}
+  hono@4.12.18: {}
 
   hookable@5.5.3: {}
 
@@ -9824,9 +9826,9 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.2.4
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.21
       caniuse-lite: 1.0.30001790
@@ -9835,14 +9837,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5


### PR DESCRIPTION
## Summary

Five new advisories published 2026-05-11 broke CI on every open PR (including #200). This patches all five at the lockfile level via `pnpm.overrides` and a Next.js pin bump — no `ignoreGhsas` additions required. Mirrors the pattern from #199 but cleaner: we patch instead of ignore where the override applies cleanly.

## The new advisories

| GHSA / CVE | Severity | Package | Vector | Patched in |
|---|---|---|---|---|
| GHSA-q3j6-qgpj-74h6 / CVE-2026-6321 | HIGH | `fast-uri` | path traversal via percent-encoded dot segments | `>=3.1.1` |
| GHSA-v39h-62p7-jpjc / CVE-2026-6322 | HIGH | `fast-uri` | host confusion via percent-encoded authority delimiters | `>=3.1.2` |
| GHSA-qp7p-654g-cw7p | MODERATE | `hono` | CSS Declaration injection in JSX SSR | `>=4.12.18` |
| GHSA-p77w-8qqv-26rm | MODERATE | `hono` | Cache middleware ignores `Vary: Authorization`/`Cookie` | `>=4.12.18` |
| GHSA-8h8q-6873-q5fj | HIGH | `next` (example) | Server Components DoS | `>=16.2.5` |

Both `fast-uri` and `hono` reach this repo only transitively (`@modelcontextprotocol/sdk@1.29.0` plus, for fast-uri, Fastify's `@fastify/ajv-compiler` via ajv). The `next` advisory only affects [`examples/nextjs-claim-page/`](examples/nextjs-claim-page/).

## Changes

- **`package.json` — `pnpm.overrides`**:
  - Added `"fast-uri@<3.1.2": ">=3.1.2"` (lockfile now resolves `fast-uri@3.1.2`).
  - Bumped existing `"hono@<4.12.14": ">=4.12.14"` to `"hono@<4.12.18": ">=4.12.18"` (lockfile now resolves `hono@4.12.18`, up from `hono@4.12.15`).
- **`package.json` — `pnpm.auditConfig`**: the hono override moots two previously-ignored advisories (both patched at `4.12.16` per the GHSA registry; the override pushes to `4.12.18`):
  - Removed `GHSA-9vqf-7f2p-gf9v` (hono `<4.12.16` bodyLimit bypass).
  - Removed `GHSA-69xw-7hcm-h432` (hono/jsx `<4.12.16` tag-name HTML injection).
  - Rewrote the `//5` / `//6` rationale comments to reflect that hono+fast-uri are now overridden, not ignored. The ip-address ignore (`GHSA-v2v4-37r5-5v8g`) stays — no upstream patch exists yet.
- **`examples/nextjs-claim-page/package.json`**: `next` `^16.2.4` → `^16.2.5` (lockfile resolves to `16.2.6`).
- **`pnpm-lock.yaml`**: refreshed.

## Reachability notes (for the record)

`fast-uri` is reached via ajv only when ajv is asked to validate a string with `format: "uri"`, plus the MCP-SDK hono transport which we don't import (#199 rationale applies). The faucet's route handlers do their own Zod validation imperatively (the OpenAPI/`fastify-type-provider-zod` integration is generation-only — see [`apps/server/src/openapi/schemas.ts:5`](apps/server/src/openapi/schemas.ts#L5)), and a repo-wide grep finds **zero** `format: "uri"` or `format: "url"` declarations and **zero** Fastify route `schema:` blocks. So the vulnerable fast-uri code path is unreachable from request input regardless of version. We're still patching to keep the dep tree clean and CI green — defense in depth, not reachability mitigation.

`hono` reachability is identical to #199's analysis — MCP-SDK only.

## Test plan

- [x] `pnpm audit --audit-level=moderate` exits 0 locally (was 3 high + 2 unignored moderate).
- [x] `pnpm build` passes (via `pnpm pre-merge` — 58/58 turbo tasks successful locally).
- [x] `pnpm typecheck` passes (same).
- [x] `pnpm test` (unit) passes (same).
- [ ] Trivy image scan — should pass without a `.trivyignore` since `fast-uri@3.1.0` is no longer in the image; CI on this PR is the in-build verification.
- [ ] `pnpm test:e2e` — n/a (no app code changed; only `package.json` + lockfile).

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — n/a (no new inputs).
- [x] No stack traces in user-facing errors — n/a.
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — n/a.
- [x] Timing-safe comparisons — n/a.

## After this merges

PR #200 (`fix(deps): bump @nimiq/core 2.4.0 → 2.5.0 + drop #119 workarounds`) will be rebased onto main and its red CI should turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)