### PR TITLE
feat(examples): minimal Vue 3 + Vite faucet starter (§2.3.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,15 @@ jobs:
           load: false
           platforms: linux/amd64
           tags: example-minimal-react:ci
+      - name: Build minimal-vue example image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: examples/minimal-vue/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          tags: example-minimal-vue:ci
 
   compose-smoke:
     runs-on: ubuntu-latest

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -42,6 +42,19 @@ services:
     depends_on:
       - faucet
 
+  # Minimal Vue 3 + Vite faucet integration — no abuse-layer handling.
+  # See examples/minimal-vue/README.md.
+  example-minimal-vue:
+    build:
+      context: ..
+      dockerfile: examples/minimal-vue/Dockerfile
+      args:
+        VITE_FAUCET_URL: http://localhost:8080
+    ports:
+      - "3009:80"
+    depends_on:
+      - faucet
+
   example-capacitor:
     build:
       context: ..

--- a/examples/minimal-vue/.env.example
+++ b/examples/minimal-vue/.env.example
@@ -1,0 +1,4 @@
+# Copy to `.env`. The faucet URL the browser hits — must be CORS-allowed
+# by the faucet (its FAUCET_CORS_ORIGINS env var). For the compose stack
+# in deploy/compose/, that's http://localhost:8080.
+VITE_FAUCET_URL=http://localhost:8080

--- a/examples/minimal-vue/Dockerfile
+++ b/examples/minimal-vue/Dockerfile
@@ -1,0 +1,27 @@
+## syntax=docker/dockerfile:1.7
+# Minimal Vue 3 + Vite faucet example — multi-stage build.
+#
+# Build context = repo root, e.g.
+#   docker buildx build -f examples/minimal-vue/Dockerfile -t minimal-vue:test .
+#
+# Same workspace-wide install pattern as the other example Dockerfiles
+# (see examples/vue-claim-page/Dockerfile, issue #116).
+
+FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS build
+COPY . .
+ARG VITE_FAUCET_URL=http://localhost:8080
+ENV VITE_FAUCET_URL=${VITE_FAUCET_URL}
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @nimiq-faucet/example-minimal-vue...
+RUN pnpm turbo run build --filter=@nimiq-faucet/example-minimal-vue
+
+FROM nginx:alpine AS runtime
+COPY --from=build /app/examples/minimal-vue/dist /usr/share/nginx/html
+COPY examples/minimal-vue/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/examples/minimal-vue/README.md
+++ b/examples/minimal-vue/README.md
@@ -1,0 +1,45 @@
+# Minimal Vue faucet example
+
+The smallest possible faucet integration: [`useFaucetClaim`](../../packages/sdk-vue)
+from `@nimiq-faucet/vue` plus a button. Vite + Vue 3, no styling framework,
+one small SFC ([`src/App.vue`](src/App.vue)). Copy this directory into your
+project, point `VITE_FAUCET_URL` at your faucet, and you have a working claim
+page.
+
+```ts
+const { status, txId, error, isPending, claim, reset } = useFaucetClaim({
+  client: { url: import.meta.env.VITE_FAUCET_URL },
+  get address() { return address.value; }, // args.address is read at claim time
+});
+// <button :disabled="!address" @click="claim">Claim</button>
+```
+
+> **Heads-up — this example does *not* handle abuse layers.** If your faucet
+> has a captcha (Cloudflare Turnstile / hCaptcha / FCaptcha) or hashcash
+> proof-of-work enabled, a plain `claim()` comes back `challenged` or gets
+> rejected. To handle those, read [`/v1/config`](../../docs/abuse-layers/),
+> render the captcha widget the server reports, and use
+> `client.solveAndClaim()` when hashcash is on — see
+> [`examples/vue-claim-page/`](../vue-claim-page) for a feature-complete Vue
+> example that wires all of it up, or the per-layer docs in
+> [`docs/abuse-layers/`](../../docs/abuse-layers/).
+
+## Run
+
+```bash
+# from the repo root
+pnpm install
+cp examples/minimal-vue/.env.example examples/minimal-vue/.env   # edit if your faucet isn't on localhost:8080
+pnpm --filter @nimiq-faucet/example-minimal-vue dev
+```
+
+Need a faucet to point at? See [`deploy/compose/README.md`](../../deploy/compose/README.md)
+(`docker compose --profile local-node up -d`).
+
+## Run with Docker
+
+```bash
+# from the repo root — starts the faucet stack + this example
+docker compose -f deploy/compose/docker-compose.yml -f examples/docker-compose.yml up --build example-minimal-vue
+# → http://localhost:3009
+```

--- a/examples/minimal-vue/index.html
+++ b/examples/minimal-vue/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nimiq Faucet — Minimal Vue Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/minimal-vue/nginx.conf
+++ b/examples/minimal-vue/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/examples/minimal-vue/package.json
+++ b/examples/minimal-vue/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nimiq-faucet/example-minimal-vue",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The smallest possible Vue 3 + Vite faucet integration — copy this directory, set VITE_FAUCET_URL, done.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nimiq-faucet/sdk": "workspace:*",
+    "@nimiq-faucet/vue": "workspace:*",
+    "vue": "^3.5.34"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.6",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.11",
+    "vue-tsc": "^3.2.8"
+  }
+}

