### PR TITLE
feat(server): low-balance reward scaling + live dashboard config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ FAUCET_RATE_LIMIT_PER_IP_PER_DAY=5
 # the faucet. Foundation for future criteria-based rewards (boosts, reductions, …).
 # FAUCET_AUTOMATIC_REWARDS_ENABLED=false
 # FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM=10
+#
+# Low-balance reward scaling (automatic mode only): when the wallet balance drops
+# below the threshold (NIM), each reward is reduced by a flat percent. These are
+# DEFAULTS — an admin can override them live from the dashboard (no restart). A
+# threshold of 0/unset disables scaling; a 100% reduction pauses payouts.
+# FAUCET_LOW_BALANCE_THRESHOLD_NIM=20
+# FAUCET_LOW_BALANCE_REDUCTION_PERCENT=50
 
 # Minimum delay (ms) before any public claim-reject response is delivered.
 # Defends against pipeline-position timing attribution — without padding,

--- a/apps/dashboard/src/views/ConfigView.vue
+++ b/apps/dashboard/src/views/ConfigView.vue
@@ -19,6 +19,8 @@ interface ConfigResponse {
     rateLimitPerIpPerDay: number;
     abuseDenyThreshold: number;
     abuseReviewThreshold: number;
+    lowBalanceThresholdNim: number | null;
+    lowBalanceReductionPercent: number | null;
     layers: LayerFlags;
   };
   overrides: Record<string, unknown>;
@@ -29,6 +31,8 @@ type PatchBody = {
   rateLimitPerIpPerDay?: number;
   abuseDenyThreshold?: number;
   abuseReviewThreshold?: number;
+  lowBalanceThresholdNim?: number;
+  lowBalanceReductionPercent?: number;
   layers?: Partial<LayerFlags>;
 };
 
