### PR TITLE
fix(release): use NPM_TOKEN for publish auth (npm dropped no-2FA option)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,19 +121,32 @@ jobs:
 
       - name: Publish npm packages (public @nimiq-faucet/*)
         env:
-          # Auth handled by Trusted Publishing (npm OIDC). The job-level
-          # `id-token: write` permission lets npm mint the exchange token
-          # automatically — no NPM_TOKEN required. Provenance attestation
-          # is produced for every published tarball.
-          #
-          # Trusted Publishers are configured per-package on npmjs.com:
-          #   Package > Settings > Trusted Publishers > GitHub Actions
-          #     Organization: PanoramicRum
-          #     Repository:   nimiq-simple-faucet
-          #     Workflow:     release.yml
+          # Provenance is signed via GitHub OIDC (job-level `id-token: write`).
+          # That part is independent of how publish is authenticated; provenance
+          # attestation lands on every tarball regardless of the publish-auth
+          # path.
           NPM_CONFIG_PROVENANCE: "true"
+          # Publish auth: granular access token (Bypass 2FA enabled, scope
+          # `@nimiq-faucet`, read-write). Stored as repo secret NPM_TOKEN.
+          # See memory `project_npm_publish_2fa_gotcha` — npm's package access
+          # page no longer offers "Don't require 2FA", so the prior pure-OIDC
+          # path (Trusted Publishers + `id-token: write`) no longer satisfies
+          # the package's 2FA gate. The granular token + Bypass-2FA flag is
+          # the path that the current "Require 2FA or granular token with
+          # bypass 2fa enabled" radio accepts. Rotate the token before
+          # expiry; the prior Trusted Publisher entries are still configured
+          # and harmless (they'd be the path used if "Don't require 2FA"
+          # ever returns to npm).
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+          # Wire the token into ~/.npmrc so `npm publish` (called under
+          # `pnpm changeset publish`) picks it up. Inline rather than via
+          # `setup-node`'s `registry-url` because this is a monorepo and
+          # we don't want a tracked .npmrc.
+          cat > "$HOME/.npmrc" <<EOF
+          //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+          EOF
           # Consume pending changesets into version bumps + CHANGELOG.
           pnpm changeset version || true
           # Publish only packages under the @nimiq-faucet scope. Internal


### PR DESCRIPTION
## Summary

The `Publish npm packages` step in `release.yml` has been failing on every v2.3.1 attempt (and on v2.3.0's first three attempts) with `E404 Not Found - PUT https://registry.npmjs.org/@nimiq-faucet%2f<pkg>`. Despite the provenance statement being OIDC-signed and Sigstore-logged successfully, the registry rejects the PUT.

**Root cause:** npm removed the **"Don't require two-factor authentication"** radio from the per-package access page. The two remaining options both block pure-OIDC publishes:

- "Require 2FA and disallow tokens" — blocks everything
- "Require 2FA or granular access token with bypass 2fa enabled" — sounds permissive but OIDC isn't recognized as "a granular access token"; still rejected

## Fix

Switch publish auth to a granular access token (repo secret `NPM_TOKEN`), which the second radio explicitly accepts. Provenance is still signed via GitHub OIDC — the `id-token: write` permission isn't going anywhere — so tarballs still carry the sigstore + SLSA attestations. Auth method is independent of provenance.

## Token requirements

- **Where:** https://www.npmjs.com/settings/panoramicrum/tokens → Generate New Token → **Granular Access Token**
- **Bypass 2FA:** enabled
- **Scope:** `@nimiq-faucet` (read + write)
- **Organization permissions:** none
- **Expiry:** short — rotate before each release. Current token expires in ~7 days.
- **GitHub repo secret name:** `NPM_TOKEN`

## What about Trusted Publishers?

The TP entries configured during the v2.3.0 ship are still on npm and harmless. If npm ever brings back the "Don't require 2FA" radio (unlikely but possible), the workflow would revert cleanly to pure-OIDC by setting the access page to "Don't require 2FA" and removing the NPM_TOKEN env from this step.

## Test plan

- [x] Memory `project_npm_publish_2fa_gotcha` updated to reflect the 3→2 radio-option policy change
- [ ] CI green on this PR (no publish actually runs on a PR; just the lint/build/test surface)
- [ ] After merge: re-trigger release.yml for v2.3.1 via `gh workflow run release.yml --ref main -f tag=v2.3.1`; verify npm/Docker/Helm/GitHub-release/openapi-PR artifacts