### PR TITLE
feat(examples): minimal React + Vite faucet starter (§2.3.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,15 @@ jobs:
           load: false
           platforms: linux/amd64
           tags: example-nextjs-claim:ci
+      - name: Build minimal-react example image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: examples/minimal-react/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          tags: example-minimal-react:ci
 
   compose-smoke:
     runs-on: ubuntu-latest

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -29,6 +29,19 @@ services:
     depends_on:
       - faucet
 
+  # Minimal React + Vite faucet integration — no abuse-layer handling, ~60
+  # lines of app code. See examples/minimal-react/README.md.
+  example-minimal-react:
+    build:
+      context: ..
+      dockerfile: examples/minimal-react/Dockerfile
+      args:
+        VITE_FAUCET_URL: http://localhost:8080
+    ports:
+      - "3008:80"
+    depends_on:
+      - faucet
+
   example-capacitor:
     build:
       context: ..

--- a/examples/minimal-react/.env.example
+++ b/examples/minimal-react/.env.example
@@ -1,0 +1,4 @@
+# Copy to `.env`. The faucet URL the browser hits — must be CORS-allowed
+# by the faucet (its FAUCET_CORS_ORIGINS env var). For the compose stack
+# in deploy/compose/, that's http://localhost:8080.
+VITE_FAUCET_URL=http://localhost:8080

--- a/examples/minimal-react/Dockerfile
+++ b/examples/minimal-react/Dockerfile
@@ -1,0 +1,29 @@
+## syntax=docker/dockerfile:1.7
+# Minimal React + Vite faucet example — multi-stage build.
+#
+# Build context = repo root, e.g.
+#   docker buildx build -f examples/minimal-react/Dockerfile -t minimal-react:test .
+#
+# Same workspace-wide install pattern as the other example Dockerfiles
+# (see examples/vue-claim-page/Dockerfile, issue #116): copy the full
+# workspace and let `pnpm install --filter <example>...` prune the graph,
+# rather than the deps-only-cache pattern that breaks the lockfile.
+
+FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS build
+COPY . .
+ARG VITE_FAUCET_URL=http://localhost:8080
+ENV VITE_FAUCET_URL=${VITE_FAUCET_URL}
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-minimal-react...
+RUN pnpm turbo run build --filter=@nimiq-faucet/example-minimal-react
+
+FROM nginx:alpine AS runtime
+COPY --from=build /app/examples/minimal-react/dist /usr/share/nginx/html
+COPY examples/minimal-react/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/examples/minimal-react/README.md
+++ b/examples/minimal-react/README.md
@@ -1,0 +1,45 @@
+# Minimal React faucet example
+
+The smallest possible faucet integration: [`useFaucetClaim`](../../packages/sdk-react)
+from `@nimiq-faucet/react` plus a button. Vite + React 19, no styling
+framework, ~60 lines of app code ([`src/App.tsx`](src/App.tsx)). Copy this
+directory into your project, point `VITE_FAUCET_URL` at your faucet, and you
+have a working claim page.
+
+```tsx
+const { status, txId, error, claim, reset } = useFaucetClaim({
+  client: { url: import.meta.env.VITE_FAUCET_URL },
+  address,
+});
+// <button onClick={claim} disabled={!address}>Claim</button>
+```
+
+> **Heads-up — this example does *not* handle abuse layers.** If your faucet
+> has a captcha (Cloudflare Turnstile / hCaptcha / FCaptcha) or hashcash
+> proof-of-work enabled, a plain `claim()` comes back `challenged` or gets
+> rejected. To handle those, read [`/v1/config`](../../docs/abuse-layers/),
+> render the captcha widget the server reports, and use
+> `client.solveAndClaim()` when hashcash is on — see
+> [`examples/nextjs-claim-page/`](../nextjs-claim-page) for a
+> feature-complete React example that wires all of it up, or the per-layer
+> docs in [`docs/abuse-layers/`](../../docs/abuse-layers/).
+
+## Run
+
+```bash
+# from the repo root
+pnpm install
+cp examples/minimal-react/.env.example examples/minimal-react/.env   # edit if your faucet isn't on localhost:8080
+pnpm --filter @nimiq-faucet/example-minimal-react dev
+```
+
+Need a faucet to point at? See [`deploy/compose/README.md`](../../deploy/compose/README.md)
+(`docker compose --profile local-node up -d`).
+
+## Run with Docker
+
+```bash
+# from the repo root — starts the faucet stack + this example
+docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.yml up --build example-minimal-react
+# → http://localhost:3008
+```

--- a/examples/minimal-react/index.html
+++ b/examples/minimal-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nimiq Faucet — Minimal React Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/minimal-react/nginx.conf
+++ b/examples/minimal-react/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/examples/minimal-react/package.json
+++ b/examples/minimal-react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nimiq-faucet/example-minimal-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The smallest possible React + Vite faucet integration — copy this directory, set VITE_FAUCET_URL, done.",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nimiq-faucet/react": "workspace:*",
+    "@nimiq-faucet/sdk": "workspace:*",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.11"
+  }
+}