@@ -43,6 +47,8 @@ const form = reactive({
   rateLimitPerIpPerDay: 50,
   abuseDenyThreshold: 0.8,
   abuseReviewThreshold: 0.5,
+  lowBalanceThresholdNim: 0,
+  lowBalanceReductionPercent: 0,
   layers: {
     turnstile: false,
     hcaptcha: false,
@@ -63,6 +69,8 @@ async function load(): Promise<void> {
     form.rateLimitPerIpPerDay = res.base.rateLimitPerIpPerDay;
     form.abuseDenyThreshold = res.base.abuseDenyThreshold;
     form.abuseReviewThreshold = res.base.abuseReviewThreshold;
+    form.lowBalanceThresholdNim = res.base.lowBalanceThresholdNim ?? 0;
+    form.lowBalanceReductionPercent = res.base.lowBalanceReductionPercent ?? 0;
     form.layers = { ...res.base.layers };
     overrides.value = res.overrides;
     error.value = null;
@@ -84,10 +92,12 @@ async function onSave(): Promise<void> {
       rateLimitPerIpPerDay: Number(form.rateLimitPerIpPerDay),
       abuseDenyThreshold: Number(form.abuseDenyThreshold),
       abuseReviewThreshold: Number(form.abuseReviewThreshold),
+      lowBalanceThresholdNim: Number(form.lowBalanceThresholdNim),
+      lowBalanceReductionPercent: Number(form.lowBalanceReductionPercent),
       layers: { ...form.layers },
     };
     const res = await api.patch<{ ok: true; persistedKeys: string[] }>('/admin/config', body);
-    status.value = `Saved: ${res.persistedKeys.join(', ')}. Layer toggles take effect immediately; other settings need a restart.`;
+    status.value = `Saved: ${res.persistedKeys.join(', ')}. Layer toggles and low-balance reward settings take effect immediately; other settings need a restart.`;
     await load();
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'failed';
@@ -110,9 +120,10 @@ onMounted(load);
       class="rounded-md border border-[color:var(--color-warning)]/30 bg-[color:var(--color-warning)]/10 p-3 text-sm"
       role="note"
     >
-      <strong>Abuse-layer toggles</strong> (fingerprint, on-chain, AI) take effect immediately on
-      Save. Other settings (claim amount, rate limits, thresholds) are persisted but require a
-      container restart to apply.
+      <strong>Abuse-layer toggles</strong> (fingerprint, on-chain, AI) and the
+      <strong>low-balance reward settings</strong> take effect immediately on Save. Other settings
+      (claim amount, rate limits, abuse thresholds) are persisted but require a container restart to
+      apply.
     </div>
 
     <p
@@ -169,6 +180,31 @@ onMounted(load);
             step="0.01"
             required
           />
+        </label>
+        <label class="flex flex-col gap-1 text-xs">
+          <span>Low-balance threshold (NIM)</span>
+          <input
+            v-model.number="form.lowBalanceThresholdNim"
+            class="input font-mono"
+            type="number"
+            min="0"
+            step="1"
+            required
+          />
+          <span class="muted">Reward scaling starts when the wallet drops below this. 0 disables it.</span>
+        </label>
+        <label class="flex flex-col gap-1 text-xs">
+          <span>Reward reduction below threshold (%)</span>
+          <input
+            v-model.number="form.lowBalanceReductionPercent"
+            class="input font-mono"
+            type="number"
+            min="0"
+            max="100"
+            step="1"
+            required
+          />
+          <span class="muted">Flat reduction applied while below the threshold. 100 pauses payouts.</span>
         </label>
       </div>
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -49,6 +49,20 @@ export const ServerConfigSchema = z.object({
    * not leak its state to clients.
    */
   automaticRewardsBaselineNim: z.coerce.number().optional(),
+  /**
+   * Low-balance reward scaling threshold, in NIM. When automatic mode is on and
+   * the wallet balance drops below this, each reward is reduced by
+   * `lowBalanceReductionPercent`. This is the env DEFAULT; an admin can override
+   * it live from the dashboard (persisted in `runtime_config`, read per payout).
+   * Unset (or ≤ 0) disables low-balance scaling.
+   */
+  lowBalanceThresholdNim: z.coerce.number().min(0).optional(),
+  /**
+   * Flat percent (0–100) by which rewards are reduced while the wallet balance
+   * is below `lowBalanceThresholdNim`. 100 pauses payouts (a reward of zero is
+   * refused opaquely). Env DEFAULT; admin-overridable live from the dashboard.
+   */
+  lowBalanceReductionPercent: z.coerce.number().min(0).max(100).optional(),
   rateLimitPerMinute: z.coerce.number().int().min(1).default(30),
   rateLimitPerIpPerDay: z.coerce.number().int().min(1).default(5),
 
@@ -279,6 +293,8 @@ export const ENV_KEYS: Record<string, string> = {
   minBalanceLuna: 'FAUCET_MIN_BALANCE_LUNA',
   automaticRewardsEnabled: 'FAUCET_AUTOMATIC_REWARDS_ENABLED',
   automaticRewardsBaselineNim: 'FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM',
+  lowBalanceThresholdNim: 'FAUCET_LOW_BALANCE_THRESHOLD_NIM',
+  lowBalanceReductionPercent: 'FAUCET_LOW_BALANCE_REDUCTION_PERCENT',
   rateLimitPerMinute: 'FAUCET_RATE_LIMIT_PER_MINUTE',
   rateLimitPerIpPerDay: 'FAUCET_RATE_LIMIT_PER_IP_PER_DAY',
   turnstileSiteKey: 'FAUCET_TURNSTILE_SITE_KEY',

--- a/apps/server/src/configView.ts
+++ b/apps/server/src/configView.ts
@@ -8,7 +8,7 @@
  */
 import type { ServerConfig } from './config.js';
 import { THEMES, isKnownTheme, DEFAULT_THEME } from './themes.js';
-import { resolvePayout } from './rewards/automatic.js';
+import { resolvePayout, resolveRewardSettings } from './rewards/automatic.js';
 
 /**
  * The amount (Luna) a successful claim actually pays right now, for display in
@@ -103,12 +103,21 @@ export function deriveUi(config: ServerConfig) {
   return ui;
 }
 
-export function deriveAdminConfigBase(config: ServerConfig) {
+export function deriveAdminConfigBase(
+  config: ServerConfig,
+  overrides: Record<string, unknown> = {},
+) {
+  // Effective low-balance settings = persisted admin override merged over the
+  // env default (override wins). Surfaced so the dashboard shows what's actually
+  // in force, not just the boot-time env value.
+  const reward = resolveRewardSettings(config, overrides);
   return {
     claimAmountLuna: effectivePayoutLuna(config).toString(),
     rateLimitPerIpPerDay: config.rateLimitPerIpPerDay,
     abuseDenyThreshold: config.aiDenyThreshold,
     abuseReviewThreshold: config.aiReviewThreshold,
+    lowBalanceThresholdNim: reward.lowBalanceThresholdNim ?? null,
+    lowBalanceReductionPercent: reward.lowBalanceReductionPercent ?? null,
     layers: deriveAbuseLayers(config),
   };
 }

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -30,6 +30,13 @@ export const driverReady = new Gauge({
   registers: [registry],
 });
 
+export const rewardAdjustmentsTotal = new Counter({
+  name: 'faucet_reward_adjustments_total',
+  help: 'Reward adjustments applied to paid automatic-mode claims, by kind (e.g. low-balance-scaling)',
+  labelNames: ['kind'] as const,
+  registers: [registry],
+});
+
 export const reconcilerFlips = new Counter({
   name: 'faucet_reconciler_flips_total',
   help: 'Claims reconciled from broadcast to a terminal state',

--- a/apps/server/src/openapi/document.ts
+++ b/apps/server/src/openapi/document.ts
@@ -260,7 +260,9 @@ function registerRoutes(): void {
     path: '/admin/config',
     tags: ['Admin'],
     summary: 'Persist runtime config overrides',
-    description: 'NOTE(M3): persisted but not yet hot-reloaded into live traffic.',
+    description:
+      'Persists runtime config overrides. Abuse-layer toggles and the low-balance reward keys ' +
+      '(lowBalanceThresholdNim, lowBalanceReductionPercent) apply live; other keys require a restart.',
     security: [{ adminSession: [] }],
     request: { body: { content: jsonContent(AdminConfigPatch) } },
     responses: { 200: { description: 'Persisted', content: jsonContent(OkResponse) } },

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -290,6 +290,10 @@ export const AdminConfigPatch = registry.register(
       rateLimitPerIpPerDay: z.number().int().min(1).max(10_000).optional(),
       abuseDenyThreshold: z.number().min(0).max(1).optional(),
       abuseReviewThreshold: z.number().min(0).max(1).optional(),
+      // Low-balance reward scaling — applied live (read per payout from
+      // runtime_config). Threshold in NIM; reduction is a flat percent.
+      lowBalanceThresholdNim: z.number().min(0).optional(),
+      lowBalanceReductionPercent: z.number().min(0).max(100).optional(),
       layers: z
         .object({
           turnstile: z.boolean().optional(),
@@ -314,6 +318,10 @@ export const AdminConfigResponse = registry.register(
       rateLimitPerIpPerDay: z.number().int(),
       abuseDenyThreshold: z.number(),
       abuseReviewThreshold: z.number(),
+      // Effective low-balance reward settings (override merged over env default);
+      // null when unset. Threshold in NIM, reduction as a flat percent.
+      lowBalanceThresholdNim: z.number().nullable(),
+      lowBalanceReductionPercent: z.number().nullable(),
       layers: z.record(z.string(), z.boolean()),
     }),
     overrides: z.record(z.string(), z.unknown()),

--- a/apps/server/src/rewards/automatic.test.ts
+++ b/apps/server/src/rewards/automatic.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { calculateAutomaticReward, nimToLuna, resolvePayout } from './automatic.js';
+import {
+  calculateAutomaticReward,
+  nimToLuna,
+  resolvePayout,
+  resolveRewardSettings,
+} from './automatic.js';
 
 describe('nimToLuna', () => {
   it('converts NIM to luna (1 NIM = 100_000 luna)', () => {
@@ -70,5 +75,146 @@ describe('resolvePayout', () => {
       resolvePayout({ ...base, automaticRewardsEnabled: true, automaticRewardsBaselineNim: 0 })
         .amountLuna,
     ).toBe(0n);
+  });
+});
+
+describe('calculateAutomaticReward — low-balance scaling', () => {
+  // baseline 10 NIM = 1_000_000 luna; threshold 5 NIM = 500_000 luna.
+  const baseInput = { baselineNim: 10, lowBalanceThresholdNim: 5, lowBalanceReductionPercent: 25 };
+
+  it('reduces the reward by the flat percent when balance is below the threshold', () => {
+    const r = calculateAutomaticReward({ ...baseInput, balanceLuna: 400_000n });
+    expect(r.amount).toBe(750_000n);
+    expect(r.baselineAmount).toBe(1_000_000n);
+    expect(r.adjustments).toEqual([
+      {
+        kind: 'low-balance-scaling',
+        deltaLuna: -250_000n,
+        reason: 'wallet balance below 5 NIM; reward reduced 25%',
+      },
+    ]);
+  });
+
+  it('pays the full baseline when balance is at or above the threshold', () => {
+    expect(calculateAutomaticReward({ ...baseInput, balanceLuna: 600_000n }).amount).toBe(1_000_000n);
+    // exactly at threshold (not strictly below) → no scaling
+    const atThreshold = calculateAutomaticReward({ ...baseInput, balanceLuna: 500_000n });
+    expect(atThreshold.amount).toBe(1_000_000n);
+    expect(atThreshold.adjustments).toEqual([]);
+  });
+
+  it('does NOT scale when the balance is unknown (null/undefined) — RPC-failure safety', () => {
+    expect(calculateAutomaticReward({ ...baseInput, balanceLuna: null }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ ...baseInput, balanceLuna: undefined }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ ...baseInput }).adjustments).toEqual([]);
+  });
+
+  it('0% reduction is a no-op', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: 0,
+      balanceLuna: 100_000n,
+    });
+    expect(r.amount).toBe(1_000_000n);
+    expect(r.adjustments).toEqual([]);
+  });
+
+  it('100% reduction scales to zero (caller refuses) and records the adjustment', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: 100,
+      balanceLuna: 100_000n,
+    });
+    expect(r.amount).toBe(0n);
+    expect(r.adjustments).toHaveLength(1);
+    expect(r.adjustments[0]?.deltaLuna).toBe(-1_000_000n);
+  });
+
+  it('ignores an out-of-range reduction (defensive) — never exceeds the baseline', () => {
+    const over = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: 150,
+      balanceLuna: 100_000n,
+    });
+    expect(over.amount).toBe(1_000_000n);
+    expect(over.adjustments).toEqual([]);
+    const negative = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: -10,
+      balanceLuna: 100_000n,
+    });
+    expect(negative.amount).toBe(1_000_000n);
+  });
+
+  it('does not scale when the threshold is unset or zero', () => {
+    expect(
+      calculateAutomaticReward({ baselineNim: 10, lowBalanceReductionPercent: 25, balanceLuna: 1n })
+        .amount,
+    ).toBe(1_000_000n);
+    expect(
+      calculateAutomaticReward({
+        baselineNim: 10,
+        lowBalanceThresholdNim: 0,
+        lowBalanceReductionPercent: 25,
+        balanceLuna: 1n,
+      }).amount,
+    ).toBe(1_000_000n);
+  });
+
+  it('truncates the reduced payout DOWN (never over-pays) on fractional luna', () => {
+    // baseline 1.00001 NIM = 100_001 luna; 1% reduction → 99_000.99 → 99_000n
+    const r = calculateAutomaticReward({
+      baselineNim: 1.00001,
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: 1,
+      balanceLuna: 1n,
+    });
+    expect(r.baselineAmount).toBe(100_001n);
+    expect(r.amount).toBe(99_000n);
+    expect(r.amount).toBeLessThan(100_001n);
+  });
+});
+
+describe('resolveRewardSettings', () => {
+  const cfg = {
+    automaticRewardsEnabled: true,
+    automaticRewardsBaselineNim: 10,
+    lowBalanceThresholdNim: 20,
+    lowBalanceReductionPercent: 30,
+    claimAmountLuna: 100_000n,
+  };
+
+  it('lets a valid persisted override win over the env default', () => {
+    const s = resolveRewardSettings(cfg, {
+      lowBalanceThresholdNim: 5,
+      lowBalanceReductionPercent: 60,
+    });
+    expect(s.lowBalanceThresholdNim).toBe(5);
+    expect(s.lowBalanceReductionPercent).toBe(60);
+    // enabled + baseline stay env-only
+    expect(s.enabled).toBe(true);
+    expect(s.baselineNim).toBe(10);
+  });
+
+  it('falls back to the env default when an override is malformed / out of range', () => {
+    const s = resolveRewardSettings(cfg, {
+      lowBalanceThresholdNim: 'oops',
+      lowBalanceReductionPercent: 150,
+    });
+    expect(s.lowBalanceThresholdNim).toBe(20);
+    expect(s.lowBalanceReductionPercent).toBe(30);
+  });
+
+  it('returns undefined when neither override nor env default is set', () => {
+    const s = resolveRewardSettings(
+      { automaticRewardsEnabled: false, claimAmountLuna: 100_000n },
+      {},
+    );
+    expect(s.lowBalanceThresholdNim).toBeUndefined();
+    expect(s.lowBalanceReductionPercent).toBeUndefined();
   });
 });

--- a/apps/server/src/rewards/automatic.ts
+++ b/apps/server/src/rewards/automatic.ts
@@ -1,84 +1,128 @@
 /**
- * Automatic reward calculation (Phase 1).
+ * Automatic reward calculation.
  *
  * In automatic mode the developer app does NOT choose or send the payout
- * amount — the faucet always derives it from operator config. Phase 1 is the
- * trivial case:
+ * amount — the faucet derives it from operator config:
  *
- *   finalAmount = baselineAmount
+ *   finalAmount = baselineAmount + Σ adjustments
  *
- * Future phases will populate `adjustments` (first-time boosts, repeat-user
- * reductions, low-balance scaling, whitelists/bonuses, …) and change how
- * `amount` is derived from the baseline. Everything here is deliberately small
- * and isolated so that growth is additive: a Phase-2 adjustment engine plugs in
- * by filling `adjustments` and recomputing `amount`, with no claim-handler
- * surgery.
+ * Phase 1 was the trivial case (`adjustments: []`). Phase 2 adds the first
+ * adjustment rule — **low-balance scaling**: when the wallet balance is below a
+ * configured threshold, the reward is reduced by a flat percentage. Further
+ * phases plug in additively by pushing more {@link RewardAdjustment}s and
+ * recomputing `amount`, with no claim-handler surgery.
  *
- * Units: every amount in this module is in **Luna** (the smallest Nimiq unit,
- * 1 NIM = 100_000 Luna), matching the rest of the server. Operator config is
- * expressed in NIM (`FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM`) for readability and
- * converted to Luna at the boundary via {@link nimToLuna}.
+ * Units: every amount here is in **Luna** (the smallest Nimiq unit, 1 NIM =
+ * 100_000 Luna), matching the rest of the server. Operator config is expressed
+ * in NIM for readability and converted at the boundary via {@link nimToLuna}.
  */
 
 export type RewardMode = 'automatic';
 
-/** A single reward adjustment. Phase 1 never produces any; Phase 2 will. */
+/** A single reward adjustment applied on top of the baseline. */
 export interface RewardAdjustment {
-  /** Stable identifier for the rule that fired, e.g. `first-time-boost`. */
+  /** Stable identifier for the rule that fired, e.g. `low-balance-scaling`. */
   kind: string;
-  /** Signed delta applied to the running amount, in Luna. */
+  /** Signed delta applied to the running amount, in Luna (negative = reduction). */
   deltaLuna: bigint;
   /** Human-readable reason, for audit/logging. */
   reason?: string;
 }
 
 export interface RewardResult {
-  /** Final amount to send, in Luna (== `baselineAmount` in Phase 1). */
+  /** Final amount to send, in Luna (`baselineAmount` + Σ adjustment deltas). */
   amount: bigint;
   rewardMode: RewardMode;
-  /** Configured baseline, in Luna. */
+  /** Configured baseline, in Luna (before adjustments). */
   baselineAmount: bigint;
-  /** Applied adjustments — always `[]` in Phase 1. */
+  /** Applied adjustments (empty when nothing modified the baseline). */
   adjustments: RewardAdjustment[];
 }
 
 const LUNA_PER_NIM = 100_000;
+/** Percent → basis points (×100), so a fractional percent stays exact in bigint math. */
+const BASIS_POINTS = 10_000n;
 
 /**
  * Convert an operator-supplied NIM amount to Luna (bigint).
  *
  * Returns `0n` for any missing/invalid input (undefined, NaN, ≤ 0) so the
  * function is total — the caller is responsible for treating a non-positive
- * result as "no valid baseline" and refusing the payout. This keeps a
- * misconfiguration from throwing deep in the request path.
+ * result as "no valid value". This keeps a misconfiguration from throwing deep
+ * in the request path.
  */
 export function nimToLuna(nim: number | undefined): bigint {
   if (nim === undefined || !Number.isFinite(nim) || nim <= 0) return 0n;
   return BigInt(Math.round(nim * LUNA_PER_NIM));
 }
 
-/**
- * Compute the automatic reward from config. Pure and total — never throws.
- *
- * For a missing/invalid baseline it returns `amount: 0n`; the caller decides
- * validity (and, per the abuse posture, refuses opaquely rather than echoing
- * the misconfiguration back to the client).
- */
-export function calculateAutomaticReward(config: { baselineNim?: number | undefined }): RewardResult {
-  const baseline = nimToLuna(config.baselineNim);
-  return {
-    amount: baseline,
-    rewardMode: 'automatic',
-    baselineAmount: baseline,
-    // Phase 1: no adjustments. Phase 2 fills this and recomputes `amount`.
-    adjustments: [],
-  };
+/** Inputs to {@link calculateAutomaticReward}. All optional; the function is total. */
+export interface RewardInput {
+  /** Baseline reward, in NIM. */
+  baselineNim?: number | undefined;
+  /** Low-balance threshold, in NIM. Scaling fires only when balance < this. */
+  lowBalanceThresholdNim?: number | undefined;
+  /** Flat reduction percent (0–100) applied below the threshold. */
+  lowBalanceReductionPercent?: number | undefined;
+  /**
+   * Current wallet balance in Luna, or `null`/`undefined` when unknown. When
+   * unknown, low-balance scaling is skipped (never reduce on a stale/failed
+   * balance read — that would silently halve every payout during an RPC blip).
+   */
+  balanceLuna?: bigint | null | undefined;
 }
 
-/** Minimal slice of `ServerConfig` the payout resolver needs. */
+/**
+ * Compute the automatic reward. Pure and total — never throws.
+ *
+ * Low-balance scaling fires only when ALL hold: a positive baseline, a positive
+ * threshold, a reduction in `(0, 100]`, a known balance, and `balance <
+ * threshold`. The reduction uses basis-point bigint math (truncates *down*, so
+ * it never over-pays). A reduction outside `(0, 100]` is ignored defensively, so
+ * a bad config can never produce `amount > baseline`.
+ *
+ * A 100% reduction yields `amount: 0n`; the caller refuses such a claim opaquely
+ * (pausing payouts while the wallet is critically low) rather than sending 0.
+ */
+export function calculateAutomaticReward(input: RewardInput): RewardResult {
+  const baseline = nimToLuna(input.baselineNim);
+  const adjustments: RewardAdjustment[] = [];
+  let amount = baseline;
+
+  const thresholdLuna = nimToLuna(input.lowBalanceThresholdNim);
+  const reduction = input.lowBalanceReductionPercent;
+  const reductionValid =
+    reduction !== undefined && Number.isFinite(reduction) && reduction > 0 && reduction <= 100;
+
+  if (
+    baseline > 0n &&
+    thresholdLuna > 0n &&
+    reductionValid &&
+    input.balanceLuna !== undefined &&
+    input.balanceLuna !== null &&
+    input.balanceLuna < thresholdLuna
+  ) {
+    const reductionBp = BigInt(Math.round((reduction as number) * 100));
+    const reduced = (baseline * (BASIS_POINTS - reductionBp)) / BASIS_POINTS;
+    if (reduced !== baseline) {
+      adjustments.push({
+        kind: 'low-balance-scaling',
+        deltaLuna: reduced - baseline,
+        reason: `wallet balance below ${input.lowBalanceThresholdNim} NIM; reward reduced ${reduction}%`,
+      });
+      amount = reduced;
+    }
+  }
+
+  return { amount, rewardMode: 'automatic', baselineAmount: baseline, adjustments };
+}
+
+/** Minimal slice of `ServerConfig` the payout/settings resolvers need. */
 export interface PayoutConfig {
   automaticRewardsEnabled: boolean;
   automaticRewardsBaselineNim?: number | undefined;
+  lowBalanceThresholdNim?: number | undefined;
+  lowBalanceReductionPercent?: number | undefined;
   claimAmountLuna: bigint;
 }
 
@@ -90,13 +134,10 @@ export interface ResolvedPayout {
 }
 
 /**
- * Single seam between config and the claim handler.
- *
- * - Automatic mode OFF (default): use the operator-configured fixed
- *   `claimAmountLuna` — today's "explicit amount" behaviour, unchanged.
- * - Automatic mode ON: use the baseline from {@link calculateAutomaticReward}.
- *   An invalid baseline surfaces as `amountLuna <= 0n`, which the handler turns
- *   into an opaque rejection.
+ * Single seam between config and the claim handler for the **baseline** payout
+ * (no balance context). Used for the public `/v1/config` display amount and for
+ * deny/challenge claim records, which never pay out. Low-balance scaling is
+ * applied separately in the claim handler once the balance is known.
  */
 export function resolvePayout(config: PayoutConfig): ResolvedPayout {
   if (config.automaticRewardsEnabled) {
@@ -104,4 +145,54 @@ export function resolvePayout(config: PayoutConfig): ResolvedPayout {
     return { amountLuna: reward.amount, reward };
   }
   return { amountLuna: config.claimAmountLuna, reward: null };
+}
+
+/** Effective reward settings after merging persisted admin overrides over env defaults. */
+export interface EffectiveRewardSettings {
+  enabled: boolean;
+  baselineNim?: number | undefined;
+  lowBalanceThresholdNim?: number | undefined;
+  lowBalanceReductionPercent?: number | undefined;
+}
+
+function pickInRange(
+  override: unknown,
+  envDefault: number | undefined,
+  min: number,
+  max: number,
+): number | undefined {
+  if (typeof override === 'number' && Number.isFinite(override) && override >= min && override <= max) {
+    return override;
+  }
+  // Malformed / out-of-range persisted override → fall back to the env default.
+  return envDefault;
+}
+
+/**
+ * Merge persisted runtime overrides over env-derived config to produce the
+ * effective reward settings used at claim time. Only the two low-balance keys
+ * are read live (override-wins); a malformed/out-of-range `runtime_config` row
+ * falls back to the env default so it can never widen behaviour unexpectedly.
+ * `enabled` and `baselineNim` stay env-only.
+ */
+export function resolveRewardSettings(
+  config: PayoutConfig,
+  overrides: Record<string, unknown>,
+): EffectiveRewardSettings {
+  return {
+    enabled: config.automaticRewardsEnabled,
+    baselineNim: config.automaticRewardsBaselineNim,
+    lowBalanceThresholdNim: pickInRange(
+      overrides.lowBalanceThresholdNim,
+      config.lowBalanceThresholdNim,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    lowBalanceReductionPercent: pickInRange(
+      overrides.lowBalanceReductionPercent,
+      config.lowBalanceReductionPercent,
+      0,
+      100,
+    ),
+  };
 }

--- a/apps/server/src/routes/admin/config.ts
+++ b/apps/server/src/routes/admin/config.ts
@@ -2,8 +2,10 @@
  * Admin config GET/PATCH.
  *
  * Layer toggles (fingerprint, onchain, AI) take effect immediately on PATCH —
- * the abuse pipeline is rebuilt in memory. Other overrides (claim amount, rate
- * limit thresholds) are persisted but require a restart to apply.
+ * the abuse pipeline is rebuilt in memory. The low-balance reward keys
+ * (lowBalanceThresholdNim, lowBalanceReductionPercent) also apply live: the
+ * claim handler reads them from `runtime_config` per payout. Other overrides
+ * (claim amount, rate-limit thresholds) are persisted but require a restart.
  */
 import type { FastifyInstance } from 'fastify';
 import { eq } from 'drizzle-orm';
@@ -14,25 +16,13 @@ import { writeAudit } from '../../auth/audit.js';
 import { requireAdminCsrf } from '../../auth/middleware.js';
 import { AdminConfigPatch as PatchBody } from '../../openapi/schemas.js';
 import { deriveAdminConfigBase } from '../../configView.js';
-
-async function readOverrides(ctx: AppContext): Promise<Record<string, unknown>> {
-  const rows = await ctx.db.select().from(runtimeConfig);
-  const out: Record<string, unknown> = {};
-  for (const r of rows) {
-    try {
-      out[r.key] = JSON.parse(r.valueJson);
-    } catch {
-      // skip malformed row
-    }
-  }
-  return out;
-}
+import { readRuntimeOverrides } from '../../runtimeConfig.js';
 
 export async function adminConfigRoutes(app: FastifyInstance, ctx: AppContext): Promise<void> {
-  app.get('/admin/config', async () => ({
-    base: deriveAdminConfigBase(ctx.config),
-    overrides: await readOverrides(ctx),
-  }));
+  app.get('/admin/config', async () => {
+    const overrides = await readRuntimeOverrides(ctx.db);
+    return { base: deriveAdminConfigBase(ctx.config, overrides), overrides };
+  });
 
   app.patch(
     '/admin/config',
@@ -58,7 +48,7 @@ export async function adminConfigRoutes(app: FastifyInstance, ctx: AppContext): 
       }
       // Rebuild the abuse pipeline with the new layer overrides so they
       // take effect immediately without a restart.
-      const allOverrides = await readOverrides(ctx);
+      const allOverrides = await readRuntimeOverrides(ctx.db);
       const layers = (allOverrides.layers ?? {}) as Record<string, boolean>;
       ctx.pipeline = buildPipeline(ctx.db, ctx.config, ctx.driver, {
         fingerprintEnabled: layers.fingerprint,

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -13,10 +13,15 @@ import { claims, integratorKeys } from '../db/schema.js';
 import type { AppContext } from '../context.js';
 import { incrementIpCounter, decrementIpCounter } from '../abuse/rateLimit.js';
 import { verifyIntegratorRequest, type IntegratorKey } from '../hmac.js';
-import { claimsTotal, claimDuration } from '../metrics.js';
+import { claimsTotal, claimDuration, rewardAdjustmentsTotal } from '../metrics.js';
 import { ClaimRequest as ClaimRequestSchema } from '../openapi/schemas.js';
 import { derivePublicConfig } from '../configView.js';
-import { resolvePayout } from '../rewards/automatic.js';
+import {
+  calculateAutomaticReward,
+  resolvePayout,
+  resolveRewardSettings,
+} from '../rewards/automatic.js';
+import { readRuntimeOverrides } from '../runtimeConfig.js';
 
 // Extend the shared OpenAPI schema with the backwards-compat transform.
 const ClaimBody = ClaimRequestSchema.transform(({ powSolution, hashcashSolution, ...rest }) => ({
@@ -344,45 +349,75 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       });
     }
 
-    // Automatic-mode payout guard. The pipeline has allowed this claim; now
-    // confirm the resolved amount is actually payable. A misconfigured baseline
-    // (missing/zero/negative) or an amount the wallet can't cover must NOT pay
-    // out — but it also must not reveal itself: log the real reason server-side
-    // and return the SAME opaque reject shape (+ timing pad) as an abuse denial,
-    // so a client can't probe the misconfiguration. Explicit mode keeps its
-    // existing behaviour (no claim-time amount/balance gate).
+    // Automatic-mode payout guard + low-balance scaling. The pipeline has
+    // allowed this claim; now derive the actual amount and confirm it is
+    // payable. A misconfigured baseline (missing/zero/negative), a reward scaled
+    // to zero by a 100% low-balance reduction, or an amount the wallet can't
+    // cover must NOT pay out — but it also must not reveal itself: log the real
+    // reason server-side and return the SAME opaque reject shape (+ timing pad)
+    // as an abuse denial, so a client can't probe the state. Explicit mode keeps
+    // its existing behaviour (no claim-time amount/balance gate).
+    //
+    // `finalPayout` defaults to the baseline `payout`; in automatic mode it is
+    // recomputed with the live low-balance settings + balance and used for the
+    // send, the DB record, and the audit log below.
+    let finalPayout = payout;
     if (ctx.config.automaticRewardsEnabled) {
+      // Low-balance threshold + reduction can be overridden live from the admin
+      // dashboard (persisted in runtime_config), so resolve effective settings
+      // per payout rather than from boot-time config.
+      const settings = resolveRewardSettings(ctx.config, await readRuntimeOverrides(ctx.db));
+
+      // Single best-effort balance snapshot, reused for both the scaling
+      // decision and the over-balance guard. On a transient getBalance()
+      // failure, balance stays null → low-balance scaling is skipped (never
+      // halve payouts on a stale read) and the over-balance check is skipped
+      // (the send try/catch below still catches a truly insufficient send).
+      let balance: bigint | null = null;
+      try {
+        balance = await ctx.driver.getBalance();
+      } catch {
+        balance = null;
+      }
+
+      const reward = calculateAutomaticReward({
+        baselineNim: settings.baselineNim,
+        lowBalanceThresholdNim: settings.lowBalanceThresholdNim,
+        lowBalanceReductionPercent: settings.lowBalanceReductionPercent,
+        balanceLuna: balance,
+      });
+      finalPayout = { amountLuna: reward.amount, reward };
+
       let refusal: string | null = null;
-      if (payout.amountLuna <= 0n) {
+      if (reward.baselineAmount <= 0n) {
         refusal = 'automatic_reward_baseline_invalid';
         req.log.error(
-          { baselineNim: ctx.config.automaticRewardsBaselineNim },
+          { baselineNim: settings.baselineNim },
           'automatic reward baseline is missing/zero/negative; refusing payout',
         );
-      } else {
-        // Best-effort balance check: skip on a transient getBalance() failure
-        // (the send try/catch below still catches a truly insufficient send),
-        // so an RPC blip never blocks an otherwise-valid payout.
-        let balance: bigint | null = null;
-        try {
-          balance = await ctx.driver.getBalance();
-        } catch {
-          balance = null;
-        }
-        if (balance !== null && payout.amountLuna > balance) {
-          refusal = 'automatic_reward_exceeds_balance';
-          req.log.error(
-            { amountLuna: payout.amountLuna.toString(), balance: balance.toString() },
-            'automatic reward exceeds available balance; refusing payout',
-          );
-        }
+      } else if (reward.amount <= 0n) {
+        refusal = 'automatic_reward_scaled_to_zero';
+        req.log.error(
+          {
+            baselineAmountLuna: reward.baselineAmount.toString(),
+            reductionPercent: settings.lowBalanceReductionPercent,
+          },
+          'automatic reward scaled to zero by low-balance reduction; refusing payout',
+        );
+      } else if (balance !== null && reward.amount > balance) {
+        refusal = 'automatic_reward_exceeds_balance';
+        req.log.error(
+          { amountLuna: reward.amount.toString(), balance: balance.toString() },
+          'automatic reward exceeds available balance; refusing payout',
+        );
       }
+
       if (refusal) {
         await decrementIpCounter(ctx.db, req.ip, now);
         await ctx.db.insert(claims).values({
           id,
           address,
-          amountLuna: payout.amountLuna.toString(),
+          amountLuna: finalPayout.amountLuna.toString(),
           status: 'rejected',
           ip: req.ip,
           userAgent: claimReq.userAgent ?? null,
@@ -413,7 +448,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     inflightClaims.add(address);
     let txId: string;
     try {
-      txId = await ctx.driver.send(address, payout.amountLuna);
+      txId = await ctx.driver.send(address, finalPayout.amountLuna);
     } catch (err) {
       inflightClaims.delete(address);
       await decrementIpCounter(ctx.db, req.ip, now);
@@ -430,7 +465,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       await ctx.db.insert(claims).values({
         id,
         address,
-        amountLuna: payout.amountLuna.toString(),
+        amountLuna: finalPayout.amountLuna.toString(),
         status: 'timeout',
         ip: req.ip,
         userAgent: claimReq.userAgent ?? null,
@@ -455,7 +490,7 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     await ctx.db.insert(claims).values({
       id,
       address,
-      amountLuna: ctx.config.claimAmountLuna.toString(),
+      amountLuna: finalPayout.amountLuna.toString(),
       status: 'broadcast',
       txId,
       ip: req.ip,
@@ -468,20 +503,22 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
     });
     inflightClaims.delete(address);
     // Automatic-mode payout: record the reward decision in the log for the audit
-    // trail. finalAmount is already persisted via the `amountLuna` column above
-    // (it equals the baseline in Phase 1).
-    // TODO(phase-2): persist rewardMode / baselineAmount / adjustments to a
-    // dedicated `rewardMetaJson` claims column once the adjustment engine lands.
-    if (payout.reward) {
+    // trail. finalAmount is already persisted via the `amountLuna` column above.
+    // TODO(future): persist rewardMode / baselineAmount / adjustments to a
+    // dedicated `rewardMetaJson` claims column for richer reporting.
+    if (finalPayout.reward) {
       req.log.info(
         {
-          rewardMode: payout.reward.rewardMode,
-          baselineAmountLuna: payout.reward.baselineAmount.toString(),
-          adjustments: payout.reward.adjustments,
-          finalAmountLuna: payout.amountLuna.toString(),
+          rewardMode: finalPayout.reward.rewardMode,
+          baselineAmountLuna: finalPayout.reward.baselineAmount.toString(),
+          adjustments: finalPayout.reward.adjustments,
+          finalAmountLuna: finalPayout.amountLuna.toString(),
         },
         'automatic reward payout',
       );
+      for (const adj of finalPayout.reward.adjustments) {
+        rewardAdjustmentsTotal.inc({ kind: adj.kind });
+      }
     }
     // IP counter was already incremented before the pipeline (see #52 fix above).
     claimsTotal.inc({ status: 'broadcast', decision: 'allow' });

--- a/apps/server/src/runtimeConfig.ts
+++ b/apps/server/src/runtimeConfig.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared reader for admin runtime-config overrides (the `runtime_config`
+ * key→valueJson table written by `PATCH /admin/config`).
+ *
+ * Lives in a neutral module so both the admin routes and the claim handler can
+ * read overrides without the claim path importing from `routes/admin/`. Most
+ * overrides are only applied on restart, but a small explicit set (the
+ * low-balance reward keys) is read here at claim time to apply live.
+ */
+import type { Db } from './db/index.js';
+import { runtimeConfig } from './db/schema.js';
+
+export async function readRuntimeOverrides(db: Db): Promise<Record<string, unknown>> {
+  const rows = await db.select().from(runtimeConfig);
+  const out: Record<string, unknown> = {};
+  for (const r of rows) {
+    try {
+      out[r.key] = JSON.parse(r.valueJson);
+    } catch {
+      // skip malformed row
+    }
+  }
+  return out;
+}

--- a/apps/server/test/low-balance-reward.e2e.test.ts
+++ b/apps/server/test/low-balance-reward.e2e.test.ts
@@ -1,0 +1,241 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import type { AppContext } from '../src/context.js';
+import { claims } from '../src/db/schema.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const USER_ADDR = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+const ADMIN_PASSWORD = 'test-password-123';
+
+class FakeNimiqDriver extends BaseTestDriver {
+  public sends: Array<{ to: string; amount: bigint }> = [];
+  public balance = 10_000_000n;
+  public failBalance = false;
+
+  override async getBalance() {
+    if (this.failBalance) throw new Error('rpc down');
+    return this.balance;
+  }
+  override async send(to: string, amount: bigint): Promise<string> {
+    this.sends.push({ to, amount });
+    this.balance -= amount;
+    return `tx_${this.sends.length}`;
+  }
+  override async waitForConfirmation(): Promise<void> {
+    // confirmed instantly
+  }
+}
+
+const open: Array<{ app: FastifyInstance; tmp: string }> = [];
+
+async function makeApp(
+  overrides: Record<string, unknown> = {},
+  driver: FakeNimiqDriver = new FakeNimiqDriver(),
+): Promise<{ app: FastifyInstance; driver: FakeNimiqDriver; ctx: AppContext }> {
+  const tmp = mkdtempSync(join(tmpdir(), 'faucet-lowbal-'));
+  const config = ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: tmp,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: ADMIN_PASSWORD,
+    automaticRewardsEnabled: 'true',
+    automaticRewardsBaselineNim: '10', // 1_000_000 luna baseline
+    dev: 'true',
+    rejectDelayMsMin: '0',
+    ...overrides,
+  });
+  const { app, ctx } = await buildApp(config, { driverOverride: driver, quietLogs: true });
+  await app.ready();
+  open.push({ app, tmp });
+  return { app, driver, ctx };
+}
+
+function claim(app: FastifyInstance, payload: Record<string, unknown> = { address: USER_ADDR }) {
+  return app.inject({
+    method: 'POST',
+    url: '/v1/claim',
+    payload,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function login(app: FastifyInstance): Promise<{ session: string; csrf: string }> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: ADMIN_PASSWORD },
+    headers: { 'content-type': 'application/json' },
+  });
+  return {
+    session: parseCookie(res.headers['set-cookie'], 'faucet_session')!,
+    csrf: parseCookie(res.headers['set-cookie'], 'faucet_csrf')!,
+  };
+}
+
+function patchConfig(
+  app: FastifyInstance,
+  auth: { session: string; csrf: string },
+  body: Record<string, unknown>,
+) {
+  return app.inject({
+    method: 'PATCH',
+    url: '/admin/config',
+    payload: body,
+    headers: { 'content-type': 'application/json', 'x-faucet-csrf': auth.csrf },
+    cookies: { faucet_session: auth.session, faucet_csrf: auth.csrf },
+  });
+}
+
+afterEach(async () => {
+  for (const { app, tmp } of open.splice(0)) {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+describe('low-balance reward scaling', () => {
+  // baseline 10 NIM = 1_000_000 luna; threshold 20 NIM = 2_000_000 luna.
+
+  it('scales the reward from env-configured threshold + reduction when balance is below it', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.balance = 1_000_000n; // < 2_000_000 (scales) and >= 750_000 (payable)
+    const { app } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '25' },
+      driver,
+    );
+    const res = await claim(app);
+    expect(res.statusCode).toBe(200);
+    expect(driver.sends).toHaveLength(1);
+    expect(driver.sends[0]?.amount).toBe(750_000n); // 25% off 1_000_000
+  });
+
+  it('applies a dashboard PATCH live — no restart needed', async () => {
+    const driver = new FakeNimiqDriver();
+    // Enough for a full first claim (1_000_000) and still below the 20-NIM
+    // threshold afterwards (1_500_000) so the post-PATCH claim scales and pays.
+    driver.balance = 2_500_000n;
+    const { app } = await makeApp({}, driver); // no env low-balance settings
+
+    // Before any PATCH → full baseline.
+    const before = await claim(app);
+    expect(before.statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+
+    // Admin sets the low-balance settings via the dashboard API.
+    const auth = await login(app);
+    const patched = await patchConfig(app, auth, {
+      lowBalanceThresholdNim: 20,
+      lowBalanceReductionPercent: 25,
+    });
+    expect(patched.statusCode).toBe(200);
+
+    // Next claim reflects the override immediately.
+    const after = await claim(app, { address: 'NQ00 2222 2222 2222 2222 2222 2222 2222 2222' });
+    expect(after.statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(750_000n);
+  });
+
+  it('pays the full baseline when balance is at or above the threshold', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.balance = 2_500_000n; // >= 2_000_000 threshold
+    const { app } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '25' },
+      driver,
+    );
+    const res = await claim(app);
+    expect(res.statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+  });
+
+  it('100% reduction pauses payouts: opaque reject, no send, reason scaled_to_zero', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.balance = 1_000_000n; // below threshold
+    const { app, ctx } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '100' },
+      driver,
+    );
+    const res = await claim(app);
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toMatchObject({ status: 'rejected' });
+    expect(driver.sends).toHaveLength(0);
+
+    const id = res.json().id as string;
+    const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
+    expect(row?.rejectionReason).toBe('automatic_reward_scaled_to_zero');
+  });
+
+  it('records the SCALED amount on the broadcast claim row (regression: line-458 bug)', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.balance = 1_000_000n;
+    const { app } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '25' },
+      driver,
+    );
+    const res = await claim(app);
+    const id = res.json().id as string;
+    const status = await app.inject({ method: 'GET', url: `/v1/claim/${id}` });
+    expect(status.json().amountLuna).toBe('750000'); // scaled, not the 100000 config claimAmountLuna
+  });
+
+  it('GET /admin/config reports the effective (overridden) low-balance settings', async () => {
+    const { app } = await makeApp();
+    const auth = await login(app);
+    await patchConfig(app, auth, { lowBalanceThresholdNim: 20, lowBalanceReductionPercent: 25 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/admin/config',
+      cookies: { faucet_session: auth.session },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().base.lowBalanceThresholdNim).toBe(20);
+    expect(res.json().base.lowBalanceReductionPercent).toBe(25);
+  });
+
+  it('/v1/config still reports the UNSCALED baseline (no wallet-state leak)', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.balance = 1_000_000n; // below threshold — scaling would apply to a claim
+    const { app } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '25' },
+      driver,
+    );
+    const res = await app.inject({ method: 'GET', url: '/v1/config' });
+    expect(res.json().claimAmountLuna).toBe('1000000');
+    expect(res.json().claimAmountNim).toBe('10');
+  });
+
+  it('does NOT scale when getBalance() fails — pays the full baseline', async () => {
+    const driver = new FakeNimiqDriver();
+    driver.failBalance = true;
+    const { app } = await makeApp(
+      { lowBalanceThresholdNim: '20', lowBalanceReductionPercent: '25' },
+      driver,
+    );
+    const res = await claim(app);
+    expect(res.statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+  });
+
+  it('PATCH /admin/config requires an admin session', async () => {
+    const { app } = await makeApp();
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/admin/config',
+      payload: { lowBalanceThresholdNim: 20 },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.statusCode).toBeGreaterThanOrEqual(401);
+    expect(res.statusCode).toBeLessThan(404);
+  });
+});

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -11,7 +11,7 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 - Runtime overrides via `PATCH /admin/config` (claim amount, rate limit, abuse thresholds, layer toggles) — see [`apps/server/src/routes/admin/config.ts`](../apps/server/src/routes/admin/config.ts) and the `AdminConfigPatch` schema in [`apps/server/src/openapi/schemas.ts`](../apps/server/src/openapi/schemas.ts).
 - The public derivation served at `GET /v1/config` — see [`apps/server/src/configView.ts`](../apps/server/src/configView.ts).
 
-## All variables (76)
+## All variables (78)
 
 | Env var | Type | Default | Constraints | Required | Description |
 |---|---|---|---|---|---|
@@ -32,6 +32,8 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 | `FAUCET_MIN_BALANCE_LUNA` | bigint | — | — |  | Minimum wallet balance (in luna) the faucet must hold for `/readyz` to report healthy. Below this, `/readyz` returns 503 so Kubernetes stops routing traffic to a faucet that's about to run dry. Optional — when unset, balance is reported informationally and never fails the probe (preserves the original §1.0 behaviour). Recommended floor: ~10 × `claimAmountLuna` so the probe trips before the wallet actually empties. |
 | `FAUCET_AUTOMATIC_REWARDS_ENABLED` | boolean | `false` | — |  | Automatic reward mode (§ Phase 1). When true, the faucet derives every payout from `automaticRewardsBaselineNim` instead of the fixed `claimAmountLuna`, and any amount a developer app sends is ignored. The foundation for a future criteria-driven reward system (boosts, repeat-user reductions, low-balance scaling, whitelists). Default off. |
 | `FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM` | number | — | — |  | Baseline automatic-mode payout, in NIM (1 NIM = 100_000 luna). Used for every valid claim when `automaticRewardsEnabled` is true. Intentionally NOT constrained to > 0 here: an invalid value (missing/zero/negative) is handled at request time as an opaque rejection plus a non-fatal boot warning, never a fatal config-parse error — so a misconfigured faucet still boots and does not leak its state to clients. |
+| `FAUCET_LOW_BALANCE_THRESHOLD_NIM` | number | — | min: 0 |  | Low-balance reward scaling threshold, in NIM. When automatic mode is on and the wallet balance drops below this, each reward is reduced by `lowBalanceReductionPercent`. This is the env DEFAULT; an admin can override it live from the dashboard (persisted in `runtime_config`, read per payout). Unset (or ≤ 0) disables low-balance scaling. |
+| `FAUCET_LOW_BALANCE_REDUCTION_PERCENT` | number | — | min: 0, max: 100 |  | Flat percent (0–100) by which rewards are reduced while the wallet balance is below `lowBalanceThresholdNim`. 100 pauses payouts (a reward of zero is refused opaquely). Env DEFAULT; admin-overridable live from the dashboard. |
 | `FAUCET_RATE_LIMIT_PER_MINUTE` | integer | `30` | min: 1 |  | — |
 | `FAUCET_RATE_LIMIT_PER_IP_PER_DAY` | integer | `5` | min: 1 |  | — |
 | `FAUCET_TURNSTILE_SITE_KEY` | string | — | — |  | — |


### PR DESCRIPTION
## Summary

Adds the first **reward adjustment rule** on top of automatic mode: when the wallet balance drops below a configured **threshold (NIM)**, each reward is reduced by a configured **flat percent**. Both settings are editable from the **admin dashboard** and applied **live** (read per payout from `runtime_config`) — no restart. This is the Phase-2 build-out of the `adjustments[]` extension point left by #249.

Example: threshold 20 NIM, reduction 25% → while the wallet is below 20 NIM, a 10-NIM baseline pays 7.5 NIM; at/above 20 NIM it pays the full 10 NIM. A 100% reduction pauses payouts (refused opaquely).

## Changes

**Reward engine** [`rewards/automatic.ts`](apps/server/src/rewards/automatic.ts)
- `calculateAutomaticReward` now takes `{ lowBalanceThresholdNim, lowBalanceReductionPercent, balanceLuna }` and populates `adjustments[]` via **basis-point bigint math** (truncates down → never over-pays; out-of-range reduction ignored defensively; **unknown balance → no scaling**).
- `resolveRewardSettings` merges persisted admin overrides over env defaults (override-wins; a malformed/out-of-range `runtime_config` value falls back to env).

**Claim handler** [`routes/claim.ts`](apps/server/src/routes/claim.ts)
- In the allow branch, reuses the **single balance snapshot** to compute the scaled reward live and threads it through `send` + every claim record + the audit log. New opaque refusal reason `automatic_reward_scaled_to_zero`. `null` balance passed through unchanged so an RPC blip never halves payouts.
- **Bug fix:** the broadcast (success) claim insert recorded `ctx.config.claimAmountLuna` instead of the actual payout amount (a #249 `replace_all` miss). The tx always sent the right amount; only the DB audit row was wrong.

**Live-config plumbing**
- [`runtimeConfig.ts`](apps/server/src/runtimeConfig.ts) (new): shared `readRuntimeOverrides`, used by the refactored [`admin/config.ts`](apps/server/src/routes/admin/config.ts) and the claim handler (no layering smell).
- Env defaults `FAUCET_LOW_BALANCE_THRESHOLD_NIM` / `FAUCET_LOW_BALANCE_REDUCTION_PERCENT` ([`config.ts`](apps/server/src/config.ts)) + regenerated [`docs/config-reference.md`](docs/config-reference.md) + [`.env.example`](.env.example).

**Admin API + dashboard**
- `AdminConfigPatch` / `AdminConfigResponse.base` gain the two fields; `GET /admin/config` reports the **effective** (merged) values; OpenAPI PATCH note updated. **No DB columns, no new routes** → schema/openapi parity tests untouched.
- [`ConfigView.vue`](apps/dashboard/src/views/ConfigView.vue): two numeric inputs wired to load/save, with a "applies live" hint.
- `/v1/config` keeps showing the **unscaled baseline** — no wallet-state leak to anonymous clients.
- New metric `faucet_reward_adjustments_total{kind}`.

## Decisions (confirmed with reviewer)
- **Live, not restart** — read per payout. **Flat** reduction. **Pause at 0** — a 100% reduction refuses opaquely. Scaling is **automatic-mode only**.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes (incl. dashboard `vue-tsc`)
- [x] `pnpm test` — **208 server tests**; new unit (scaling math, edges, settings merge) + e2e (live PATCH, env default, above-threshold, 100% pause, **scaled broadcast row** regression, `/v1/config` unscaled, `getBalance` failure, PATCH auth)
- [x] `pnpm pre-merge` (typecheck + build + test + config-reference drift) green
- [x] Parity guard green: `schema-parity`, `openapi-parity`, `openapi.e2e`, `sdk-contract`
- [ ] `pnpm test:e2e` — n/a (no public route-shape change; `/v1/claim` contract unchanged)

## Security checklist

- [x] No secrets in diff
- [x] New inputs validated at boundary (Zod: threshold ≥ 0, reduction 0–100; defensive clamp in the pure reward fn so a bad value can't over-pay)
- [x] No stack traces in user-facing errors — invalid/zero/over-balance rewards return the opaque uniform reject, reason logged server-side only
- [x] Admin mutations go through `/admin/*` (CSRF + session; no new direct DB writes from UI)
- [x] New env vars added to `.env.example` with a one-line description
- [x] Timing-safe comparisons where user input meets secrets (none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)