### PR TITLE
feat(sdk): surface idempotencyKey across all SDKs; align status enums (§2.3.1)

### DIFF
--- a/packages/sdk-flutter/lib/src/client.dart
+++ b/packages/sdk-flutter/lib/src/client.dart
@@ -54,6 +54,7 @@ class FaucetClient {
     final body = <String, dynamic>{'address': address};
     if (opts.captchaToken != null) body['captchaToken'] = opts.captchaToken;
     if (opts.hashcashSolution != null) body['hashcashSolution'] = opts.hashcashSolution;
+    if (opts.idempotencyKey != null) body['idempotencyKey'] = opts.idempotencyKey;
     if (opts.fingerprint != null) body['fingerprint'] = opts.fingerprint!.toJson();
     if (opts.hostContext != null) body['hostContext'] = opts.hostContext!.toJson();
     final res = await _post('/v1/claim', body);
@@ -85,8 +86,9 @@ class FaucetClient {
     return claim(address, opts.copyWith(hashcashSolution: '${challenge.challenge}#$nonce'));
   }
 
-  /// Poll until status is `confirmed` or `rejected`. Throws `FaucetException`
-  /// with status 408 if `timeout` elapses first.
+  /// Poll until status reaches a terminal state (`confirmed`, `rejected`, or
+  /// `expired`). Throws `FaucetException` with status 408 if `timeout` elapses
+  /// first.
   Future<ClaimResponse> waitForConfirmation(
     String id, {
     Duration timeout = const Duration(seconds: 60),
@@ -94,7 +96,7 @@ class FaucetClient {
     final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
       final s = await status(id);
-      if (s.status == 'confirmed' || s.status == 'rejected') return s;
+      if (s.status == 'confirmed' || s.status == 'rejected' || s.status == 'expired') return s;
       await Future<void>.delayed(const Duration(seconds: 2));
     }
     throw FaucetException(

--- a/packages/sdk-flutter/lib/src/hmac.dart
+++ b/packages/sdk-flutter/lib/src/hmac.dart
@@ -53,8 +53,10 @@ String _canonicalizeHostContext(HostContext ctx) {
     final sorted = List<String>.from(ctx.tags!)..sort();
     values['tags'] = sorted;
   }
-  // verifiedIdentities not yet on the Dart HostContext; the canonical
-  // order below already accounts for it so once added it lines up.
+  if (ctx.verifiedIdentities != null && ctx.verifiedIdentities!.isNotEmpty) {
+    final sorted = List<String>.from(ctx.verifiedIdentities!)..sort();
+    values['verifiedIdentities'] = sorted;
+  }
   final entries = <List<dynamic>>[];
   for (final k in _canonicalHostContextFields) {
     final v = values[k];
@@ -89,6 +91,7 @@ HostContext signHostContext(
     emailDomainHash: ctx.emailDomainHash,
     kycLevel: ctx.kycLevel,
     tags: ctx.tags,
+    verifiedIdentities: ctx.verifiedIdentities,
     signature: sig,
   );
 }

--- a/packages/sdk-flutter/lib/src/types.dart
+++ b/packages/sdk-flutter/lib/src/types.dart
@@ -11,6 +11,10 @@ class HostContext {
   /// One of: 'none' | 'email' | 'phone' | 'id'.
   final String? kycLevel;
   final List<String>? tags;
+  /// SSO providers the integrator has authenticated the user against
+  /// (e.g. ['apple', 'google', 'github']). Max 10. Covered by the
+  /// hostContext signature when signed.
+  final List<String>? verifiedIdentities;
   final String? signature;
 
   const HostContext({
@@ -21,6 +25,7 @@ class HostContext {
     this.emailDomainHash,
     this.kycLevel,
     this.tags,
+    this.verifiedIdentities,
     this.signature,
   });
 
@@ -33,6 +38,7 @@ class HostContext {
     if (emailDomainHash != null) map['emailDomainHash'] = emailDomainHash;
     if (kycLevel != null) map['kycLevel'] = kycLevel;
     if (tags != null) map['tags'] = tags;
+    if (verifiedIdentities != null) map['verifiedIdentities'] = verifiedIdentities;
     if (signature != null) map['signature'] = signature;
     return map;
   }
@@ -59,6 +65,9 @@ class ClaimOptions {
   final FingerprintBundle? fingerprint;
   final String? captchaToken;
   final String? hashcashSolution;
+  /// Idempotency key for safe retries: two claims with the same key within
+  /// the server's retention window resolve to the same claim id. Max 128 chars.
+  final String? idempotencyKey;
   final String? uid;
   final void Function(int attempts)? onProgress;
 
@@ -67,6 +76,7 @@ class ClaimOptions {
     this.fingerprint,
     this.captchaToken,
     this.hashcashSolution,
+    this.idempotencyKey,
     this.uid,
     this.onProgress,
   });
@@ -76,6 +86,7 @@ class ClaimOptions {
     FingerprintBundle? fingerprint,
     String? captchaToken,
     String? hashcashSolution,
+    String? idempotencyKey,
     String? uid,
     void Function(int)? onProgress,
   }) {
@@ -84,6 +95,7 @@ class ClaimOptions {
       fingerprint: fingerprint ?? this.fingerprint,
       captchaToken: captchaToken ?? this.captchaToken,
       hashcashSolution: hashcashSolution ?? this.hashcashSolution,
+      idempotencyKey: idempotencyKey ?? this.idempotencyKey,
       uid: uid ?? this.uid,
       onProgress: onProgress ?? this.onProgress,
     );
@@ -95,7 +107,7 @@ class ClaimOptions {
 /// "Public-API silence on rejection".
 class ClaimResponse {
   final String id;
-  /// One of: 'queued' | 'broadcast' | 'confirmed' | 'rejected' | 'challenged'.
+  /// One of: 'queued' | 'broadcast' | 'confirmed' | 'rejected' | 'challenged' | 'timeout' | 'expired'.
   final String status;
   final String? txId;
 

--- a/packages/sdk-go/faucet.go
+++ b/packages/sdk-go/faucet.go
@@ -69,6 +69,7 @@ type claimBody struct {
 	Address          string             `json:"address"`
 	CaptchaToken     *string            `json:"captchaToken,omitempty"`
 	HashcashSolution *string            `json:"hashcashSolution,omitempty"`
+	IdempotencyKey   *string            `json:"idempotencyKey,omitempty"`
 	Fingerprint      *FingerprintBundle `json:"fingerprint,omitempty"`
 	HostContext      *HostContext       `json:"hostContext,omitempty"`
 }
@@ -79,6 +80,7 @@ func (c *Client) Claim(ctx context.Context, address string, opts ClaimOptions) (
 		Address:          address,
 		CaptchaToken:     opts.CaptchaToken,
 		HashcashSolution: opts.HashcashSolution,
+		IdempotencyKey:   opts.IdempotencyKey,
 		Fingerprint:      opts.Fingerprint,
 		HostContext:      opts.HostContext,
 	}
@@ -129,9 +131,9 @@ func (c *Client) SolveAndClaim(ctx context.Context, address string, opts ClaimOp
 	return c.Claim(ctx, address, opts)
 }
 
-// WaitForConfirmation polls Status until the claim is "confirmed" or
-// "rejected", or until `timeout` elapses. Returns a FaucetError with
-// Status 408 on timeout.
+// WaitForConfirmation polls Status until the claim reaches a terminal state
+// ("confirmed", "rejected", or "expired"), or until `timeout` elapses.
+// Returns a FaucetError with Status 408 on timeout.
 func (c *Client) WaitForConfirmation(ctx context.Context, id string, timeout time.Duration) (*ClaimResponse, error) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -139,7 +141,7 @@ func (c *Client) WaitForConfirmation(ctx context.Context, id string, timeout tim
 		if err != nil {
 			return nil, err
 		}
-		if resp.Status == "confirmed" || resp.Status == "rejected" {
+		if resp.Status == "confirmed" || resp.Status == "rejected" || resp.Status == "expired" {
 			return resp, nil
 		}
 		select {

--- a/packages/sdk-go/types.go
+++ b/packages/sdk-go/types.go
@@ -28,6 +28,10 @@ type ClaimOptions struct {
 	Fingerprint      *FingerprintBundle `json:"fingerprint,omitempty"`
 	CaptchaToken     *string            `json:"captchaToken,omitempty"`
 	HashcashSolution *string            `json:"hashcashSolution,omitempty"`
+	// IdempotencyKey lets callers retry safely: two claims with the same key
+	// within the server's retention window resolve to the same claim id.
+	// Max 128 chars.
+	IdempotencyKey *string `json:"idempotencyKey,omitempty"`
 }
 
 // ClaimResponse mirrors the TS `ClaimResponse`.
@@ -36,8 +40,9 @@ type ClaimOptions struct {
 // No abuse-layer attribution leaks to clients.
 // See SECURITY.md "Public-API silence on rejection".
 type ClaimResponse struct {
-	ID     string `json:"id"`
-	Status string `json:"status"` // queued | broadcast | confirmed | rejected | challenged
+	ID string `json:"id"`
+	// Status is one of: queued | broadcast | confirmed | rejected | challenged | timeout | expired.
+	Status string `json:"status"`
 	TxID   string `json:"txId,omitempty"`
 }
 

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -51,7 +51,8 @@ export function useFaucetClaim(args: UseFaucetClaimArgs): UseFaucetClaimResult {
     return () => manager.current?.destroy();
   }, [client]);
 
-  const { address, hostContext, captchaToken, hashcashSolution, fingerprint, pollForConfirmation } = args;
+  const { address, hostContext, captchaToken, hashcashSolution, idempotencyKey, fingerprint, pollForConfirmation } =
+    args;
 
   const claim = useCallback(
     async () => {
@@ -59,11 +60,12 @@ export function useFaucetClaim(args: UseFaucetClaimArgs): UseFaucetClaimResult {
         hostContext,
         captchaToken,
         hashcashSolution,
+        idempotencyKey,
         fingerprint,
         pollForConfirmation,
       });
     },
-    [address, hostContext, captchaToken, hashcashSolution, fingerprint, pollForConfirmation],
+    [address, hostContext, captchaToken, hashcashSolution, idempotencyKey, fingerprint, pollForConfirmation],
   );
 
   const reset = useCallback(() => manager.current?.reset(), []);

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -20,10 +20,22 @@ export interface ClaimOptions {
   fingerprint?: FingerprintBundle | undefined;
   captchaToken?: string | undefined;
   hashcashSolution?: string | undefined;
+  /**
+   * Idempotency key for safe retries. Two claims with the same key within the
+   * server's retention window resolve to the same claim id. Max 128 chars.
+   */
+  idempotencyKey?: string | undefined;
   signal?: AbortSignal | undefined;
 }
 
-export type ClaimStatus = 'queued' | 'broadcast' | 'confirmed' | 'rejected' | 'challenged';
+export type ClaimStatus =
+  | 'queued'
+  | 'broadcast'
+  | 'confirmed'
+  | 'rejected'
+  | 'challenged'
+  | 'timeout'
+  | 'expired';
 
 export interface ClaimResponse {
   id: string;
@@ -131,6 +143,7 @@ export class FaucetClient {
       address,
       captchaToken: options.captchaToken,
       hashcashSolution: options.hashcashSolution,
+      idempotencyKey: options.idempotencyKey,
       fingerprint: options.fingerprint,
       hostContext: options.hostContext,
     };
@@ -166,7 +179,7 @@ export class FaucetClient {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const s = await this.status(id);
-      if (s.status === 'confirmed' || s.status === 'rejected') return s;
+      if (s.status === 'confirmed' || s.status === 'rejected' || s.status === 'expired') return s;
       await new Promise((r) => setTimeout(r, 2_000));
     }
     throw new FaucetError(`Claim ${id} not confirmed in ${timeoutMs}ms`, 408);

--- a/packages/sdk-vue/src/index.ts
+++ b/packages/sdk-vue/src/index.ts
@@ -50,6 +50,7 @@ export function useFaucetClaim(args: UseFaucetClaimArgs) {
         hostContext: args.hostContext,
         captchaToken: args.captchaToken,
         hashcashSolution: args.hashcashSolution,
+        idempotencyKey: args.idempotencyKey,
         fingerprint: args.fingerprint,
         pollForConfirmation: args.pollForConfirmation,
       }),


### PR DESCRIPTION
## Summary

First item of ROADMAP §2.3 (the integrator-DX backlog, added in #208): close the SDK feature-parity gaps. `idempotencyKey` on `POST /v1/claim` has been a server feature since v1.7.0 (accepted everywhere — `apps/server/src/routes/claim.ts`, `apps/server/src/openapi/schemas.ts:52`) but only the Python SDK surfaced it; the `timeout`/`expired` claim statuses (also v1.7.0) weren't uniformly in the SDK status enums; and the Flutter SDK's `HostContext` was missing `verifiedIdentities` (a v2.0.0 field).

## Changes

**`idempotencyKey` in the claim request:**
- `packages/sdk-ts` — `ClaimOptions.idempotencyKey`, included in the claim body.
- `packages/sdk-react` / `packages/sdk-vue` — passed through the hook/composable args (`UseFaucetClaimArgs extends Omit<ClaimOptions, 'signal'>` already had the type; the implementations cherry-pick fields rather than spreading, so they needed the explicit wiring).
- `packages/sdk-go` — `ClaimOptions.IdempotencyKey` + `claimBody.IdempotencyKey` (`*string`, `omitempty`).
- `packages/sdk-flutter` — `ClaimOptions.idempotencyKey` (+ `copyWith`), included in the claim body.
- `packages/sdk-capacitor` / `packages/sdk-react-native` — inherit it via `export * from '@nimiq-faucet/sdk'`; no change.

**Status-enum alignment:**
- `packages/sdk-ts` — `ClaimStatus` gains `'timeout' | 'expired'` (matching `apps/server/src/openapi/schemas.ts:62`'s enum). `waitForConfirmation` now also terminates on `'expired'` (matching the Python SDK's `wait_for_confirmation`, which returns on `confirmed | rejected | expired`).
- `packages/sdk-go` / `packages/sdk-flutter` — status doc comments updated; `WaitForConfirmation` / `waitForConfirmation` also terminate on `expired`.

**Flutter `verifiedIdentities`:**
- `packages/sdk-flutter/lib/src/types.dart` — new `verifiedIdentities` field on `HostContext` (field + ctor + `toJson`).
- `packages/sdk-flutter/lib/src/hmac.dart` — wire it into the canonical string (lexicographically sorted, same as `tags`) and pass it through in `signHostContext` — mirrors `canonicalizeHostContext` in `packages/core/src/hostContext.ts` (which sorts any array value). Removed the stale `// verifiedIdentities not yet on the Dart HostContext` comment.

## Test plan

- [x] `pnpm pre-merge` green (58/58 turbo tasks — typecheck + build + test across the TS workspace incl. sdk-ts/react/vue/capacitor/react-native).
- [x] `dart analyze` on `packages/sdk-flutter` introduces no new issues (verified with `git stash` — the one pre-existing `error` in `test/client_test.dart:84` references a `decision` param on `FaucetException` that doesn't exist yet; that's §2.3.6 scope, not this PR).
- [ ] `go build`/`go vet` on `packages/sdk-go` — couldn't run locally (`go` not installed in this env); changes are mechanical struct-field additions; CI's Go job will verify.
- [ ] Cross-SDK contract test (§2.3.3) — separate follow-up; this PR is the parity *fix*, that's the parity *guard*.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — `idempotencyKey` is validated server-side (`z.string().max(128)`); the SDKs just forward it.
- [x] No stack traces in user-facing errors — n/a.
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — n/a.
- [x] Timing-safe comparisons — n/a (the Flutter `hmac.dart` change extends an existing canonicalization, doesn't add a comparison path).

## Follow-ups (other §2.3 items)

§2.3.2 cut a release · §2.3.3 cross-SDK contract test · §2.3.4 minimal starters · §2.3.5 abuse-layer integration guide · §2.3.6 consistent typed errors (incl. the Flutter `decision` field) · §2.3.7 MCP docs · §2.3.8 config reference · §2.3.9 snippets cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)