--- a/examples/minimal-react/src/App.tsx
+++ b/examples/minimal-react/src/App.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useFaucetClaim } from '@nimiq-faucet/react';
+
+// The faucet URL the browser hits. Override with VITE_FAUCET_URL.
+const FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
+
+export function App() {
+  const [address, setAddress] = useState('');
+  const { status, txId, error, claim, reset } = useFaucetClaim({
+    client: { url: FAUCET_URL },
+    address,
+  });
+
+  // `status` walks: idle → pending → broadcast → confirmed (or rejected).
+  const busy = status === 'pending' || status === 'broadcast' || status === 'queued';
+
+  return (
+    <main style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 480, margin: '4rem auto', padding: '0 1rem' }}>
+      <h1>Claim NIM</h1>
+      <p>
+        The smallest faucet integration: <code>useFaucetClaim</code> + a button.
+      </p>
+
+      <input
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        placeholder="NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
+        spellCheck={false}
+        disabled={busy}
+        style={{ width: '100%', padding: '0.6rem', fontFamily: 'monospace', boxSizing: 'border-box' }}
+      />
+
+      <button
+        onClick={claim}
+        disabled={!address || busy}
+        style={{ marginTop: '0.75rem', padding: '0.6rem 1.2rem', cursor: busy ? 'progress' : 'pointer' }}
+      >
+        {busy ? 'Claiming…' : 'Claim'}
+      </button>
+
+      {status === 'confirmed' && (
+        <p style={{ color: 'green' }}>
+          ✓ Confirmed — tx <code>{txId}</code>. <button onClick={reset}>Claim again</button>
+        </p>
+      )}
+      {(status === 'rejected' || error) && (
+        <p style={{ color: 'crimson' }}>
+          {error?.message ?? 'Claim rejected.'} <button onClick={reset}>Try again</button>
+        </p>
+      )}
+      {status === 'challenged' && (
+        <p style={{ color: '#a60' }}>
+          The faucet asked for a captcha or proof-of-work. This minimal example doesn’t handle abuse layers — see the
+          README.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/examples/minimal-react/src/env.d.ts
+++ b/examples/minimal-react/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** The faucet URL the browser hits. Must be CORS-allowed by the faucet
+   *  (FAUCET_CORS_ORIGINS). For the compose stack that's http://localhost:8080. */
+  readonly VITE_FAUCET_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/minimal-react/src/main.tsx
+++ b/examples/minimal-react/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/minimal-react/tsconfig.json
+++ b/examples/minimal-react/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/env.d.ts"]
+}

--- a/examples/minimal-react/vite.config.ts
+++ b/examples/minimal-react/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 3008 },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,37 @@ importers:
         specifier: ^3.2.8
         version: 3.2.8(typescript@6.0.3)
 
+  examples/minimal-react:
+    dependencies:
+      '@nimiq-faucet/react':
+        specifier: workspace:*
+        version: link:../../packages/sdk-react
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.2.0(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.11
+        version: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+
   examples/nextjs-claim-page:
     dependencies:
       '@nimiq-faucet/react':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "packages/*"
   - "examples/nextjs-claim-page"
   - "examples/vue-claim-page"
+  - "examples/minimal-react"
   - "examples/capacitor-mobile-app"
   - "examples/mini-app-claim-shared"
   - "examples/mini-app-claim-vue"


### PR DESCRIPTION
## Summary

ROADMAP §2.3.4 (onboarding) — there's no minimal pure-React example today. `examples/nextjs-claim-page/` is feature-complete (captcha, hashcash, signed `hostContext`) but not a copy-paste starter, and the only other React example is the Nimiq-Pay mini-app. This adds `examples/minimal-react/`: ~60 lines of app code, `useFaucetClaim` from `@nimiq-faucet/react` + a button, Vite + React 19, no styling framework. Structure mirrors `examples/vue-claim-page/` (Dockerfile, `nginx.conf`, `.env.example`, README).

```tsx
const { status, txId, error, claim, reset } = useFaucetClaim({
  client: { url: import.meta.env.VITE_FAUCET_URL },
  address,
});
// <button onClick={claim} disabled={!address}>Claim</button>
```

It **deliberately doesn't handle abuse layers** — the README is up-front about that and points at `docs/abuse-layers/` and `examples/nextjs-claim-page/` for the captcha/hashcash recipe. A framework-agnostic "abuse layers in your integration" guide is the companion §2.3.5 item.

## Changes

- **`examples/minimal-react/`** — new example: `package.json` (`@nimiq-faucet/example-minimal-react`), `index.html`, `vite.config.ts`, `tsconfig.json`, `src/{main.tsx,App.tsx,env.d.ts}`, `nginx.conf`, `Dockerfile` (same workspace-wide-install pattern as the other example Dockerfiles), `.env.example`, `README.md`.
- **`pnpm-workspace.yaml`** — add `examples/minimal-react`.
- **`examples/docker-compose.yml`** — add the `example-minimal-react` service (port `3008` — next free after the other examples' 3001–3007).
- **`.github/workflows/ci.yml`** — add a `Build minimal-react example image` step to the `examples-build` job.
- **`pnpm-lock.yaml`** — refreshed for the new package.

## Test plan

- [x] `pnpm pre-merge` green (59/59 turbo tasks — the new package's `build` (`tsc --noEmit && vite build`) added one task and passes).
- [x] `pnpm --filter @nimiq-faucet/example-minimal-react... build` succeeds locally.
- [ ] CI's `examples-build` job builds `examples/minimal-react/Dockerfile`.
- [ ] Manual: `pnpm --filter @nimiq-faucet/example-minimal-react dev` against a local faucet → enter an address → claim → see `confirmed` + tx hash.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — the address is validated server-side by the faucet; the example just forwards it.
- [x] No stack traces in user-facing errors — the example shows `error.message` (which the SDK builds from the faucet's opaque error response — no abuse-layer attribution).
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — yes (`VITE_FAUCET_URL`).
- [x] Timing-safe comparisons — n/a.

## Follow-ups (§2.3.4 / §2.3.5)

`examples/minimal-vue/` (symmetric, quick) · the framework-agnostic abuse-layers integration guide (§2.3.5) · the missing React Native example app (§1.5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)