### PR TITLE
refactor(mcp): derive tool input schemas from REST Zod sources (§2.3.7b)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -642,7 +642,7 @@ envelope isn't uniform.
 
 ### 2.3.7 MCP tool docs + schema linkage
 
-**Status:** docs half (a) shipped in v2.3.1 — [docs/mcp.md](docs/mcp.md) enumerates the 3 public + 6 admin tools, their input/output shapes, the resources channel, the auth model (session+TOTP step-up vs deprecated static `FAUCET_ADMIN_MCP_TOKEN`), and client config snippets for Claude Code / Cursor / curl. AGENTS.md + llms.txt link to it. Schema-derivation half (b) — replacing the inline Zod in `apps/server/src/mcp/server.ts` with imports from canonical REST schemas — is the follow-up PR also in v2.3.1.
+**Status:** ✅ shipped in v2.3.1. Half (a) — [docs/mcp.md](docs/mcp.md) enumerates the 3 public + 6 admin tools, their input/output shapes, the resources channel, the auth model (session+TOTP step-up vs deprecated static `FAUCET_ADMIN_MCP_TOKEN`), and client config snippets for Claude Code / Cursor / curl. AGENTS.md + llms.txt link to it. Half (b) — `apps/server/src/mcp/server.ts` now derives input schemas for `faucet.send` (picks `to` from `AdminSendRequest`), `faucet.block_address` (full shape from `BlocklistCreateRequest`), and `faucet.unblock_address` (picks `kind`+`value` from `BlocklistCreateRequest`). The kind enum + value-length limits cannot drift; a new block kind added to the REST canonical schema propagates to MCP automatically. Other tools intentionally retain inline schemas where MCP needs different constraints (larger limits, no query-string coercion).
 
 **Original goal:** an agent integrator can read what `/mcp` exposes without
 introspecting the protocol, and the tool schemas can't drift from the

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -44,6 +44,10 @@ Response: `{ id, status, txId? }`. Poll `GET /v1/claim/:id` or subscribe to `WS 
 
 `POST /mcp` exposes 9 tools (3 public + 6 admin) for AI coding assistants — claim history, abuse decisions, stats, and with admin auth: blocklist + send-tx. Discovery: `GET /mcp`. See [docs/mcp.md](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/docs/mcp.md) for the full tool catalogue, auth model (session+TOTP step-up vs deprecated static token), and client config snippets.
 
+## MCP server
+
+`POST /mcp` exposes 9 tools (3 public + 6 admin) for AI coding assistants — claim history, abuse decisions, stats, and with admin auth: blocklist + send-tx. Discovery: `GET /mcp`. See [docs/mcp.md](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/docs/mcp.md) for the full tool catalogue, auth model (session+TOTP step-up vs deprecated static token), and client config snippets.
+
 ## Full reference
 
 Fetch `/openapi.json` for the authoritative schema or `/llms-full.txt` for an LLM-ready flat dump of docs and decisions.

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -44,10 +44,6 @@ Response: `{ id, status, txId? }`. Poll `GET /v1/claim/:id` or subscribe to `WS 
 
 `POST /mcp` exposes 9 tools (3 public + 6 admin) for AI coding assistants — claim history, abuse decisions, stats, and with admin auth: blocklist + send-tx. Discovery: `GET /mcp`. See [docs/mcp.md](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/docs/mcp.md) for the full tool catalogue, auth model (session+TOTP step-up vs deprecated static token), and client config snippets.
 
