### PR TITLE
docs(snippets): redirect dead /snippets/<framework> links to playground SDK pages (§2.3.9, closes §1.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Each layer emits signals that can be inspected per claim in the dashboard and re
 - MCP server at `/mcp` — `faucet.claim`, `faucet.stats`, `faucet.explain_decision`, `faucet.balance`, `faucet.block_address`, etc. Point Claude Code / Cursor / any MCP client at it.
 - `AGENTS.md` — one-prompt recipes for adding a faucet to a new app.
 - `/llms.txt` and `/llms-full.txt` — stable, scrapable integration surface for web-search-based coding agents.
-- Per-framework snippet pages at `/snippets/<framework>` regenerated on each release.
+- Per-framework SDK pages in the [developer playground](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/) — code recipes for TS, React, Vue, Capacitor, React Native, Flutter, Go, Python.
 
 ## Repository layout
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -238,9 +238,9 @@ we go the shared-wallet route).
 
 ### 1.2.2 Live `/snippets/<framework>` URLs
 
-**Status:** → absorbed into §3.0.3 (interactive SDK showcase in the playground).
+**Status:** ✅ done by substitution. The `scripts/generate-snippets.mts` generator was never built; the playground SDK showcase (§3.0.3, shipped in v2.2.1) covers the same need with per-framework pages at [playground/frameworks/](apps/playground/frameworks/). Remaining dead `/snippets/` links were cleaned up in §2.3.9.
 
-**Goal:** the "latest working snippet" URL referenced from each integration doc is actually generated and served.
+**Original goal:** the "latest working snippet" URL referenced from each integration doc is actually generated and served.
 
 **Scope:**
 - New `scripts/generate-snippets.mts` at the repo root that:
@@ -678,11 +678,9 @@ form. Narrower than §1.8.2 (issue #58, the full config-catalog refactor)
 
 ### 2.3.9 `/snippets/<framework>` link cleanup
 
-**Goal:** close out §1.2.2. The planned `scripts/generate-snippets.mts`
-never shipped — the work was absorbed into §3.0.3 (the playground SDK
-showcase, which did ship). Audit `docs/`, `apps/docs/`, and AGENTS.md
-for any reference to a live `/snippets/<framework>` URL and point it at
-the playground SDK pages (or drop it). Mark §1.2.2 done-by-substitution.
+**Status:** ✅ shipped in v2.3.1. Dead `/snippets/<framework>` references in [apps/docs/public/llms.txt](apps/docs/public/llms.txt) and [README.md](README.md) were redirected to the live playground SDK pages at `https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/<name>`. Python added to the list (previously only TS/React/Vue/Capacitor/RN/Flutter/Go). §1.2.2 marked done-by-substitution above. While in `llms.txt`, also corrected the public claim response field list to match §2.3.6's uniform reject envelope (removed `decision`, `reason`).
+
+**Original goal:** close out §1.2.2. The planned `scripts/generate-snippets.mts` never shipped — the work was absorbed into §3.0.3 (the playground SDK showcase, which did ship). Audit `docs/`, `apps/docs/`, and AGENTS.md for any reference to a live `/snippets/<framework>` URL and point it at the playground SDK pages (or drop it).
 
 **Estimated effort:** ~30 min.
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -27,18 +27,19 @@ Content-Type: application/json
 }
 ```
 
-Response: `{ id, status, txId?, decision?, reason? }`. Poll `GET /v1/claim/:id` or subscribe to `WS /v1/stream` for confirmation.
+Response: `{ id, status, txId? }`. Poll `GET /v1/claim/:id` or subscribe to `WS /v1/stream` for confirmation. Errors return `{ error, code, message? }` with a stable SCREAMING_SNAKE_CASE `code`.
 
 ## Integration recipes
 
-- TS / Node / browser: [/snippets/typescript](./snippets/typescript)
-- React: [/snippets/react](./snippets/react)
-- Vue 3: [/snippets/vue](./snippets/vue)
-- Capacitor: [/snippets/capacitor](./snippets/capacitor)
-- React Native: [/snippets/react-native](./snippets/react-native)
-- Flutter: [/snippets/flutter](./snippets/flutter)
-- Go backend: [/snippets/go](./snippets/go)
+- TS / Node / browser: [Playground — TypeScript SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/typescript)
+- React: [Playground — React SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/react)
+- Vue 3: [Playground — Vue SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/vue)
+- Capacitor: [Playground — Capacitor SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/capacitor)
+- React Native: [Playground — React Native SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/react-native)
+- Flutter: [Playground — Flutter SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/flutter)
+- Go backend: [Playground — Go SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/go)
+- Python backend: [Playground — Python SDK](https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/python)
 
 ## Full reference
 
-Fetch `/openapi.json` for the authoritative schema or `/llms-full.txt` for an LLM-ready flat dump of docs, snippets and decisions.
+Fetch `/openapi.json` for the authoritative schema or `/llms-full.txt` for an LLM-ready flat dump of docs and decisions.


### PR DESCRIPTION
## Summary

Closes out **§2.3.9** and marks **§1.2.2 done-by-substitution** — the planned `scripts/generate-snippets.mts` (§1.2.2) was never built; the playground SDK showcase (§3.0.3, shipped in v2.2.1) covers the same use case. This PR audits the codebase for dead `/snippets/<framework>` references and points them at the live playground.

## Changes

- **[apps/docs/public/llms.txt](apps/docs/public/llms.txt) L34-L40** — 7 dead framework links → absolute URLs to `https://panoramicrum.github.io/nimiq-simple-faucet/frameworks/<name>`
- **[apps/docs/public/llms.txt](apps/docs/public/llms.txt) +Python** — added Python as an 8th framework. The playground page [apps/playground/frameworks/python.md](apps/playground/frameworks/python.md) exists but llms.txt didn't surface it.
- **[apps/docs/public/llms.txt](apps/docs/public/llms.txt) L30** — corrected the public claim response field list to match §2.3.6's uniform reject envelope (dropped `decision`, `reason`; mentioned the error envelope shape).
- **[apps/docs/public/llms.txt](apps/docs/public/llms.txt) L44** — removed "snippets and" from the "/llms-full.txt" prose.
- **[README.md](README.md) L126** — rewrote prose from "Per-framework snippet pages at `/snippets/<framework>` regenerated on each release" to a link to the playground frameworks index.
- **[ROADMAP.md](ROADMAP.md) §1.2.2** — marked ✅ done-by-substitution.
- **[ROADMAP.md](ROADMAP.md) §2.3.9** — marked ✅ shipped in v2.3.1.

## Test plan

- [x] `grep -rEn "/snippets/" .` returns no live references outside ROADMAP/CHANGELOG (historical context only)
- [x] Every `apps/playground/frameworks/<name>.md` referenced in `llms.txt` exists on disk
- [ ] CI green
- [ ] Visual diff review on `llms.txt` to ensure the rendered LLM-discoverable surface still reads well