### PR TITLE
fix(nimiq-pow-ui): fill viewport with the world map on mobile

### DIFF
--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -343,6 +343,16 @@ function handleClaim() {
   .top-right {
     display: none; /* free up the small-screen real estate; status stays in the strip on mobile */
   }
+  /* The 12rem/24rem insets above are sized to clear the desktop top
+     chrome (brand pill + stats grid). On mobile the stats grid is
+     hidden and the pill is only ~3.5rem wide, so those insets just
+     shrink the map to a thin band (negative width below ~384px).
+     Let it fill the viewport — the brand pill keeps its own opaque
+     backdrop, so it stays legible on top. */
+  .map-bg {
+    left: 0;
+    width: 100vw;
+  }
   .strip-inner { flex-direction: column; align-items: stretch; }
 }
 </style>


### PR DESCRIPTION
## Summary

The decorative hex world map in the NimiqPoW theme renders as a tiny band on mobile because `.map-bg`'s `left: 12rem` / `width: calc(100vw - 24rem)` insets are sized for the desktop top chrome. On a 360px viewport the width math goes negative and the map collapses entirely; at 480px it's ~96px wide; at 720px it's ~336px in a viewport-tall container, so most of the background is empty.

## Changes

- `apps/nimiq-pow-ui/src/App.vue` — inside the existing `@media (max-width: 720px)` block, reset `.map-bg` to `left: 0; width: 100vw`. The stats grid is already hidden at that breakpoint and the brand pill is only ~3.5rem wide with its own opaque backdrop, so the desktop insets aren't needed there. 10-line CSS addition, no template or script changes.

## Test plan

- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui build` passes locally.
- [ ] `pnpm build` / `pnpm typecheck` / `pnpm test` — covered by CI.
- [ ] `pnpm test:e2e` — n/a (decorative element, no behaviour change).
- [ ] Manual: open the NimiqPoW theme (`FAUCET_CLAIM_UI_THEME=nimiq-pow`) at ≤720px width — the map should fill the background instead of shrinking to a band.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — n/a.
- [x] No stack traces in user-facing errors — n/a.
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — n/a.
- [x] Timing-safe comparisons — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)