-## MCP server
-
-`POST /mcp` exposes 9 tools (3 public + 6 admin) for AI coding assistants — claim history, abuse decisions, stats, and with admin auth: blocklist + send-tx. Discovery: `GET /mcp`. See [docs/mcp.md](https://github.com/PanoramicRum/nimiq-simple-faucet/blob/main/docs/mcp.md) for the full tool catalogue, auth model (session+TOTP step-up vs deprecated static token), and client config snippets.
-
 ## Full reference
 
 Fetch `/openapi.json` for the authoritative schema or `/llms-full.txt` for an LLM-ready flat dump of docs and decisions.

--- a/apps/server/src/mcp/server.ts
+++ b/apps/server/src/mcp/server.ts
@@ -14,6 +14,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { blocklist, claims } from '../db/schema.js';
 import type { AppContext } from '../context.js';
 import { writeAudit } from '../auth/audit.js';
+import {
+  AdminSendRequest,
+  BlocklistCreateRequest,
+} from '../openapi/schemas.js';
 
 /** Identifies who invoked an admin-scoped MCP tool. */
 export type AdminPrincipal =
@@ -50,7 +54,9 @@ export const ALL_TOOLS: readonly string[] = [
   'faucet.explain_decision',
 ];
 
-const BLOCK_KINDS = ['ip', 'address', 'uid', 'asn', 'country'] as const;
+// Block-kind enum is the source of truth in `openapi/schemas.ts`
+// (`BlocklistCreateRequest.shape.kind`). MCP-tool schemas pick it via
+// `.shape` so a new kind added on the REST side propagates here.
 
 /**
  * Enforces the admin-principal policy for a tool call. Throws a plain `Error`
@@ -211,8 +217,12 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
     'faucet.send',
     {
       description: 'Send Luna out of the faucet wallet. Admin-scoped.',
+      // `to` derived from `AdminSendRequest` (REST: POST /admin/account/send)
+      // so address-validation changes propagate. `amountLuna` is intentionally
+      // stricter than REST — MCP only accepts a decimal-integer string to
+      // avoid JSON-number precision loss for large Luna amounts.
       inputSchema: {
-        to: z.string().min(1),
+        to: AdminSendRequest.shape.to,
         amountLuna: z.string().regex(/^[0-9]+$/, 'amountLuna must be a decimal integer string'),
       },
     },
@@ -228,12 +238,9 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
     'faucet.block_address',
     {
       description: 'Add an entry to the blocklist. Admin-scoped.',
-      inputSchema: {
-        kind: z.enum(BLOCK_KINDS),
-        value: z.string().min(1),
-        reason: z.string().optional(),
-        expiresAt: z.number().int().positive().optional(),
-      },
+      // Derived from `BlocklistCreateRequest` (REST: POST /admin/blocklist)
+      // so the kind enum and length limits stay in sync.
+      inputSchema: BlocklistCreateRequest.shape,
     },
     async ({ kind, value, reason, expiresAt }) => {
       await guard('faucet.block_address');
@@ -253,10 +260,9 @@ export function buildMcpServer(ctx: AppContext, opts: BuildMcpServerOptions = {}
     'faucet.unblock_address',
     {
       description: 'Remove blocklist entries matching (kind, value). Admin-scoped.',
-      inputSchema: {
-        kind: z.enum(BLOCK_KINDS),
-        value: z.string().min(1),
-      },
+      // Same kind+value pair as `BlocklistCreateRequest`; picked so the enum
+      // and length limit don't drift from the canonical schema.
+      inputSchema: BlocklistCreateRequest.pick({ kind: true, value: true }).shape,
     },
     async ({ kind, value }) => {
       await guard('faucet.unblock_address');

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,6 +26,13 @@ If no admin auth is presented (or it fails), public tools still work but admin t
 
 There are **9 tools**: 3 public, 6 admin-scoped.
 
+> **Schema sources.** Input schemas for tools that overlap REST endpoints are derived from the canonical Zod sources in [apps/server/src/openapi/schemas.ts](../apps/server/src/openapi/schemas.ts) so they cannot drift. Specifically:
+> - `faucet.send` → `to` picked from `AdminSendRequest`; `amountLuna` kept stricter (decimal-integer string only — JSON-number precision is not enough for large Luna values)
+> - `faucet.block_address` → full shape derived from `BlocklistCreateRequest`
+> - `faucet.unblock_address` → `kind` + `value` picked from `BlocklistCreateRequest`
+>
+> The remaining tools either have no REST overlap (`faucet.stats`, `faucet.balance`, `faucet.status`, `faucet.explain_decision`) or have intentionally different constraints (`faucet.recent_claims` and `faucet.list_blocks` accept larger limits than the admin-UI pagination endpoints).
+
 ### Public
 
 #### `faucet.status`


### PR DESCRIPTION
## Summary

Half (b) of **§2.3.7**, completing the work begun in #235. Replaces the inline Zod schemas for the three MCP tools whose inputs overlap canonical REST schemas with `.shape` / `.pick().shape` imports from [apps/server/src/openapi/schemas.ts](apps/server/src/openapi/schemas.ts).

## Changes

- **[apps/server/src/mcp/server.ts](apps/server/src/mcp/server.ts):**
  - Imports `AdminSendRequest`, `BlocklistCreateRequest` from `../openapi/schemas.js`.
  - **`faucet.send`** — `to` picked from `AdminSendRequest.shape`. `amountLuna` left inline (MCP intentionally accepts decimal-integer string only, while REST accepts string or number — keeping it inline documents the deliberate divergence and avoids JSON-number precision loss).
  - **`faucet.block_address`** — full input shape derived from `BlocklistCreateRequest.shape`. Tightens MCP's `value: min(1)` to canonical's `min(1).max(128)` and `reason: optional` to `max(256)` — both match what the REST handler already enforces.
  - **`faucet.unblock_address`** — `kind` + `value` picked from `BlocklistCreateRequest`. Drops the local `BLOCK_KINDS` constant.
- **[docs/mcp.md](docs/mcp.md)** — adds a "Schema sources" callout near the top of the Tools section pointing readers at the canonical Zod for each derived tool.
- **[ROADMAP.md](ROADMAP.md) §2.3.7** — marked ✅ fully shipped (covers both #235's docs half and this refactor).

## Drift safety

The kind enum (`'ip' | 'address' | 'uid' | 'asn' | 'country'`) and length limits cannot diverge between MCP and REST. A new kind added to `BlocklistCreateRequest` propagates to `faucet.block_address` and `faucet.unblock_address` automatically — exactly the §2.3.7 goal.

## Why some tools stay inline

The remaining tools either have no REST overlap (`faucet.stats`, `faucet.balance`, `faucet.status`, `faucet.explain_decision`) or have intentionally different constraints:
- `faucet.recent_claims` limit max=200 matches REST's `ClaimsListQuery`, but uses plain `z.number` rather than `z.coerce.number` (no query-string coercion needed for JSON-RPC) and `.optional()` instead of `.default(50)`.
- `faucet.list_blocks` limit max=1000 vs REST `BlocklistListQuery.limit.max=200` — agents may want bulk listing the admin UI doesn't expose.

## Test plan

- [x] `pnpm -F @faucet/server build` — clean
- [x] `pnpm -F @faucet/server test` — 162/162 pass (incl. `mcp.e2e.test.ts`, `mcp-auth.e2e.test.ts`, `openapi-parity.test.ts`, `sdk-contract.e2e.test.ts`)
- [ ] CI green