### PR TITLE
feat(sdk+server): uniform error envelope + typed errors parity (§2.3.6)

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -185,6 +185,7 @@ export async function buildApp(
       reply.header('Retry-After', '10');
       return reply.code(503).send({
         error: 'driver_not_ready',
+        code: 'DRIVER_NOT_READY',
         message: 'Signer driver is still establishing consensus. Retry shortly.',
       });
     }
@@ -275,7 +276,7 @@ export async function buildApp(
     return { ready: allOk, checks };
   });
   app.get('/metrics', async (_req, reply) => {
-    if (!config.metricsEnabled) return reply.code(404).send({ error: 'metrics disabled' });
+    if (!config.metricsEnabled) return reply.code(404).send({ error: 'metrics disabled', code: 'METRICS_DISABLED' });
     driverReady.set(isDriverReady() ? 1 : 0);
     try {
       walletBalance.set(Number(await driver.getBalance()));

--- a/apps/server/src/auth/middleware.ts
+++ b/apps/server/src/auth/middleware.ts
@@ -59,12 +59,12 @@ export function requireAdminSession(ctx: AppContext) {
   return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     const token = getCookie(req, cookieName);
     if (!token) {
-      await reply.code(401).send({ error: 'unauthorized' });
+      await reply.code(401).send({ error: 'unauthorized', code: 'UNAUTHORIZED' });
       return;
     }
     const session = await validateSession(ctx.db, token);
     if (!session) {
-      await reply.code(401).send({ error: 'unauthorized' });
+      await reply.code(401).send({ error: 'unauthorized', code: 'UNAUTHORIZED' });
       return;
     }
     req.adminUser = { id: session.userId, sessionToken: token };
@@ -87,13 +87,13 @@ export function requireAdminCsrf(ctx: AppContext) {
     const header = req.headers[ADMIN_CSRF_HEADER];
     const headerStr = Array.isArray(header) ? header[0] : header;
     if (!cookie || !headerStr || typeof headerStr !== 'string') {
-      await reply.code(403).send({ error: 'csrf token missing' });
+      await reply.code(403).send({ error: 'csrf token missing', code: 'CSRF_TOKEN_MISSING' });
       return;
     }
     const a = Buffer.from(cookie);
     const b = Buffer.from(headerStr);
     if (a.length !== b.length || !timingSafeEqual(a, b)) {
-      await reply.code(403).send({ error: 'csrf token mismatch' });
+      await reply.code(403).send({ error: 'csrf token mismatch', code: 'CSRF_TOKEN_MISMATCH' });
       return;
     }
   };
@@ -106,7 +106,7 @@ export function requireAdminCsrf(ctx: AppContext) {
 export function requireTotpStepUp(ctx: AppContext) {
   return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     if (!req.adminUser) {
-      await reply.code(401).send({ error: 'unauthorized' });
+      await reply.code(401).send({ error: 'unauthorized', code: 'UNAUTHORIZED' });
       return;
     }
     const [user] = await ctx.db
@@ -115,17 +115,17 @@ export function requireTotpStepUp(ctx: AppContext) {
       .where(eq(adminUsers.id, req.adminUser.id))
       .limit(1);
     if (!user?.totpSecret) {
-      await reply.code(403).send({ error: 'totp not enrolled' });
+      await reply.code(403).send({ error: 'totp not enrolled', code: 'TOTP_NOT_ENROLLED' });
       return;
     }
     const header = req.headers[ADMIN_TOTP_HEADER];
     const code = Array.isArray(header) ? header[0] : header;
     if (!code || typeof code !== 'string') {
-      await reply.code(403).send({ error: 'totp step-up required' });
+      await reply.code(403).send({ error: 'totp step-up required', code: 'TOTP_STEP_UP_REQUIRED' });
       return;
     }
     if (!verifyTotp(user.totpSecret, code)) {
-      await reply.code(403).send({ error: 'invalid totp' });
+      await reply.code(403).send({ error: 'invalid totp', code: 'INVALID_TOTP' });
       return;
     }
     // Caller route may choose to mark the session step-up afterwards.

--- a/apps/server/src/hardening.ts
+++ b/apps/server/src/hardening.ts
@@ -247,17 +247,22 @@ export async function applyHardening(app: FastifyInstance, config: ServerConfig)
     });
   }
 
-  if (!config.dev) {
-    app.setErrorHandler((err: Error & { statusCode?: number; code?: string }, req, reply) => {
-      req.log.error({ err }, 'request failed');
-      const status =
-        typeof err.statusCode === 'number' && err.statusCode >= 400 && err.statusCode < 600
-          ? err.statusCode
-          : 500;
-      reply.code(status).send({
-        error: status >= 500 ? 'internal error' : err.name || 'error',
-        code: err.code ?? 'INTERNAL',
-      });
-    });
-  }
+  // Uniform ErrorResponse envelope ({error, code, message?}) for all
+  // unhandled errors. Registered in both dev and prod: dev includes
+  // `message` for faster debugging, prod hides it for 5xx (no stack
+  // traces or env strings leaking via err.message — see hardening.e2e
+  // `error handler: in prod mode a thrown error yields 500 with no stack`).
+  app.setErrorHandler((err: Error & { statusCode?: number; code?: string }, req, reply) => {
+    req.log.error({ err }, 'request failed');
+    const status =
+      typeof err.statusCode === 'number' && err.statusCode >= 400 && err.statusCode < 600
+        ? err.statusCode
+        : 500;
+    const body: { error: string; code: string; message?: string } = {
+      error: status >= 500 ? 'internal error' : err.name || 'error',
+      code: err.code ?? 'INTERNAL',
+    };
+    if (config.dev || status < 500) body.message = err.message;
+    reply.code(status).send(body);
+  });
 }

--- a/apps/server/src/openapi/route.ts
+++ b/apps/server/src/openapi/route.ts
@@ -48,7 +48,7 @@ export async function openapiRoute(app: FastifyInstance, ctx: AppContext): Promi
 
   app.get('/docs/api', async (_req, reply) => {
     if (!ctx.config.dev && !ctx.config.openapiPublic) {
-      return reply.code(404).send({ error: 'not found' });
+      return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
     }
     reply.type('text/html; charset=utf-8');
     return DOCS_HTML;

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -132,6 +132,35 @@ export const StatsResponse = registry.register(
   }),
 );
 
+/**
+ * Uniform error envelope returned for every non-success response.
+ *
+ * - `error`: short machine-readable identifier (e.g. `'invalid request'`,
+ *   `'browser_required'`). Stable across releases; integrators may match
+ *   on it for backwards-compatibility, but new code should prefer `code`.
+ * - `code`: stable error code in `SCREAMING_SNAKE_CASE`. Use this for
+ *   programmatic branching. Codes currently in use:
+ *   - **Public claim API**: `INVALID_REQUEST`, `INVALID_ADDRESS`,
+ *     `INTEGRATOR_AUTH_FAILED`, `HASHCASH_DISABLED`, `BROWSER_REQUIRED`,
+ *     `ORIGIN_NOT_ALLOWED`, `CLAIM_IN_PROGRESS`, `SEND_FAILED`,
+ *     `DRIVER_NOT_READY`, `NOT_FOUND`, `TLS_REQUIRED`.
+ *   - **Admin API**: `UNAUTHORIZED`, `CSRF_TOKEN_MISSING`,
+ *     `CSRF_TOKEN_MISMATCH`, `TOTP_NOT_ENROLLED`, `TOTP_STEP_UP_REQUIRED`,
+ *     `INVALID_TOTP`, `INVALID_CREDENTIALS`, `ADMIN_NOT_CONFIGURED`,
+ *     `ALREADY_ENROLLED`, `PASSWORD_REQUIRED`, `INVALID_QUERY`,
+ *     `INVALID_BODY`, `INTEGRATOR_EXISTS`, `CONCURRENT_ROTATION`,
+ *     `METRICS_DISABLED`.
+ *   - **Fallback** (unhandled errors via `setErrorHandler`): `INTERNAL`.
+ * - `message`: human-readable detail. Always present for 4xx; suppressed
+ *   for unhandled 5xx in production (no stack/secret leakage) but
+ *   included in dev mode. Optional and informative — never rely on its
+ *   wording.
+ *
+ * The public claim-reject path (`POST /v1/claim` with `decision='deny'`
+ * or `'review'`) returns `{id, status: 'rejected'}` instead, by design
+ * (SECURITY.md "Public-API silence on rejection"). Status responses for
+ * non-error 4xx/5xx (e.g. challenge body) use route-specific schemas.
+ */
 export const ErrorResponse = registry.register(
   'ErrorResponse',
   z.object({

--- a/apps/server/src/routes/admin/account.ts
+++ b/apps/server/src/routes/admin/account.ts
@@ -47,13 +47,13 @@ export async function adminAccountRoutes(app: FastifyInstance, ctx: AppContext):
     { bodyLimit: 32 * 1024, preHandler: [requireAdminCsrf(ctx), requireTotpStepUp(ctx)] },
     async (req, reply) => {
       const parsed = SendBody.safeParse(req.body);
-      if (!parsed.success) return reply.code(400).send({ error: 'invalid body' });
+      if (!parsed.success) return reply.code(400).send({ error: 'invalid body', code: 'INVALID_BODY' });
       const { to, amountLuna, memo } = parsed.data;
       let address: string;
       try {
         address = ctx.driver.parseAddress(to);
       } catch (err) {
-        return reply.code(400).send({ error: 'invalid address', message: (err as Error).message });
+        return reply.code(400).send({ error: 'invalid address', code: 'INVALID_ADDRESS', message: (err as Error).message });
       }
       const amount =
         typeof amountLuna === 'string' ? BigInt(amountLuna) : BigInt(amountLuna);

--- a/apps/server/src/routes/admin/audit.ts
+++ b/apps/server/src/routes/admin/audit.ts
@@ -7,7 +7,7 @@ import { AuditListQuery as ListQuery } from '../../openapi/schemas.js';
 export async function adminAuditRoutes(app: FastifyInstance, ctx: AppContext): Promise<void> {
   app.get('/admin/audit-log', async (req, reply) => {
     const parsed = ListQuery.safeParse(req.query);
-    if (!parsed.success) return reply.code(400).send({ error: 'invalid query' });
+    if (!parsed.success) return reply.code(400).send({ error: 'invalid query', code: 'INVALID_QUERY' });
     const { limit, offset } = parsed.data;
     const rows = await ctx.db
       .select()

--- a/apps/server/src/routes/admin/auth.ts
+++ b/apps/server/src/routes/admin/auth.ts
@@ -73,7 +73,7 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
     async (req, reply) => {
       const parsed = LoginBody.safeParse(req.body);
       if (!parsed.success) {
-        return reply.code(400).send({ error: 'invalid body' });
+        return reply.code(400).send({ error: 'invalid body', code: 'INVALID_BODY' });
       }
       const { password, totp } = parsed.data;
 
@@ -86,10 +86,10 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
       // First-login seeding.
       if (!existing) {
         if (!ctx.config.adminPassword) {
-          return reply.code(403).send({ error: 'admin not configured' });
+          return reply.code(403).send({ error: 'admin not configured', code: 'ADMIN_NOT_CONFIGURED' });
         }
         if (!safeEqualUtf8(password, ctx.config.adminPassword)) {
-          return reply.code(401).send({ error: 'invalid credentials' });
+          return reply.code(401).send({ error: 'invalid credentials', code: 'INVALID_CREDENTIALS' });
         }
         const { hash, salt } = await hashPassword(password);
         const secret = ctx.config.adminTotpSecret || genTotpSecret();
@@ -126,13 +126,13 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
       // Subsequent logins: password + TOTP (if enrolled).
       const ok = await verifyPassword(password, existing.passwordHash, existing.passwordSalt);
       if (!ok) {
-        return reply.code(401).send({ error: 'invalid credentials' });
+        return reply.code(401).send({ error: 'invalid credentials', code: 'INVALID_CREDENTIALS' });
       }
       // Unified error for all TOTP failures — prevents authentication
       // enumeration where distinct messages reveal password correctness
       // or TOTP enrolment status (#55).
       if (existing.totpSecret && (!totp || !verifyTotp(existing.totpSecret, totp))) {
-        return reply.code(401).send({ error: 'invalid credentials' });
+        return reply.code(401).send({ error: 'invalid credentials', code: 'INVALID_CREDENTIALS' });
       }
       const { token, expiresAt } = await issueSession(
         ctx.db,
@@ -168,11 +168,11 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
   // so it's not exploitable without knowing the configured password.
   app.post('/admin/auth/reset', async (req, reply) => {
     if (!ctx.config.dev) {
-      return reply.code(404).send({ error: 'not found' });
+      return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
     }
     const body = req.body as { password?: string } | null;
     if (!body?.password || body.password !== ctx.config.adminPassword) {
-      return reply.code(401).send({ error: 'password required' });
+      return reply.code(401).send({ error: 'password required', code: 'PASSWORD_REQUIRED' });
     }
     await ctx.db.delete(adminSessions);
     await ctx.db.delete(adminUsers);
@@ -191,7 +191,7 @@ export async function adminAuthRoutes(app: FastifyInstance, ctx: AppContext): Pr
       .where(eq(adminUsers.id, ADMIN_USER_ID))
       .limit(1);
     if (existing) {
-      return reply.code(409).send({ error: 'already enrolled' });
+      return reply.code(409).send({ error: 'already enrolled', code: 'ALREADY_ENROLLED' });
     }
     const secret = genTotpSecret();
     return reply

--- a/apps/server/src/routes/admin/blocklist.ts
+++ b/apps/server/src/routes/admin/blocklist.ts
@@ -14,7 +14,7 @@ import {
 export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext): Promise<void> {
   app.get('/admin/blocklist', async (req, reply) => {
     const parsed = ListQuery.safeParse(req.query);
-    if (!parsed.success) return reply.code(400).send({ error: 'invalid query' });
+    if (!parsed.success) return reply.code(400).send({ error: 'invalid query', code: 'INVALID_QUERY' });
     const { limit, offset } = parsed.data;
     const rows = await ctx.db
       .select()
@@ -31,7 +31,7 @@ export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext
     { bodyLimit: 32 * 1024, preHandler: requireAdminCsrf(ctx) },
     async (req, reply) => {
       const parsed = CreateBody.safeParse(req.body);
-      if (!parsed.success) return reply.code(400).send({ error: 'invalid body' });
+      if (!parsed.success) return reply.code(400).send({ error: 'invalid body', code: 'INVALID_BODY' });
       const id = nanoid();
       let expiresAt: Date | null = null;
       if (parsed.data.expiresAt !== undefined) {
@@ -40,7 +40,7 @@ export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext
             ? new Date(parsed.data.expiresAt)
             : new Date(parsed.data.expiresAt);
         if (Number.isNaN(d.getTime())) {
-          return reply.code(400).send({ error: 'invalid expiresAt' });
+          return reply.code(400).send({ error: 'invalid expiresAt', code: 'INVALID_BODY' });
         }
         expiresAt = d;
       }
@@ -71,7 +71,7 @@ export async function adminBlocklistRoutes(app: FastifyInstance, ctx: AppContext
     async (req, reply) => {
       const { id } = req.params as { id: string };
       const [row] = await ctx.db.select().from(blocklist).where(eq(blocklist.id, id)).limit(1);
-      if (!row) return reply.code(404).send({ error: 'not found' });
+      if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
       await ctx.db.delete(blocklist).where(eq(blocklist.id, id));
       await writeAudit(ctx.db, {
         actor: req.adminUser?.id ?? 'admin',

--- a/apps/server/src/routes/admin/claims.ts
+++ b/apps/server/src/routes/admin/claims.ts
@@ -9,7 +9,7 @@ import { ClaimsListQuery as ListQuery } from '../../openapi/schemas.js';
 export async function adminClaimsRoutes(app: FastifyInstance, ctx: AppContext): Promise<void> {
   app.get('/admin/claims', async (req, reply) => {
     const parsed = ListQuery.safeParse(req.query);
-    if (!parsed.success) return reply.code(400).send({ error: 'invalid query' });
+    if (!parsed.success) return reply.code(400).send({ error: 'invalid query', code: 'INVALID_QUERY' });
     const { limit, offset, status, decision, address } = parsed.data;
 
     const conds: SQL[] = [];
@@ -48,7 +48,7 @@ export async function adminClaimsRoutes(app: FastifyInstance, ctx: AppContext): 
   app.get('/admin/claims/:id/explain', async (req, reply) => {
     const { id } = req.params as { id: string };
     const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
-    if (!row) return reply.code(404).send({ error: 'not found' });
+    if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
     let signals: unknown = {};
     try {
       signals = JSON.parse(row.signalsJson);
@@ -64,7 +64,7 @@ export async function adminClaimsRoutes(app: FastifyInstance, ctx: AppContext): 
     async (req, reply) => {
       const { id } = req.params as { id: string };
       const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
-      if (!row) return reply.code(404).send({ error: 'not found' });
+      if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
       await ctx.db
         .update(claims)
         .set({ status: 'manual-allow', decision: 'allow', rejectionReason: null })
@@ -87,7 +87,7 @@ export async function adminClaimsRoutes(app: FastifyInstance, ctx: AppContext): 
       const body = (req.body ?? {}) as { reason?: string };
       const reason = typeof body.reason === 'string' ? body.reason.slice(0, 256) : 'manual deny';
       const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
-      if (!row) return reply.code(404).send({ error: 'not found' });
+      if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
       await ctx.db
         .update(claims)
         .set({ status: 'rejected', decision: 'deny', rejectionReason: reason })

--- a/apps/server/src/routes/admin/config.ts
+++ b/apps/server/src/routes/admin/config.ts
@@ -40,7 +40,7 @@ export async function adminConfigRoutes(app: FastifyInstance, ctx: AppContext): 
     async (req, reply) => {
       const parsed = PatchBody.safeParse(req.body);
       if (!parsed.success) {
-        return reply.code(400).send({ error: 'invalid body', issues: parsed.error.issues });
+        return reply.code(400).send({ error: 'invalid body', code: 'INVALID_BODY', issues: parsed.error.issues });
       }
       const entries = Object.entries(parsed.data);
       for (const [k, v] of entries) {

--- a/apps/server/src/routes/admin/integrators.ts
+++ b/apps/server/src/routes/admin/integrators.ts
@@ -42,14 +42,14 @@ export async function adminIntegratorsRoutes(
     { bodyLimit: 32 * 1024, preHandler: [requireAdminCsrf(ctx), requireTotpStepUp(ctx)] },
     async (req, reply) => {
       const parsed = CreateBody.safeParse(req.body);
-      if (!parsed.success) return reply.code(400).send({ error: 'invalid body' });
+      if (!parsed.success) return reply.code(400).send({ error: 'invalid body', code: 'INVALID_BODY' });
       const { id } = parsed.data;
       const [existing] = await ctx.db
         .select()
         .from(integratorKeys)
         .where(eq(integratorKeys.id, id))
         .limit(1);
-      if (existing) return reply.code(409).send({ error: 'integrator exists' });
+      if (existing) return reply.code(409).send({ error: 'integrator exists', code: 'INTEGRATOR_EXISTS' });
       const apiKey = mintApiKey();
       const hmacSecret = mintHmacSecret();
       await ctx.db.insert(integratorKeys).values({
@@ -77,7 +77,7 @@ export async function adminIntegratorsRoutes(
     async (req, reply) => {
       const { id } = req.params as { id: string };
       const [row] = await ctx.db.select().from(integratorKeys).where(eq(integratorKeys.id, id)).limit(1);
-      if (!row) return reply.code(404).send({ error: 'not found' });
+      if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
       const apiKey = mintApiKey();
       const hmacSecret = mintHmacSecret();
       // Optimistic locking: only update if the key hash hasn't changed
@@ -89,7 +89,7 @@ export async function adminIntegratorsRoutes(
         .where(and(eq(integratorKeys.id, id), eq(integratorKeys.apiKeyHash, row.apiKeyHash)))
         .run();
       if ((result as { changes?: number }).changes === 0) {
-        return reply.code(409).send({ error: 'concurrent rotation detected, retry' });
+        return reply.code(409).send({ error: 'concurrent rotation detected, retry', code: 'CONCURRENT_ROTATION' });
       }
       await writeAudit(ctx.db, {
         actor: req.adminUser?.id ?? 'admin',
@@ -110,7 +110,7 @@ export async function adminIntegratorsRoutes(
     async (req, reply) => {
       const { id } = req.params as { id: string };
       const [row] = await ctx.db.select().from(integratorKeys).where(eq(integratorKeys.id, id)).limit(1);
-      if (!row) return reply.code(404).send({ error: 'not found' });
+      if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
       await ctx.db
         .update(integratorKeys)
         .set({ revokedAt: new Date() })

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -49,7 +49,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     },
   }, async (req, reply) => {
     if (!ctx.config.hashcashSecret) {
-      return reply.code(404).send({ error: 'hashcash not enabled' });
+      return reply.code(404).send({ error: 'hashcash not enabled', code: 'HASHCASH_DISABLED' });
     }
     // Browser-only enforcement for challenge minting too.
     if (ctx.config.requireBrowser) {
@@ -58,6 +58,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       if (!hasIntegratorAuth && !req.headers['sec-fetch-site']) {
         return reply.code(403).send({
           error: 'browser_required',
+          code: 'BROWSER_REQUIRED',
           message: 'Challenges must be requested from a browser.',
         });
       }
@@ -101,6 +102,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         if (!secFetchSite) {
           return reply.code(403).send({
             error: 'browser_required',
+            code: 'BROWSER_REQUIRED',
             message: 'Claims must be submitted from a browser. Use the ClaimUI or an authorized integrator SDK.',
           });
         }
@@ -120,6 +122,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         ) {
           return reply.code(403).send({
             error: 'origin_not_allowed',
+            code: 'ORIGIN_NOT_ALLOWED',
             message: 'Request origin is not in the allowed list.',
           });
         }
@@ -131,7 +134,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     const parsed = ClaimBody.safeParse(req.body);
     if (!parsed.success) {
       await padRejectDelay(requestStart, T_min);
-      return reply.code(400).send({ error: 'invalid request' });
+      return reply.code(400).send({ error: 'invalid request', code: 'INVALID_REQUEST' });
     }
 
     let integratorId: string | undefined;
@@ -168,7 +171,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       });
       if (!result.ok) {
         await padRejectDelay(requestStart, T_min);
-        return reply.code(401).send({ error: 'integrator auth failed' });
+        return reply.code(401).send({ error: 'integrator auth failed', code: 'INTEGRATOR_AUTH_FAILED' });
       }
       integratorId = result.integratorId;
       hostContextVerified = true;
@@ -209,7 +212,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       address = ctx.driver.parseAddress(parsed.data.address);
     } catch {
       await padRejectDelay(requestStart, T_min);
-      return reply.code(400).send({ error: 'invalid address' });
+      return reply.code(400).send({ error: 'invalid address', code: 'INVALID_ADDRESS' });
     }
 
     // Idempotency lookup (#86). Scoped by:
@@ -338,6 +341,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     if (inflightClaims.has(address)) {
       return reply.code(429).send({
         error: 'claim_in_progress',
+        code: 'CLAIM_IN_PROGRESS',
         message: 'A claim for this address is already being processed. Try again shortly.',
       });
     }
@@ -352,6 +356,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         await padRejectDelay(requestStart, T_min);
         return reply.code(400).send({
           error: 'invalid address',
+          code: 'INVALID_ADDRESS',
           message: 'Address rejected by the network (invalid checksum or format)',
         });
       }
@@ -378,6 +383,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         id,
         status: 'error',
         error: 'send_failed',
+        code: 'SEND_FAILED',
         message: 'Faucet is temporarily unavailable. Please try again shortly.',
       });
     }
@@ -424,7 +430,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
   app.get('/v1/claim/:id', async (req, reply) => {
     const { id } = req.params as { id: string };
     const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
-    if (!row) return reply.code(404).send({ error: 'not found' });
+    if (!row) return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
     // Public claim-status response intentionally omits `decision` and
     // `rejectionReason`. Operators querying for granular abuse-pipeline
     // attribution use the admin endpoints (/v1/admin/claims/:id).

--- a/apps/server/src/ui.ts
+++ b/apps/server/src/ui.ts
@@ -168,7 +168,7 @@ export async function registerUi(app: FastifyInstance, config: ServerConfig): Pr
       url === '/readyz' ||
       url === '/llms.txt'
     ) {
-      return reply.code(404).send({ error: 'not found' });
+      return reply.code(404).send({ error: 'not found', code: 'NOT_FOUND' });
     }
     // Strip query string + leading slash; reject path-traversal attempts.
     const pathOnly = url.split('?')[0]?.replace(/^\/+/, '') ?? '';

--- a/packages/sdk-flutter/test/client_test.dart
+++ b/packages/sdk-flutter/test/client_test.dart
@@ -80,13 +80,12 @@ void main() {
   });
 
   group('FaucetException', () {
-    test('toString includes status, code, and decision when present', () {
-      const err = FaucetException('denied', status: 403, code: 'abuse', decision: 'deny');
+    test('toString includes status, message, and code when present', () {
+      const err = FaucetException('denied', status: 403, code: 'INVALID_REQUEST');
       final s = err.toString();
       expect(s, contains('403'));
       expect(s, contains('denied'));
-      expect(s, contains('abuse'));
-      expect(s, contains('deny'));
+      expect(s, contains('INVALID_REQUEST'));
     });
   });
 }

--- a/packages/sdk-python/nimiq_faucet/client.py
+++ b/packages/sdk-python/nimiq_faucet/client.py
@@ -148,5 +148,4 @@ class FaucetClient:
                 status=e.code,
                 message=err_body.get("error") or err_body.get("message") or str(e),
                 code=err_body.get("code", ""),
-                decision=err_body.get("decision", ""),
             ) from e

--- a/packages/sdk-python/nimiq_faucet/errors.py
+++ b/packages/sdk-python/nimiq_faucet/errors.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 
 class FaucetError(Exception):
-    """Raised for non-2xx server responses."""
+    """Raised for non-2xx server responses.
 
-    def __init__(self, status: int, message: str, code: str = "", decision: str = ""):
+    Mirrors the server's uniform ``ErrorResponse`` envelope
+    (``{error, code?, message?}``). ``status`` is the HTTP status code;
+    ``message`` is the human-readable detail; ``code`` is the stable
+    ``SCREAMING_SNAKE_CASE`` identifier for programmatic branching.
+    """
+
+    def __init__(self, status: int, message: str, code: str = ""):
         self.status = status
         self.message = message
         self.code = code
-        self.decision = decision
         super().__init__(f"faucet error: {status} {message}" + (f" ({code})" if code else ""))

--- a/packages/sdk-ts/src/claimManager.ts
+++ b/packages/sdk-ts/src/claimManager.ts
@@ -6,6 +6,7 @@
  * this with its own reactivity primitives (useState / ref).
  */
 import type { ClaimOptions, ClaimResponse, ClaimStatus } from './index.js';
+import { FaucetError } from './index.js';
 
 export type FaucetClaimClient = {
   claim(address: string, options?: ClaimOptions): Promise<ClaimResponse>;
@@ -16,7 +17,7 @@ export interface ClaimState {
   status: 'idle' | 'pending' | ClaimStatus;
   id: string | null;
   txId: string | null;
-  error: Error | null;
+  error: FaucetError | null;
 }
 
 const INITIAL_STATE: ClaimState = {
@@ -63,7 +64,22 @@ export class ClaimManager {
         });
       }
     } catch (err) {
-      this.#set({ error: err as Error, status: 'rejected' });
+      // Wrap so consumers always get a FaucetError off ClaimState.error.
+      // FaucetClient.#handle throws FaucetError for non-2xx responses; fetch
+      // failures (offline, DNS, abort) raise generic Error/DOMException — we
+      // surface those with status=0 and a synthetic code so integrators can
+      // still branch on `err.code`.
+      const faucetErr =
+        err instanceof FaucetError
+          ? err
+          : new FaucetError(
+              err instanceof Error ? err.message : String(err),
+              0,
+              (err as { name?: string } | null)?.name === 'AbortError'
+                ? 'ABORTED'
+                : 'NETWORK_ERROR',
+            );
+      this.#set({ error: faucetErr, status: 'rejected' });
     } finally {
       this.#controller = null;
     }

--- a/packages/sdk-ts/src/statusPoller.ts
+++ b/packages/sdk-ts/src/statusPoller.ts
@@ -2,6 +2,7 @@
  * Framework-agnostic claim status poller.
  */
 import type { ClaimResponse } from './index.js';
+import { FaucetError } from './index.js';
 
 export type FaucetStatusClient = {
   status(id: string): Promise<ClaimResponse>;
@@ -9,7 +10,7 @@ export type FaucetStatusClient = {
 
 export interface StatusState {
   data: ClaimResponse | null;
-  error: Error | null;
+  error: FaucetError | null;
   loading: boolean;
 }
 
@@ -55,7 +56,18 @@ export class StatusPoller {
       const next = await this.#client.status(id);
       if (n === this.#tick) this.#set({ data: next, loading: false });
     } catch (err) {
-      if (n === this.#tick) this.#set({ error: err as Error, loading: false });
+      if (n !== this.#tick) return;
+      const faucetErr =
+        err instanceof FaucetError
+          ? err
+          : new FaucetError(
+              err instanceof Error ? err.message : String(err),
+              0,
+              (err as { name?: string } | null)?.name === 'AbortError'
+                ? 'ABORTED'
+                : 'NETWORK_ERROR',
+            );
+      this.#set({ error: faucetErr, loading: false });
     }
   }
 


### PR DESCRIPTION
## Summary

- **Uniform error envelope**: every server error response now returns `{error, code, message?}`. The `setErrorHandler` is registered in both dev and prod (dev includes `message`; prod 5xx still hides it). Every ad-hoc `reply.code(<4xx|5xx>).send({...})` in `routes/`, `auth/middleware.ts`, `openapi/route.ts`, `ui.ts`, and `app.ts` now carries a stable `code` field (`INVALID_REQUEST`, `BROWSER_REQUIRED`, `UNAUTHORIZED`, etc.).
- **Typed-error SDK parity**: `FaucetError` / `FaucetException` is the same shape `{status, code, message}` across TS, Capacitor, React Native, Go, Flutter, Python. Drops the speculative `decision` field from Python (the server never emits it publicly — see SECURITY.md "Public-API silence on rejection") and fixes the live `dart analyze` regression where the Flutter test referenced a non-existent `decision` constructor param.
- **React/Vue hook error narrowing**: `ClaimState.error` and `StatusState.error` in `@nimiq-faucet/sdk` are now `FaucetError | null` (were `Error | null`). Network/abort errors get wrapped with synthetic `NETWORK_ERROR` / `ABORTED` codes so the hook contract is uniform.
- **OpenAPI**: `ErrorResponse` schema gets a JSDoc enum of all error codes so integrators can branch on `err.code` deterministically.

Preserved by design: the uniform public reject body (`{id, status: 'rejected'}` at `claim.ts:306`) and the 202 challenge body — both are SECURITY.md guarantees enforced by `claim-rejection-uniformity.e2e.test.ts`.

Closes ROADMAP §2.3.6.

## Test plan

- [x] `pnpm pre-merge` — 61/61 tasks green, server 162/162 tests passing (incl. `hardening.e2e` and `claim-rejection-uniformity.e2e`).
- [x] `dart analyze` clean on `packages/sdk-flutter`; `dart test` 7/7 passing.
- [x] `python3 -m unittest discover` on `packages/sdk-python` — 7/7 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)