### PR TITLE
fix(nimiq-pow-ui): gate wallet-connect behind the captcha

### DIFF
--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -32,11 +32,26 @@ function triggerConnect(): void {
   void connectWalletRef.value?.connect();
 }
 
-const canClaim = computed(() => {
-  if (!isAddressValid.value) return false;
+// Phases where the user can act rather than wait on a claim in flight.
+const isClaimablePhase = computed(
+  () =>
+    state.phase === 'idle' ||
+    state.phase === 'rejected' ||
+    state.phase === 'error' ||
+    state.phase === 'confirmed',
+);
+
+// The abuse-layer gate the Claim button enforces, minus the address
+// requirement: captcha solved (when a provider is configured) and not
+// mid-claim. The wallet-connect controls (the top-right pill and the
+// in-strip Connect button) are disabled until this passes, so a visitor
+// has to clear the captcha before the page will open the Nimiq Hub.
+const canConnect = computed(() => {
   if (needsCaptcha.value && !captchaToken.value) return false;
-  return state.phase === 'idle' || state.phase === 'rejected' || state.phase === 'error' || state.phase === 'confirmed';
+  return isClaimablePhase.value;
 });
+
+const canClaim = computed(() => canConnect.value && isAddressValid.value);
 
 const isPending = computed(() =>
   ['loading-config', 'solving-hashcash', 'submitting', 'broadcast'].includes(state.phase),
@@ -89,7 +104,7 @@ function handleClaim() {
         <span class="stat-value">{{ config?.network ? config.network.charAt(0).toUpperCase() + config.network.slice(1) : '—' }}</span>
       </div>
       <div class="stat status-stat">
-        <button type="button" class="connect-btn" @click="triggerConnect">
+        <button type="button" class="connect-btn" :disabled="!canConnect" @click="triggerConnect">
           Connect Wallet
         </button>
       </div>
@@ -130,6 +145,7 @@ function handleClaim() {
           ref="connectWalletRef"
           v-model="address"
           :disabled="isPending"
+          :connect-disabled="!canConnect"
           :network="config?.network"
           @connected-label="connectedLabel = $event"
         />
@@ -278,12 +294,13 @@ function handleClaim() {
   white-space: nowrap;
   transition: background-color 160ms ease, transform 120ms ease, box-shadow 200ms ease;
 }
-.connect-btn:hover {
+.connect-btn:not(:disabled):hover {
   background: rgba(246, 174, 45, 0.16);
   transform: translateY(-1px);
   box-shadow: 0 0 0 3px rgba(246, 174, 45, 0.10);
 }
-.connect-btn:active { transform: translateY(0); }
+.connect-btn:not(:disabled):active { transform: translateY(0); }
+.connect-btn:disabled { opacity: 0.55; cursor: not-allowed; }
 
 /* ── Middle: blank space, world map shows through ─────────── */
 .middle {

--- a/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
+++ b/apps/nimiq-pow-ui/src/components/ConnectWallet.vue
@@ -22,7 +22,13 @@ import { isValidNimiqAddress } from '../lib/nimiqAddress';
 
 const props = defineProps<{
   modelValue: string;
+  // Locks the whole row (paste input + Connect + Disconnect) while a
+  // claim is in flight.
   disabled?: boolean;
+  // Locks only the Hub "Connect" button — lets the parent keep the
+  // abuse-layer gate (captcha) in front of the wallet-connect flow
+  // without also freezing the paste input or the Disconnect link.
+  connectDisabled?: boolean;
   network: FaucetConfig['network'] | undefined;
 }>();
 const emit = defineEmits<{
@@ -83,7 +89,7 @@ defineExpose({ connect });
     <button
       type="button"
       class="hub-btn"
-      :disabled="disabled || isConnecting"
+      :disabled="disabled || connectDisabled || isConnecting"
       @click="connect"
     >
       <svg class="hub-logo" viewBox="0 0 64 64" aria-hidden="true">


### PR DESCRIPTION
## Summary

In the NimiqPoW theme the "Connect Wallet" pill (top-right) and the "Connect" button in the address strip were always enabled, so a visitor could open the Nimiq Hub before clearing any abuse layer. This disables both until the abuse-layer gate the Claim button enforces is satisfied — captcha solved (when a provider is configured) and not mid-claim — but **without** the address requirement, since connecting is one of the two ways the user supplies their address (the paste input is the other and is intentionally left ungated).

## Changes

- `apps/nimiq-pow-ui/src/App.vue`
  - extracted `isClaimablePhase` (`idle` / `rejected` / `error` / `confirmed`) and added `canConnect = captcha-satisfied && isClaimablePhase`
  - `canClaim` is now `canConnect && isAddressValid` — same truth value as before, expressed via the shared gate
  - top-right `.connect-btn` gets `:disabled="!canConnect"` plus a `:disabled` style; its `:hover` / `:active` rules are scoped to `:not(:disabled)`
- `apps/nimiq-pow-ui/src/components/ConnectWallet.vue`
  - new `connectDisabled` prop, applied **only** to the Hub `Connect` button — the paste input and the `Disconnect` link keep their existing `disabled` (= `isPending`) behaviour and aren't frozen by the captcha gate
  - App.vue passes `:connect-disabled="!canConnect"`

No-captcha deployments are unaffected: `canConnect` is then just `isClaimablePhase`, so the buttons enable as soon as the config loads — same as today.

## Test plan

- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui typecheck` (vue-tsc) passes
- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui build` passes
- [ ] `pnpm build` / `pnpm typecheck` / `pnpm test` — covered by CI
- [ ] `pnpm test:e2e` — n/a (no e2e covers this theme's connect flow)
- [ ] Manual (`FAUCET_CLAIM_UI_THEME=nimiq-pow` with an FCaptcha provider configured): on load both connect buttons are disabled; after solving the captcha they enable; the paste input and (once connected) the Disconnect link stay usable throughout. With no captcha provider: buttons enabled on load as before.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — n/a (UI-only gating; the server still enforces every abuse layer at claim time).
- [x] No stack traces in user-facing errors — n/a.
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — n/a.
- [x] Timing-safe comparisons — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)