### PR TITLE
docs(mcp): enumerate tools, auth model, client config (§2.3.7a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ When you need exact wire shape, SDK surface, or behaviour — consult these, in 
 - **API wire shape:** `GET /openapi.json` on a running instance, or the frozen [packages/openapi/openapi.yaml](packages/openapi/openapi.yaml).
 - **Per-package contract:** `packages/<name>/README.md` + `packages/<name>/llms.txt`.
 - **Machine-readable overview:** `/llms.txt` and `/llms-full.txt` served by the faucet.
+- **MCP server:** [docs/mcp.md](docs/mcp.md) enumerates the 9 tools (3 public + 6 admin), the auth model, and client config snippets.
 - **Anti-fraud details:** [docs/fraud-prevention.md](docs/fraud-prevention.md).
 
 ## Stable facts (do not invent alternatives)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -642,7 +642,9 @@ envelope isn't uniform.
 
 ### 2.3.7 MCP tool docs + schema linkage
 
-**Goal:** an agent integrator can read what `/mcp` exposes without
+**Status:** docs half (a) shipped in v2.3.1 — [docs/mcp.md](docs/mcp.md) enumerates the 3 public + 6 admin tools, their input/output shapes, the resources channel, the auth model (session+TOTP step-up vs deprecated static `FAUCET_ADMIN_MCP_TOKEN`), and client config snippets for Claude Code / Cursor / curl. AGENTS.md + llms.txt link to it. Schema-derivation half (b) — replacing the inline Zod in `apps/server/src/mcp/server.ts` with imports from canonical REST schemas — is the follow-up PR also in v2.3.1.
+
+**Original goal:** an agent integrator can read what `/mcp` exposes without
 introspecting the protocol, and the tool schemas can't drift from the
 REST schemas. Today `AGENTS.md` mentions `/mcp` but doesn't enumerate
 the tools; tool input schemas are inline Zod, not derived from the REST

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -39,6 +39,10 @@ Response: `{ id, status, txId?, decision?, reason? }`. Poll `GET /v1/claim/:id` 
 - Flutter: [/snippets/flutter](./snippets/flutter)
 - Go backend: [/snippets/go](./snippets/go)
 
+## MCP server
+
+`POST /mcp` exposes 9 tools (3 public + 6 admin) for AI coding assistants — claim history, abuse decisions, stats, and with admin auth: blocklist + send-tx. Discovery: `GET /mcp`. See [docs/mcp.md](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/docs/mcp.md) for the full tool catalogue, auth model (session+TOTP step-up vs deprecated static token), and client config snippets.
+
 ## Full reference
 
 Fetch `/openapi.json` for the authoritative schema or `/llms-full.txt` for an LLM-ready flat dump of docs, snippets and decisions.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,171 @@
+# MCP server reference
+
+The faucet exposes a [Model Context Protocol](https://modelcontextprotocol.io) server at `/mcp` so AI coding assistants (Claude Code, Cursor, Continue, any MCP client) can read claim history, inspect abuse decisions, and — with admin auth — drive blocklist and send-tx operations.
+
+Source: [apps/server/src/mcp/](../apps/server/src/mcp/) — [server.ts](../apps/server/src/mcp/server.ts) defines the tools, [index.ts](../apps/server/src/mcp/index.ts) wires them onto Fastify with auth.
+
+## Transport
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /mcp` | Discovery — returns `{ name, version, transport: 'streamable-http', tools: [{name, admin}] }`. Lightweight enough to put behind a marketing-site link or a curl one-liner. |
+| `POST /mcp` | The MCP transport. Streamable HTTP (JSON-RPC over HTTP with optional SSE). Stateless: one transport per request, no session IDs. |
+
+`POST /mcp` shares the `adminLoginRatePerMinute` rate-limit bucket (per-IP) with `/admin/auth/login`. Every admin tool call is written to the audit log naming the resolved principal.
+
+## Auth model
+
+Public tools are unauthenticated. Admin tools require an `AdminPrincipal`, resolved upstream by [apps/server/src/mcp/index.ts](../apps/server/src/mcp/index.ts) — two paths, tried in order:
+
+1. **Admin session + TOTP step-up** (preferred, tracked at #88). Client sends the `__Host-faucet_session` cookie obtained from `POST /admin/auth/login`. The session must have a fresh TOTP step-up within `FAUCET_ADMIN_TOTP_STEP_UP_TTL_MS`, either persisted on the session row or supplied as `x-faucet-totp: <code>` on the same request.
+2. **Static `FAUCET_ADMIN_MCP_TOKEN`** (deprecated fallback). Sent via `x-faucet-admin-token: <token>`. Only honoured when `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN=true`. Kept so existing deployments don't break across the v1 → v2 admin-auth rewrite; flip the flag to `false` once your MCP clients are on the session path.
+
+If no admin auth is presented (or it fails), public tools still work but admin tools return an MCP tool-call error of `Admin MCP auth required`.
+
+## Tools
+
+There are **9 tools**: 3 public, 6 admin-scoped.
+
+### Public
+
+#### `faucet.status`
+
+Fetch a single claim by id.
+
+```ts
+input:  { id: string }
+output: { id, status, address, amountLuna, txId, createdAt, decision, rejectionReason }
+        | { error: 'not found', id }
+```
+
+#### `faucet.recent_claims`
+
+List recent claims with PII stripped (no IP, no user-agent). Includes the abuse `decision`, `abuseScore`, and full structured `signals` JSON so an agent can reason about how a claim was scored.
+
+```ts
+input:  { limit?: number (1..200, default 20) }
+output: Array<{ id, createdAt, address, amountLuna, status, txId,
+                decision, abuseScore, signals, integratorId }>
+```
+
+#### `faucet.stats`
+
+Aggregate counts across the most recent 100 claims.
+
+```ts
+input:  {}
+output: { total, byStatus: Record<string, number>, byDecision: Record<string, number> }
+```
+
+### Admin-scoped
+
+Every call below requires an `AdminPrincipal` (see [Auth model](#auth-model)) and is written to the audit log.
+
+#### `faucet.balance`
+
+Faucet wallet balance in Luna (decimal string — `BigInt`-compatible).
+
+```ts
+input:  {}
+output: { balanceLuna: string }
+```
+
+#### `faucet.send`
+
+Send Luna out of the faucet wallet. Validates the address through the active currency driver before broadcasting.
+
+```ts
+input:  { to: string, amountLuna: string /* decimal integer */ }
+output: { txId: string, to: string, amountLuna: string }
+```
+
+#### `faucet.block_address`
+
+Add an entry to the blocklist.
+
+```ts
+input:  { kind: 'ip' | 'address' | 'uid' | 'asn' | 'country',
+          value: string,
+          reason?: string,
+          expiresAt?: number /* ms epoch */ }
+output: { id: string, kind, value }
+```
+
+#### `faucet.unblock_address`
+
+Remove blocklist entries matching `(kind, value)`. Multiple rows with the same key are all deleted.
+
+```ts
+input:  { kind: 'ip' | 'address' | 'uid' | 'asn' | 'country', value: string }
+output: { removed: { kind, value } }
+```
+
+#### `faucet.list_blocks`
+
+Enumerate blocklist entries, newest first.
+
+```ts
+input:  { limit?: number (1..1000, default 100) }
+output: Array<{ id, kind, value, reason, expiresAt, createdAt }>
+```
+
+#### `faucet.explain_decision`
+
+Return the full structured abuse-pipeline signals JSON for a claim. The same data backs the dashboard's per-claim "explain" modal.
+
+```ts
+input:  { claimId: string }
+output: { id, decision, abuseScore, rejectionReason, signals }
+        | { error: 'not found', claimId }
+```
+
+## Resources
+
+Three read-only resources are also exposed via the MCP `resources/*` channel:
+
+| URI | Description |
+|---|---|
+| `faucet://config` | Public faucet configuration — mirrors the `GET /v1/config` REST endpoint. |
+| `faucet://openapi.json` | Placeholder. The authoritative OpenAPI spec lives at `GET /openapi.json` on the running server, or in the frozen [packages/openapi/openapi.yaml](../packages/openapi/openapi.yaml). |
+| `faucet://recent-claims` | Last 50 claims (PII-sanitized). Equivalent to `faucet.recent_claims` with `limit: 50`. |
+
+## Client setup
+
+### Claude Code
+
+Add to your `~/.claude.json` (or per-project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "nimiq-faucet": {
+      "type": "http",
+      "url": "https://your-faucet.example.com/mcp"
+    }
+  }
+}
+```
+
+For admin access, log into `/admin` first (browser keeps the session cookie); Claude Code then reuses it. For headless setups (CI, scripts), provision a token via `FAUCET_ADMIN_MCP_TOKEN` and configure your client to send `x-faucet-admin-token` — but the session+TOTP path is strongly preferred for human operators.
+
+### Cursor / Continue / generic MCP clients
+
+Same shape — `transport: streamable-http`, URL `<faucet>/mcp`. Refer to your client's MCP-server docs for the exact config-file location.
+
+### curl smoke test
+
+```bash
+# Discovery
+curl https://your-faucet.example.com/mcp
+
+# Public tool: stats
+curl -X POST https://your-faucet.example.com/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"faucet.stats","arguments":{}}}'
+```
+
+## See also
+
+- [AGENTS.md](../AGENTS.md) — one-prompt recipes for integrators, including LLM-friendly framework code paths.
+- [packages/openapi/openapi.yaml](../packages/openapi/openapi.yaml) — frozen wire-format reference.
+- [/llms.txt](../apps/docs/public/llms.txt) and `/llms-full.txt` (served by the running faucet) — flat, scrapable surface for web-search agents.


### PR DESCRIPTION
## Summary

Half (a) of **§2.3.7**. Authors [docs/mcp.md](docs/mcp.md) — the canonical reference for what `/mcp` exposes, so AI-coding-assistant integrators don't have to introspect the protocol. Schema-derivation half (b) follows in a separate PR.

## Changes

- **NEW [docs/mcp.md](docs/mcp.md)** (~170 lines):
  - **Transport** — `GET /mcp` discovery + `POST /mcp` streamable HTTP with rate-limit + audit-log behaviour
  - **Auth model** — admin session + TOTP step-up (preferred, #88) vs the deprecated static `FAUCET_ADMIN_MCP_TOKEN`; exact cookie and header shapes
  - **9 tools** documented (3 public: `faucet.status`, `faucet.recent_claims`, `faucet.stats` — 6 admin: `faucet.balance`, `faucet.send`, `faucet.block_address`, `faucet.unblock_address`, `faucet.list_blocks`, `faucet.explain_decision`). Input/output Zod-equivalent shapes for each.
  - **3 resources** (`faucet://config`, `faucet://openapi.json`, `faucet://recent-claims`)
  - **Client config** snippets for Claude Code + curl smoke test
- **[AGENTS.md](AGENTS.md)** — adds an MCP bullet under "Authoritative sources" pointing at `docs/mcp.md`.
- **[apps/docs/public/llms.txt](apps/docs/public/llms.txt)** — new `## MCP server` section between framework recipes and the full-reference footer.
- **[ROADMAP.md](ROADMAP.md) §2.3.7** — marked docs half shipped; schema half remains in-flight for the follow-up PR.

## Test plan

- [x] Every tool in `apps/server/src/mcp/server.ts` is documented; every documented tool exists in source
- [x] Auth model matches `apps/server/src/mcp/index.ts:resolveAdminPrincipal` exactly (session-first, static-token fallback gated on `FAUCET_ADMIN_MCP_ALLOW_STATIC_TOKEN`)
- [x] No source code changes (pure docs)
- [ ] CI green

## Follow-up

§2.3.7b — refactor `apps/server/src/mcp/server.ts` to import canonical Zod schemas from the REST routes/schemas modules where overlap exists. The doc here will be updated to point at the canonical source per tool once that lands.