### PR TITLE
fix(nimiq-pow-ui): keep the stats grid visible on mobile

### DIFF
--- a/apps/nimiq-pow-ui/src/App.vue
+++ b/apps/nimiq-pow-ui/src/App.vue
@@ -357,15 +357,28 @@ function handleClaim() {
 }
 
 @media (max-width: 720px) {
+  /* The brand pill and the stats grid can't share the top row on a
+     narrow screen, so the stats grid drops onto its own line just
+     below the pill — right-aligned, tighter padding/fonts, borders
+     dropped, allowed to wrap on very small screens. (It used to be
+     `display: none` here, which made the whole right side of the
+     header disappear on mobile.) */
   .top-right {
-    display: none; /* free up the small-screen real estate; status stays in the strip on mobile */
+    top: 4.5rem;
+    padding: 0.4rem 0.5rem;
+    max-width: calc(100vw - 3rem);
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: 0.2rem;
   }
-  /* The 12rem/24rem insets above are sized to clear the desktop top
-     chrome (brand pill + stats grid). On mobile the stats grid is
-     hidden and the pill is only ~3.5rem wide, so those insets just
-     shrink the map to a thin band (negative width below ~384px).
-     Let it fill the viewport — the brand pill keeps its own opaque
-     backdrop, so it stays legible on top. */
+  .top-right .stat { min-width: 0; padding: 0.15rem 0.7rem; border-right: none; }
+  .top-right .stat-label { font-size: 0.55rem; letter-spacing: 0.1em; }
+  .top-right .stat-value { font-size: 0.82rem; }
+  .top-right .connect-btn { height: 1.85rem; padding: 0 0.75rem; font-size: 0.72rem; }
+  /* The 12rem/24rem insets above clear the desktop top chrome; on
+     mobile the chrome stacks vertically instead, so let the map fill
+     the viewport width (the brand pill keeps its own opaque backdrop,
+     so it stays legible on top). */
   .map-bg {
     left: 0;
     width: 100vw;


### PR DESCRIPTION
## Summary

On phones (`≤720px`) the whole right side of the NimiqPoW header — claim amount, network, and the Connect Wallet button — disappeared, because the `@media (max-width: 720px)` block set `.top-right { display: none }`. The grid doesn't fit alongside the brand pill on one narrow row, so it was just hidden.

This keeps it visible by dropping it onto its own line just below the brand pill, in a tighter layout.

## Changes

- `apps/nimiq-pow-ui/src/App.vue` — in the mobile media query, replace `.top-right { display: none }` with:
  - `top: 4.5rem` (sits below the brand-pill row)
  - tighter padding/fonts, inter-stat borders removed, `justify-content: flex-end`
  - `flex-wrap: wrap` + `max-width: calc(100vw - 3rem)` so on very narrow screens (~320px) the Connect button moves to a second line instead of overflowing
  - kept the existing `.map-bg { left: 0; width: 100vw }` from the earlier mobile-map fix (comment updated)

Desktop layout is unchanged.

## Test plan

- [x] `pnpm --filter @nimiq-faucet/nimiq-pow-ui typecheck` + `build` pass
- [x] Visually checked the rendered header at 375 / 360 / 320 px viewports (Playwright screenshots): the stats grid + Connect Wallet button render as a second header row; wraps cleanly at 320px; desktop unchanged (`.top-right` still top-right).
- [ ] `pnpm build` / `pnpm typecheck` / `pnpm test` — covered by CI
- [ ] `pnpm test:e2e` — n/a
- [ ] Manual on a real phone after redeploy: header shows brand pill on row 1, stats grid (Claim / Network / Connect Wallet) on row 2; nothing clipped.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — n/a (CSS only).
- [x] No stack traces in user-facing errors — n/a.
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — n/a.
- [x] Timing-safe comparisons — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)