--- a/examples/minimal-vue/src/App.vue
+++ b/examples/minimal-vue/src/App.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useFaucetClaim } from '@nimiq-faucet/vue';
+
+// The faucet URL the browser hits. Override with VITE_FAUCET_URL.
+const FAUCET_URL = import.meta.env.VITE_FAUCET_URL ?? 'http://localhost:8080';
+
+const address = ref('');
+
+// `useFaucetClaim` reads `args.address` at claim time, so expose the ref
+// via a getter to keep the typed-in value live.
+const { status, txId, error, isPending, claim, reset } = useFaucetClaim({
+  client: { url: FAUCET_URL },
+  get address() {
+    return address.value;
+  },
+});
+
+// `status` walks: idle → pending → broadcast → confirmed (or rejected).
+// `isPending` covers only the initial submit; include the polling states.
+const busy = computed(() => isPending.value || status.value === 'broadcast' || status.value === 'queued');
+</script>
+
+<template>
+  <main style="font-family: system-ui, sans-serif; max-width: 480px; margin: 4rem auto; padding: 0 1rem">
+    <h1>Claim NIM</h1>
+    <p>The smallest faucet integration: <code>useFaucetClaim</code> + a button.</p>
+
+    <input
+      v-model="address"
+      placeholder="NQ00 0000 0000 0000 0000 0000 0000 0000 0000"
+      spellcheck="false"
+      :disabled="busy"
+      style="width: 100%; padding: 0.6rem; font-family: monospace; box-sizing: border-box"
+    />
+
+    <button
+      :disabled="!address || busy"
+      :style="{ marginTop: '0.75rem', padding: '0.6rem 1.2rem', cursor: busy ? 'progress' : 'pointer' }"
+      @click="claim"
+    >
+      {{ busy ? 'Claiming…' : 'Claim' }}
+    </button>
+
+    <p v-if="status === 'confirmed'" style="color: green">
+      ✓ Confirmed — tx <code>{{ txId }}</code>. <button @click="reset">Claim again</button>
+    </p>
+    <p v-else-if="status === 'rejected' || error" style="color: crimson">
+      {{ error?.message ?? 'Claim rejected.' }} <button @click="reset">Try again</button>
+    </p>
+    <p v-else-if="status === 'challenged'" style="color: #a60">
+      The faucet asked for a captcha or proof-of-work. This minimal example doesn’t handle abuse layers — see the
+      README.
+    </p>
+  </main>
+</template>

--- a/examples/minimal-vue/src/env.d.ts
+++ b/examples/minimal-vue/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** The faucet URL the browser hits. Must be CORS-allowed by the faucet
+   *  (FAUCET_CORS_ORIGINS). For the compose stack that's http://localhost:8080. */
+  readonly VITE_FAUCET_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/minimal-vue/src/main.ts
+++ b/examples/minimal-vue/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/minimal-vue/tsconfig.json
+++ b/examples/minimal-vue/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/env.d.ts"]
+}

--- a/examples/minimal-vue/vite.config.ts
+++ b/examples/minimal-vue/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: { port: 3009 },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,31 @@ importers:
         specifier: ^8.0.11
         version: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  examples/minimal-vue:
+    dependencies:
+      '@nimiq-faucet/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk-ts
+      '@nimiq-faucet/vue':
+        specifier: workspace:*
+        version: link:../../packages/sdk-vue
+      vue:
+        specifier: ^3.5.34
+        version: 3.5.34(typescript@6.0.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.6
+        version: 6.0.6(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.11
+        version: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vue-tsc:
+        specifier: ^3.2.8
+        version: 3.2.8(typescript@6.0.3)
+
   examples/nextjs-claim-page:
     dependencies:
       '@nimiq-faucet/react':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - "examples/nextjs-claim-page"
   - "examples/vue-claim-page"
   - "examples/minimal-react"
+  - "examples/minimal-vue"
   - "examples/capacitor-mobile-app"
   - "examples/mini-app-claim-shared"
   - "examples/mini-app-claim-vue"


### PR DESCRIPTION
## Summary

ROADMAP §2.3.4 — the Vue counterpart of `examples/minimal-react/` (#211). One small SFC, `useFaucetClaim` from `@nimiq-faucet/vue` + a button, Vite + Vue 3, no styling framework. Same structure/Dockerfile/README pattern as the other examples.

```ts
const { status, txId, error, isPending, claim, reset } = useFaucetClaim({
  client: { url: import.meta.env.VITE_FAUCET_URL },
  get address() { return address.value; }, // args.address is read at claim time
});
// <button :disabled="!address" @click="claim">Claim</button>
```

> The getter on `address` is deliberate and documented in the example: `useFaucetClaim` reads `args.address` when its returned `claim()` is invoked, so exposing the `ref` via `get address()` keeps the typed-in value live (a plain `address.value` would be captured once at setup).

Like minimal-react, it **doesn't handle abuse layers** — the README points at `docs/abuse-layers/` and `examples/vue-claim-page/` (the feature-complete Vue example), and the framework-agnostic abuse-layers guide is the §2.3.5 companion.

## Changes

- **`examples/minimal-vue/`** — `package.json` (`@nimiq-faucet/example-minimal-vue`), `index.html`, `vite.config.ts`, `tsconfig.json`, `src/{main.ts,App.vue,env.d.ts}`, `nginx.conf`, `Dockerfile`, `.env.example`, `README.md`.
- **`pnpm-workspace.yaml`** — add `examples/minimal-vue`.
- **`examples/docker-compose.yml`** — add the `example-minimal-vue` service (port `3009`).
- **`.github/workflows/ci.yml`** — add a `Build minimal-vue example image` step to the `examples-build` job.
- **`pnpm-lock.yaml`** — refreshed for the new package.

## Test plan

- [x] `pnpm pre-merge` green (60/60 turbo tasks — the new package's `build` (`vue-tsc --noEmit && vite build`) added one task and passes).
- [x] `pnpm --filter @nimiq-faucet/example-minimal-vue... build` succeeds locally.
- [ ] CI's `examples-build` job builds `examples/minimal-vue/Dockerfile`.
- [ ] Manual: `pnpm --filter @nimiq-faucet/example-minimal-vue dev` against a local faucet → enter an address → claim → see `confirmed` + tx hash.

## Security checklist

- [x] No secrets in diff.
- [x] New inputs validated at boundary — the address is validated server-side; the example just forwards it.
- [x] No stack traces in user-facing errors — shows `error.message` (from the SDK's opaque error response).
- [x] Admin mutations go through `/admin/*` — n/a.
- [x] New env vars added to `.env.example` — yes (`VITE_FAUCET_URL`).
- [x] Timing-safe comparisons — n/a.

## Follow-ups (§2.3.5 / §1.5.1)

The framework-agnostic abuse-layers integration guide (§2.3.5) · the missing React Native example app (§1.5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)