### PR TITLE
feat(server): first-time reward boost (identity-gated, live config)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,15 @@ FAUCET_RATE_LIMIT_PER_IP_PER_DAY=5
 # threshold of 0/unset disables scaling; a 100% reduction pauses payouts.
 # FAUCET_LOW_BALANCE_THRESHOLD_NIM=20
 # FAUCET_LOW_BALANCE_REDUCTION_PERCENT=50
+#
+# First-time boost (automatic mode only): pay a never-before-paid claimant an
+# extra percent (0–500). Suppressed while the wallet is below the low-balance
+# threshold. IP + address always define "first-time"; optionally also use the
+# device fingerprint and/or the integrator uid (uid counts only for HMAC-verified
+# integrator claims). Env defaults; admin-overridable live from the dashboard.
+# FAUCET_FIRST_TIME_BOOST_PERCENT=50
+# FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT=false
+# FAUCET_FIRST_TIME_BOOST_USE_UID=false
 
 # Minimum delay (ms) before any public claim-reject response is delivered.
 # Defends against pipeline-position timing attribution — without padding,

--- a/apps/dashboard/src/views/ConfigView.vue
+++ b/apps/dashboard/src/views/ConfigView.vue
@@ -21,6 +21,9 @@ interface ConfigResponse {
     abuseReviewThreshold: number;
     lowBalanceThresholdNim: number | null;
     lowBalanceReductionPercent: number | null;
+    firstTimeBoostPercent: number | null;
+    firstTimeBoostUseFingerprint: boolean;
+    firstTimeBoostUseUid: boolean;
     layers: LayerFlags;
   };
   overrides: Record<string, unknown>;
@@ -33,6 +36,9 @@ type PatchBody = {
   abuseReviewThreshold?: number;
   lowBalanceThresholdNim?: number;
   lowBalanceReductionPercent?: number;
+  firstTimeBoostPercent?: number;
+  firstTimeBoostUseFingerprint?: boolean;
+  firstTimeBoostUseUid?: boolean;
   layers?: Partial<LayerFlags>;
 };
 
@@ -49,6 +55,9 @@ const form = reactive({
   abuseReviewThreshold: 0.5,
   lowBalanceThresholdNim: 0,
   lowBalanceReductionPercent: 0,
+  firstTimeBoostPercent: 0,
+  firstTimeBoostUseFingerprint: false,
+  firstTimeBoostUseUid: false,
   layers: {
     turnstile: false,
     hcaptcha: false,
@@ -71,6 +80,9 @@ async function load(): Promise<void> {
     form.abuseReviewThreshold = res.base.abuseReviewThreshold;
     form.lowBalanceThresholdNim = res.base.lowBalanceThresholdNim ?? 0;
     form.lowBalanceReductionPercent = res.base.lowBalanceReductionPercent ?? 0;
+    form.firstTimeBoostPercent = res.base.firstTimeBoostPercent ?? 0;
+    form.firstTimeBoostUseFingerprint = res.base.firstTimeBoostUseFingerprint;
+    form.firstTimeBoostUseUid = res.base.firstTimeBoostUseUid;
     form.layers = { ...res.base.layers };
     overrides.value = res.overrides;
     error.value = null;
@@ -94,6 +106,9 @@ async function onSave(): Promise<void> {
       abuseReviewThreshold: Number(form.abuseReviewThreshold),
       lowBalanceThresholdNim: Number(form.lowBalanceThresholdNim),
       lowBalanceReductionPercent: Number(form.lowBalanceReductionPercent),
+      firstTimeBoostPercent: Number(form.firstTimeBoostPercent),
+      firstTimeBoostUseFingerprint: form.firstTimeBoostUseFingerprint,
+      firstTimeBoostUseUid: form.firstTimeBoostUseUid,
       layers: { ...form.layers },
     };
     const res = await api.patch<{ ok: true; persistedKeys: string[] }>('/admin/config', body);
@@ -206,7 +221,40 @@ onMounted(load);
           />
           <span class="muted">Flat reduction applied while below the threshold. 100 pauses payouts.</span>
         </label>
+        <label class="flex flex-col gap-1 text-xs">
+          <span>First-time boost (%)</span>
+          <input
+            v-model.number="form.firstTimeBoostPercent"
+            class="input font-mono"
+            type="number"
+            min="0"
+            max="500"
+            step="1"
+            required
+          />
+          <span class="muted">Extra reward for a never-paid claimant. Suppressed while the wallet is low. 0 disables it.</span>
+        </label>
       </div>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-xs font-semibold">First-time identity signals</legend>
+        <p class="muted text-xs">
+          IP and address always define a first-time user; enable extra signals to make the boost
+          harder to farm (a returning user on any enabled signal gets no boost).
+        </p>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="form.firstTimeBoostUseFingerprint" type="checkbox" />
+          <span>Use device fingerprint (visitorId)</span>
+        </label>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="form.firstTimeBoostUseUid" type="checkbox" />
+          <span>Use user id (uid)</span>
+        </label>
+        <span class="muted text-xs">
+          The user-id signal only counts for verified-integrator (HMAC-signed) claims; browser-only
+          claims never match it.
+        </span>
+      </fieldset>
 
       <fieldset class="flex flex-wrap gap-3">
         <legend class="text-xs font-semibold">Abuse layers</legend>

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -63,6 +63,26 @@ export const ServerConfigSchema = z.object({
    * refused opaquely). Env DEFAULT; admin-overridable live from the dashboard.
    */
   lowBalanceReductionPercent: z.coerce.number().min(0).max(100).optional(),
+
+  /**
+   * First-time reward boost percent (0–500), automatic mode only. A claimant who
+   * has never been paid before gets `baseline × (1 + percent/100)`. Suppressed
+   * while the wallet is below `lowBalanceThresholdNim`. Env DEFAULT; an admin can
+   * override it live from the dashboard. Unset/0 disables the boost.
+   */
+  firstTimeBoostPercent: z.coerce.number().min(0).max(500).optional(),
+  /**
+   * Include the device fingerprint `visitorId` as a first-time identity signal
+   * (a returning device is denied the boost even from a new IP/address). Env
+   * DEFAULT; admin-overridable live. Default off.
+   */
+  firstTimeBoostUseFingerprint: z.coerce.boolean().default(false),
+  /**
+   * Include the integrator `uid` as a first-time identity signal. Only counts for
+   * HMAC-verified host contexts — browser-only claims never match. Env DEFAULT;
+   * admin-overridable live. Default off.
+   */
+  firstTimeBoostUseUid: z.coerce.boolean().default(false),
   rateLimitPerMinute: z.coerce.number().int().min(1).default(30),
   rateLimitPerIpPerDay: z.coerce.number().int().min(1).default(5),
 
@@ -295,6 +315,9 @@ export const ENV_KEYS: Record<string, string> = {
   automaticRewardsBaselineNim: 'FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM',
   lowBalanceThresholdNim: 'FAUCET_LOW_BALANCE_THRESHOLD_NIM',
   lowBalanceReductionPercent: 'FAUCET_LOW_BALANCE_REDUCTION_PERCENT',
+  firstTimeBoostPercent: 'FAUCET_FIRST_TIME_BOOST_PERCENT',
+  firstTimeBoostUseFingerprint: 'FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT',
+  firstTimeBoostUseUid: 'FAUCET_FIRST_TIME_BOOST_USE_UID',
   rateLimitPerMinute: 'FAUCET_RATE_LIMIT_PER_MINUTE',
   rateLimitPerIpPerDay: 'FAUCET_RATE_LIMIT_PER_IP_PER_DAY',
   turnstileSiteKey: 'FAUCET_TURNSTILE_SITE_KEY',

--- a/apps/server/src/configView.ts
+++ b/apps/server/src/configView.ts
@@ -118,6 +118,9 @@ export function deriveAdminConfigBase(
     abuseReviewThreshold: config.aiReviewThreshold,
     lowBalanceThresholdNim: reward.lowBalanceThresholdNim ?? null,
     lowBalanceReductionPercent: reward.lowBalanceReductionPercent ?? null,
+    firstTimeBoostPercent: reward.firstTimeBoostPercent ?? null,
+    firstTimeBoostUseFingerprint: reward.firstTimeBoostUseFingerprint,
+    firstTimeBoostUseUid: reward.firstTimeBoostUseUid,
     layers: deriveAbuseLayers(config),
   };
 }

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -64,10 +64,15 @@ function runMigrations(db: any, dialect: 'sqlite' | 'pg'): void {
     }
     // v1.7.0: idempotency key column migration (ALTER TABLE).
     try { exec('ALTER TABLE claims ADD COLUMN idempotency_key TEXT'); } catch { /* already exists */ }
+    // First-time-boost identity columns (nullable).
+    try { exec('ALTER TABLE claims ADD COLUMN fingerprint_visitor_id TEXT'); } catch { /* already exists */ }
+    try { exec('ALTER TABLE claims ADD COLUMN host_uid TEXT'); } catch { /* already exists */ }
   }
   if (dialect === 'pg') {
     // Postgres supports IF NOT EXISTS on ALTER TABLE.
     try { exec('ALTER TABLE claims ADD COLUMN IF NOT EXISTS idempotency_key TEXT'); } catch { /* */ }
+    try { exec('ALTER TABLE claims ADD COLUMN IF NOT EXISTS fingerprint_visitor_id TEXT'); } catch { /* */ }
+    try { exec('ALTER TABLE claims ADD COLUMN IF NOT EXISTS host_uid TEXT'); } catch { /* */ }
   }
 
   // Shared CREATE TABLE + CREATE INDEX statements.

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -32,11 +32,21 @@ export function migrationStatements(dialect: Dialect): string[] {
       decision TEXT NOT NULL,
       signals_json TEXT NOT NULL DEFAULT '{}',
       rejection_reason TEXT,
-      idempotency_key TEXT
+      idempotency_key TEXT,
+      fingerprint_visitor_id TEXT,
+      host_uid TEXT
     )`,
     'CREATE INDEX IF NOT EXISTS idx_claims_created_at ON claims(created_at DESC)',
     'CREATE INDEX IF NOT EXISTS idx_claims_address ON claims(address)',
     'CREATE INDEX IF NOT EXISTS idx_claims_ip ON claims(ip)',
+    // First-time-boost detection dimensions (opt-in). Partial indexes keep them
+    // tiny — only claims that actually carried the signal are indexed.
+    `CREATE INDEX IF NOT EXISTS idx_claims_fp_visitor
+      ON claims(fingerprint_visitor_id)
+      WHERE fingerprint_visitor_id IS NOT NULL`,
+    `CREATE INDEX IF NOT EXISTS idx_claims_host_uid
+      ON claims(host_uid)
+      WHERE host_uid IS NOT NULL`,
     // #86: idempotency was previously keyed by `idempotency_key` alone,
     // letting callers across unrelated integrators collide on the same
     // string and read each other's claim status. Drop the global index

--- a/apps/server/src/db/schema.pg.ts
+++ b/apps/server/src/db/schema.pg.ts
@@ -24,6 +24,10 @@ export const claims = pgTable('claims', {
   signalsJson: text('signals_json').notNull().default('{}'),
   rejectionReason: text('rejection_reason'),
   idempotencyKey: text('idempotency_key'),
+  // Identity signals for first-time-boost detection (nullable). `host_uid` is
+  // recorded only when the host context was HMAC-verified.
+  fingerprintVisitorId: text('fingerprint_visitor_id'),
+  hostUid: text('host_uid'),
 });
 
 export const blocklist = pgTable('blocklist', {

--- a/apps/server/src/db/schema.sqlite.ts
+++ b/apps/server/src/db/schema.sqlite.ts
@@ -18,6 +18,10 @@ export const claims = sqliteTable('claims', {
   signalsJson: text('signals_json').notNull().default('{}'),
   rejectionReason: text('rejection_reason'),
   idempotencyKey: text('idempotency_key'),
+  // Identity signals for first-time-boost detection (nullable). `host_uid` is
+  // recorded only when the host context was HMAC-verified.
+  fingerprintVisitorId: text('fingerprint_visitor_id'),
+  hostUid: text('host_uid'),
 });
 
 export const blocklist = sqliteTable('blocklist', {

--- a/apps/server/src/openapi/document.ts
+++ b/apps/server/src/openapi/document.ts
@@ -261,8 +261,9 @@ function registerRoutes(): void {
     tags: ['Admin'],
     summary: 'Persist runtime config overrides',
     description:
-      'Persists runtime config overrides. Abuse-layer toggles and the low-balance reward keys ' +
-      '(lowBalanceThresholdNim, lowBalanceReductionPercent) apply live; other keys require a restart.',
+      'Persists runtime config overrides. Abuse-layer toggles and the reward keys ' +
+      '(lowBalanceThresholdNim, lowBalanceReductionPercent, firstTimeBoostPercent, ' +
+      'firstTimeBoostUseFingerprint, firstTimeBoostUseUid) apply live; other keys require a restart.',
     security: [{ adminSession: [] }],
     request: { body: { content: jsonContent(AdminConfigPatch) } },
     responses: { 200: { description: 'Persisted', content: jsonContent(OkResponse) } },

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -294,6 +294,11 @@ export const AdminConfigPatch = registry.register(
       // runtime_config). Threshold in NIM; reduction is a flat percent.
       lowBalanceThresholdNim: z.number().min(0).optional(),
       lowBalanceReductionPercent: z.number().min(0).max(100).optional(),
+      // First-time boost — applied live. Percent capped at 500 to bound a
+      // fat-finger fund drain; the two flags toggle the optional identity signals.
+      firstTimeBoostPercent: z.number().min(0).max(500).optional(),
+      firstTimeBoostUseFingerprint: z.boolean().optional(),
+      firstTimeBoostUseUid: z.boolean().optional(),
       layers: z
         .object({
           turnstile: z.boolean().optional(),
@@ -322,6 +327,10 @@ export const AdminConfigResponse = registry.register(
       // null when unset. Threshold in NIM, reduction as a flat percent.
       lowBalanceThresholdNim: z.number().nullable(),
       lowBalanceReductionPercent: z.number().nullable(),
+      // Effective first-time boost settings. Percent null when unset.
+      firstTimeBoostPercent: z.number().nullable(),
+      firstTimeBoostUseFingerprint: z.boolean(),
+      firstTimeBoostUseUid: z.boolean(),
       layers: z.record(z.string(), z.boolean()),
     }),
     overrides: z.record(z.string(), z.unknown()),

--- a/apps/server/src/rewards/automatic.test.ts
+++ b/apps/server/src/rewards/automatic.test.ts
@@ -179,23 +179,103 @@ describe('calculateAutomaticReward — low-balance scaling', () => {
   });
 });
 
+describe('calculateAutomaticReward — first-time boost', () => {
+  // baseline 10 NIM = 1_000_000 luna.
+  it('boosts a first-time claimant when the wallet is not low (no threshold configured)', () => {
+    const r = calculateAutomaticReward({ baselineNim: 10, firstTimeBoostPercent: 50, isFirstTime: true });
+    expect(r.amount).toBe(1_500_000n);
+    expect(r.adjustments).toEqual([
+      { kind: 'first-time-boost', deltaLuna: 500_000n, reason: 'first-time claimant; reward boosted 50%' },
+    ]);
+  });
+
+  it('boosts when first-time and balance is at/above the threshold', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      firstTimeBoostPercent: 50,
+      isFirstTime: true,
+      lowBalanceThresholdNim: 20,
+      balanceLuna: 5_000_000n, // >= 20 NIM threshold
+    });
+    expect(r.amount).toBe(1_500_000n);
+  });
+
+  it('does not boost a returning claimant or when the boost is 0/undefined', () => {
+    expect(calculateAutomaticReward({ baselineNim: 10, firstTimeBoostPercent: 50, isFirstTime: false }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ baselineNim: 10, firstTimeBoostPercent: 0, isFirstTime: true }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ baselineNim: 10, isFirstTime: true }).amount).toBe(1_000_000n);
+  });
+
+  // Key decision: the boost is suppressed while the wallet is low; the
+  // low-balance pause is preserved even for first-time claimants.
+  it('suppresses the boost while the wallet is below the threshold (only reduction applies)', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      firstTimeBoostPercent: 50,
+      isFirstTime: true,
+      lowBalanceThresholdNim: 20,
+      lowBalanceReductionPercent: 25,
+      balanceLuna: 1_000_000n, // < 20 NIM threshold
+    });
+    expect(r.amount).toBe(750_000n); // reduction only, NO boost
+    expect(r.adjustments.map((a) => a.kind)).toEqual(['low-balance-scaling']);
+  });
+
+  it('a 100% reduction still pauses payouts for a first-timer (boost cannot rescue it)', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      firstTimeBoostPercent: 500,
+      isFirstTime: true,
+      lowBalanceThresholdNim: 20,
+      lowBalanceReductionPercent: 100,
+      balanceLuna: 1_000_000n,
+    });
+    expect(r.amount).toBe(0n);
+  });
+
+  it('suppresses the boost when a threshold is set but the balance is unknown', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      firstTimeBoostPercent: 50,
+      isFirstTime: true,
+      lowBalanceThresholdNim: 20,
+      balanceLuna: null,
+    });
+    expect(r.amount).toBe(1_000_000n);
+  });
+
+  it('ignores an out-of-range boost (>500) defensively', () => {
+    const r = calculateAutomaticReward({ baselineNim: 10, firstTimeBoostPercent: 600, isFirstTime: true });
+    expect(r.amount).toBe(1_000_000n);
+    expect(r.adjustments).toEqual([]);
+  });
+});
+
 describe('resolveRewardSettings', () => {
   const cfg = {
     automaticRewardsEnabled: true,
     automaticRewardsBaselineNim: 10,
     lowBalanceThresholdNim: 20,
     lowBalanceReductionPercent: 30,
+    firstTimeBoostPercent: 40,
+    firstTimeBoostUseFingerprint: false,
+    firstTimeBoostUseUid: false,
     claimAmountLuna: 100_000n,
   };
 
-  it('lets a valid persisted override win over the env default', () => {
+  it('lets valid persisted overrides win over the env defaults', () => {
     const s = resolveRewardSettings(cfg, {
       lowBalanceThresholdNim: 5,
       lowBalanceReductionPercent: 60,
+      firstTimeBoostPercent: 75,
+      firstTimeBoostUseFingerprint: true,
+      firstTimeBoostUseUid: true,
     });
     expect(s.lowBalanceThresholdNim).toBe(5);
     expect(s.lowBalanceReductionPercent).toBe(60);
-    // enabled + baseline stay env-only
+    expect(s.firstTimeBoostPercent).toBe(75);
+    expect(s.firstTimeBoostUseFingerprint).toBe(true);
+    expect(s.firstTimeBoostUseUid).toBe(true);
     expect(s.enabled).toBe(true);
     expect(s.baselineNim).toBe(10);
   });
@@ -204,17 +284,23 @@ describe('resolveRewardSettings', () => {
     const s = resolveRewardSettings(cfg, {
       lowBalanceThresholdNim: 'oops',
       lowBalanceReductionPercent: 150,
+      firstTimeBoostPercent: 9999, // > 500
+      firstTimeBoostUseFingerprint: 'yes', // not a boolean
     });
     expect(s.lowBalanceThresholdNim).toBe(20);
     expect(s.lowBalanceReductionPercent).toBe(30);
+    expect(s.firstTimeBoostPercent).toBe(40);
+    expect(s.firstTimeBoostUseFingerprint).toBe(false);
   });
 
-  it('returns undefined when neither override nor env default is set', () => {
+  it('returns undefined/false when neither override nor env default is set', () => {
     const s = resolveRewardSettings(
       { automaticRewardsEnabled: false, claimAmountLuna: 100_000n },
       {},
     );
     expect(s.lowBalanceThresholdNim).toBeUndefined();
-    expect(s.lowBalanceReductionPercent).toBeUndefined();
+    expect(s.firstTimeBoostPercent).toBeUndefined();
+    expect(s.firstTimeBoostUseFingerprint).toBe(false);
+    expect(s.firstTimeBoostUseUid).toBe(false);
   });
 });

--- a/apps/server/src/rewards/automatic.ts
+++ b/apps/server/src/rewards/automatic.ts
@@ -42,6 +42,8 @@ export interface RewardResult {
 const LUNA_PER_NIM = 100_000;
 /** Percent → basis points (×100), so a fractional percent stays exact in bigint math. */
 const BASIS_POINTS = 10_000n;
+/** Defensive ceiling on the first-time boost (also enforced by Zod + the admin API). */
+const MAX_FIRST_TIME_BOOST_PERCENT = 500;
 
 /**
  * Convert an operator-supplied NIM amount to Luna (bigint).
@@ -64,55 +66,86 @@ export interface RewardInput {
   lowBalanceThresholdNim?: number | undefined;
   /** Flat reduction percent (0–100) applied below the threshold. */
   lowBalanceReductionPercent?: number | undefined;
+  /** Whether this claimant qualifies for the first-time boost (caller decides). */
+  isFirstTime?: boolean | undefined;
+  /** First-time boost percent (0–500); applies only when not in a low-balance state. */
+  firstTimeBoostPercent?: number | undefined;
   /**
    * Current wallet balance in Luna, or `null`/`undefined` when unknown. When
    * unknown, low-balance scaling is skipped (never reduce on a stale/failed
-   * balance read — that would silently halve every payout during an RPC blip).
+   * balance read — that would silently halve every payout during an RPC blip),
+   * and the first-time boost is suppressed (we can't confirm the wallet is healthy).
    */
   balanceLuna?: bigint | null | undefined;
 }
 
 /**
- * Compute the automatic reward. Pure and total — never throws.
+ * Compute the automatic reward. Pure and total — never throws. The final amount
+ * is the baseline plus the sum of every applied adjustment delta, floored at 0.
  *
- * Low-balance scaling fires only when ALL hold: a positive baseline, a positive
- * threshold, a reduction in `(0, 100]`, a known balance, and `balance <
- * threshold`. The reduction uses basis-point bigint math (truncates *down*, so
- * it never over-pays). A reduction outside `(0, 100]` is ignored defensively, so
- * a bad config can never produce `amount > baseline`.
- *
- * A 100% reduction yields `amount: 0n`; the caller refuses such a claim opaquely
- * (pausing payouts while the wallet is critically low) rather than sending 0.
+ * Two rules, mutually exclusive by balance state:
+ *  - **Low-balance scaling** (negative) fires when a positive threshold is set,
+ *    the balance is known, and `balance < threshold`. Basis-point bigint math
+ *    truncates *down* (never over-pays); a reduction outside `(0, 100]` is
+ *    ignored. A 100% reduction yields `amount: 0n` (caller refuses → pause).
+ *  - **First-time boost** (positive) fires when `isFirstTime`, a boost in
+ *    `(0, 500]` is set, and the wallet is known to be at/above the threshold
+ *    (or no threshold is configured). It is **suppressed while the wallet is low
+ *    or its balance is unknown** — a low faucet must not hand out extra.
  */
 export function calculateAutomaticReward(input: RewardInput): RewardResult {
   const baseline = nimToLuna(input.baselineNim);
   const adjustments: RewardAdjustment[] = [];
-  let amount = baseline;
 
   const thresholdLuna = nimToLuna(input.lowBalanceThresholdNim);
-  const reduction = input.lowBalanceReductionPercent;
-  const reductionValid =
-    reduction !== undefined && Number.isFinite(reduction) && reduction > 0 && reduction <= 100;
+  const balanceKnown = input.balanceLuna !== undefined && input.balanceLuna !== null;
+  // "Low-balance state" = a threshold is configured and we're confident the
+  // wallet is below it. When a threshold is set but the balance can't be read,
+  // we treat the state as uncertain: skip the reduction AND suppress the boost.
+  const lowBalanceConfigured = thresholdLuna > 0n;
+  const walletIsLow = lowBalanceConfigured && balanceKnown && (input.balanceLuna as bigint) < thresholdLuna;
+  const lowBalanceUncertain = lowBalanceConfigured && !balanceKnown;
 
-  if (
-    baseline > 0n &&
-    thresholdLuna > 0n &&
-    reductionValid &&
-    input.balanceLuna !== undefined &&
-    input.balanceLuna !== null &&
-    input.balanceLuna < thresholdLuna
-  ) {
-    const reductionBp = BigInt(Math.round((reduction as number) * 100));
-    const reduced = (baseline * (BASIS_POINTS - reductionBp)) / BASIS_POINTS;
-    if (reduced !== baseline) {
-      adjustments.push({
-        kind: 'low-balance-scaling',
-        deltaLuna: reduced - baseline,
-        reason: `wallet balance below ${input.lowBalanceThresholdNim} NIM; reward reduced ${reduction}%`,
-      });
-      amount = reduced;
+  // Low-balance reduction (negative delta) — only while the wallet is low.
+  if (baseline > 0n && walletIsLow) {
+    const reduction = input.lowBalanceReductionPercent;
+    const reductionValid =
+      reduction !== undefined && Number.isFinite(reduction) && reduction > 0 && reduction <= 100;
+    if (reductionValid) {
+      const reductionBp = BigInt(Math.round(reduction * 100));
+      const reduced = (baseline * (BASIS_POINTS - reductionBp)) / BASIS_POINTS;
+      if (reduced !== baseline) {
+        adjustments.push({
+          kind: 'low-balance-scaling',
+          deltaLuna: reduced - baseline,
+          reason: `wallet balance below ${input.lowBalanceThresholdNim} NIM; reward reduced ${reduction}%`,
+        });
+      }
     }
   }
+
+  // First-time boost (positive delta) — only when the wallet is confidently NOT
+  // low (mutually exclusive with the reduction above).
+  if (baseline > 0n && input.isFirstTime && !walletIsLow && !lowBalanceUncertain) {
+    const boost = input.firstTimeBoostPercent;
+    const boostValid =
+      boost !== undefined && Number.isFinite(boost) && boost > 0 && boost <= MAX_FIRST_TIME_BOOST_PERCENT;
+    if (boostValid) {
+      const boostBp = BigInt(Math.round(boost * 100));
+      const boosted = (baseline * (BASIS_POINTS + boostBp)) / BASIS_POINTS;
+      if (boosted !== baseline) {
+        adjustments.push({
+          kind: 'first-time-boost',
+          deltaLuna: boosted - baseline,
+          reason: `first-time claimant; reward boosted ${boost}%`,
+        });
+      }
+    }
+  }
+
+  let amount = baseline;
+  for (const adj of adjustments) amount += adj.deltaLuna;
+  if (amount < 0n) amount = 0n;
 
   return { amount, rewardMode: 'automatic', baselineAmount: baseline, adjustments };
 }
@@ -123,6 +156,9 @@ export interface PayoutConfig {
   automaticRewardsBaselineNim?: number | undefined;
   lowBalanceThresholdNim?: number | undefined;
   lowBalanceReductionPercent?: number | undefined;
+  firstTimeBoostPercent?: number | undefined;
+  firstTimeBoostUseFingerprint?: boolean | undefined;
+  firstTimeBoostUseUid?: boolean | undefined;
   claimAmountLuna: bigint;
 }
 
@@ -153,6 +189,9 @@ export interface EffectiveRewardSettings {
   baselineNim?: number | undefined;
   lowBalanceThresholdNim?: number | undefined;
   lowBalanceReductionPercent?: number | undefined;
+  firstTimeBoostPercent?: number | undefined;
+  firstTimeBoostUseFingerprint: boolean;
+  firstTimeBoostUseUid: boolean;
 }
 
 function pickInRange(
@@ -168,11 +207,15 @@ function pickInRange(
   return envDefault;
 }
 
+function pickBool(override: unknown, envDefault: boolean): boolean {
+  return typeof override === 'boolean' ? override : envDefault;
+}
+
 /**
  * Merge persisted runtime overrides over env-derived config to produce the
- * effective reward settings used at claim time. Only the two low-balance keys
- * are read live (override-wins); a malformed/out-of-range `runtime_config` row
- * falls back to the env default so it can never widen behaviour unexpectedly.
+ * effective reward settings used at claim time. The low-balance + first-time
+ * keys are read live (override-wins); a malformed/out-of-range `runtime_config`
+ * row falls back to the env default so it can never widen behaviour unexpectedly.
  * `enabled` and `baselineNim` stay env-only.
  */
 export function resolveRewardSettings(
@@ -193,6 +236,20 @@ export function resolveRewardSettings(
       config.lowBalanceReductionPercent,
       0,
       100,
+    ),
+    firstTimeBoostPercent: pickInRange(
+      overrides.firstTimeBoostPercent,
+      config.firstTimeBoostPercent,
+      0,
+      MAX_FIRST_TIME_BOOST_PERCENT,
+    ),
+    firstTimeBoostUseFingerprint: pickBool(
+      overrides.firstTimeBoostUseFingerprint,
+      config.firstTimeBoostUseFingerprint ?? false,
+    ),
+    firstTimeBoostUseUid: pickBool(
+      overrides.firstTimeBoostUseUid,
+      config.firstTimeBoostUseUid ?? false,
     ),
   };
 }

--- a/apps/server/src/rewards/firstTime.test.ts
+++ b/apps/server/src/rewards/firstTime.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { openDb, type Db } from '../db/index.js';
+import { claims } from '../db/schema.js';
+import { isFirstTimeClaimant } from './firstTime.js';
+
+let tmp: string;
+let db: Db;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'faucet-firsttime-'));
+  db = openDb({ dataDir: tmp });
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function insertClaim(row: {
+  id: string;
+  ip: string;
+  address: string;
+  decision: string;
+  txId: string | null;
+  fingerprintVisitorId?: string | null;
+  hostUid?: string | null;
+}) {
+  await db.insert(claims).values({
+    id: row.id,
+    address: row.address,
+    amountLuna: '1000000',
+    status: row.txId ? 'broadcast' : 'rejected',
+    txId: row.txId,
+    ip: row.ip,
+    decision: row.decision,
+    fingerprintVisitorId: row.fingerprintVisitorId ?? null,
+    hostUid: row.hostUid ?? null,
+  });
+}
+
+const base = { useFingerprint: false, useUid: false } as const;
+
+describe('isFirstTimeClaimant', () => {
+  it('is true when there is no prior paid claim on any dimension', async () => {
+    expect(await isFirstTimeClaimant(db, { ip: 'IP1', address: 'A1', ...base })).toBe(true);
+  });
+
+  it('is false when a prior PAID claim shares the IP or the address', async () => {
+    await insertClaim({ id: '1', ip: 'IP1', address: 'A1', decision: 'allow', txId: 'tx1' });
+    expect(await isFirstTimeClaimant(db, { ip: 'IP1', address: 'A-new', ...base })).toBe(false); // IP match
+    expect(await isFirstTimeClaimant(db, { ip: 'IP-new', address: 'A1', ...base })).toBe(false); // address match
+    expect(await isFirstTimeClaimant(db, { ip: 'IP-new', address: 'A-new', ...base })).toBe(true);
+  });
+
+  it('only counts PAID claims (decision=allow AND txId not null)', async () => {
+    await insertClaim({ id: 'd', ip: 'IP2', address: 'A2', decision: 'deny', txId: null });
+    await insertClaim({ id: 't', ip: 'IP3', address: 'A3', decision: 'allow', txId: null }); // timeout
+    expect(await isFirstTimeClaimant(db, { ip: 'IP2', address: 'A2', ...base })).toBe(true);
+    expect(await isFirstTimeClaimant(db, { ip: 'IP3', address: 'A3', ...base })).toBe(true);
+  });
+
+  it('uses the fingerprint dimension only when enabled', async () => {
+    await insertClaim({ id: '1', ip: 'IP1', address: 'A1', decision: 'allow', txId: 'tx1', fingerprintVisitorId: 'V1' });
+    const q = { ip: 'IP-new', address: 'A-new', fingerprintVisitorId: 'V1' };
+    expect(await isFirstTimeClaimant(db, { ...q, useFingerprint: false, useUid: false })).toBe(true);
+    expect(await isFirstTimeClaimant(db, { ...q, useFingerprint: true, useUid: false })).toBe(false);
+  });
+
+  it('uses the uid dimension only when enabled', async () => {
+    await insertClaim({ id: '1', ip: 'IP1', address: 'A1', decision: 'allow', txId: 'tx1', hostUid: 'U1' });
+    const q = { ip: 'IP-new', address: 'A-new', hostUid: 'U1' };
+    expect(await isFirstTimeClaimant(db, { ...q, useFingerprint: false, useUid: false })).toBe(true);
+    expect(await isFirstTimeClaimant(db, { ...q, useFingerprint: false, useUid: true })).toBe(false);
+  });
+
+  it('ignores a null/absent optional signal even when the dimension is enabled', async () => {
+    await insertClaim({ id: '1', ip: 'IP1', address: 'A1', decision: 'allow', txId: 'tx1' });
+    // No visitorId on the query → fingerprint dimension contributes nothing; falls back to IP/address.
+    expect(
+      await isFirstTimeClaimant(db, { ip: 'IP-new', address: 'A-new', useFingerprint: true, useUid: true }),
+    ).toBe(true);
+  });
+});

--- a/apps/server/src/rewards/firstTime.ts
+++ b/apps/server/src/rewards/firstTime.ts
@@ -1,0 +1,47 @@
+/**
+ * First-time-claimant detection for the first-time reward boost.
+ *
+ * A claimant is "first-time" if NO prior **paid** claim (`decision='allow' AND
+ * tx_id IS NOT NULL`) matches on ANY enabled identity dimension. IP + address
+ * are always checked; the device fingerprint `visitorId` and the integrator
+ * `uid` are admin-opt-in extra dimensions. Because the dimensions are OR-ed, a
+ * returning user on *any* enabled signal is correctly denied the boost — so
+ * enabling more dimensions only makes the boost harder to farm.
+ *
+ * Security: `uid` is only ever passed in (and recorded) when the host context
+ * was HMAC-verified by an integrator; a forgeable/unverified uid must never
+ * reach this query. `visitorId` is client-rotatable, so it can only *deny* the
+ * boost, never grant one (the always-on IP+address gate backstops a rotation).
+ */
+import { and, eq, isNotNull, or, type SQL } from 'drizzle-orm';
+import type { Db } from '../db/index.js';
+import { claims } from '../db/schema.js';
+
+export interface FirstTimeQuery {
+  ip: string;
+  address: string;
+  /** Device fingerprint visitorId for this claim, if any. */
+  fingerprintVisitorId?: string | null | undefined;
+  /** Integrator uid for this claim — pass only when HMAC-verified. */
+  hostUid?: string | null | undefined;
+  useFingerprint: boolean;
+  useUid: boolean;
+}
+
+export async function isFirstTimeClaimant(db: Db, q: FirstTimeQuery): Promise<boolean> {
+  const dims: SQL[] = [eq(claims.ip, q.ip), eq(claims.address, q.address)];
+  if (q.useFingerprint && q.fingerprintVisitorId) {
+    dims.push(eq(claims.fingerprintVisitorId, q.fingerprintVisitorId));
+  }
+  if (q.useUid && q.hostUid) {
+    dims.push(eq(claims.hostUid, q.hostUid));
+  }
+
+  const [row] = await db
+    .select({ id: claims.id })
+    .from(claims)
+    .where(and(eq(claims.decision, 'allow'), isNotNull(claims.txId), or(...dims)))
+    .limit(1);
+
+  return row === undefined;
+}

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -21,6 +21,7 @@ import {
   resolvePayout,
   resolveRewardSettings,
 } from '../rewards/automatic.js';
+import { isFirstTimeClaimant } from '../rewards/firstTime.js';
 import { readRuntimeOverrides } from '../runtimeConfig.js';
 
 // Extend the shared OpenAPI schema with the backwards-compat transform.
@@ -292,6 +293,13 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       requestedAt: now,
     };
 
+    // Identity signals recorded on every claim row for first-time-boost
+    // detection. `hostUid` is recorded ONLY when the host context was
+    // HMAC-verified — a forgeable/unverified uid must never enter the table
+    // (it would let an attacker poison detection or grief a victim's boost).
+    const fingerprintVisitorId = parsed.data.fingerprint?.visitorId ?? null;
+    const hostUid = hostContextVerified ? (parsed.data.hostContext?.uid ?? null) : null;
+
     const evaluation = await ctx.pipeline.evaluate(claimReq);
     const id = nanoid();
 
@@ -380,10 +388,27 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         balance = null;
       }
 
+      // First-time-boost detection. Only run the lookup when a boost is actually
+      // configured (zero-cost path otherwise). The current claim isn't inserted
+      // until after the send below, so it can't match itself.
+      let isFirstTime = false;
+      if ((settings.firstTimeBoostPercent ?? 0) > 0) {
+        isFirstTime = await isFirstTimeClaimant(ctx.db, {
+          ip: req.ip,
+          address,
+          fingerprintVisitorId,
+          hostUid,
+          useFingerprint: settings.firstTimeBoostUseFingerprint,
+          useUid: settings.firstTimeBoostUseUid,
+        });
+      }
+
       const reward = calculateAutomaticReward({
         baselineNim: settings.baselineNim,
         lowBalanceThresholdNim: settings.lowBalanceThresholdNim,
         lowBalanceReductionPercent: settings.lowBalanceReductionPercent,
+        firstTimeBoostPercent: settings.firstTimeBoostPercent,
+        isFirstTime,
         balanceLuna: balance,
       });
       finalPayout = { amountLuna: reward.amount, reward };
@@ -500,6 +525,10 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
       decision: 'allow',
       signalsJson: JSON.stringify(evaluation.signals),
       idempotencyKey: parsed.data.idempotencyKey ?? null,
+      // Recorded on the paid row so a later claim's first-time detection can
+      // match this identity. (Detection only reads decision='allow' + txId rows.)
+      fingerprintVisitorId,
+      hostUid,
     });
     inflightClaims.delete(address);
     // Automatic-mode payout: record the reward decision in the log for the audit

--- a/apps/server/test/first-time-boost.e2e.test.ts
+++ b/apps/server/test/first-time-boost.e2e.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import type { AppContext } from '../src/context.js';
+import { claims } from '../src/db/schema.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const ADMIN_PASSWORD = 'test-password-123';
+const A1 = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+const A2 = 'NQ00 2222 2222 2222 2222 2222 2222 2222 2222';
+const A3 = 'NQ00 3333 3333 3333 3333 3333 3333 3333 3333';
+
+class FakeNimiqDriver extends BaseTestDriver {
+  public sends: Array<{ to: string; amount: bigint }> = [];
+  public balance = 100_000_000n;
+  override async getBalance() {
+    return this.balance;
+  }
+  override async send(to: string, amount: bigint): Promise<string> {
+    this.sends.push({ to, amount });
+    this.balance -= amount;
+    return `tx_${this.sends.length}`;
+  }
+  override async waitForConfirmation(): Promise<void> {}
+}
+
+const open: Array<{ app: FastifyInstance; tmp: string }> = [];
+
+async function makeApp(
+  overrides: Record<string, unknown> = {},
+  driver: FakeNimiqDriver = new FakeNimiqDriver(),
+): Promise<{ app: FastifyInstance; driver: FakeNimiqDriver; ctx: AppContext }> {
+  const tmp = mkdtempSync(join(tmpdir(), 'faucet-ftb-'));
+  const config = ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: tmp,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: ADMIN_PASSWORD,
+    automaticRewardsEnabled: 'true',
+    automaticRewardsBaselineNim: '10', // 1_000_000 luna
+    dev: 'true',
+    rejectDelayMsMin: '0',
+    // dev mode trusts loopback XFF, so tests can vary the client IP.
+    ...overrides,
+  });
+  const { app, ctx } = await buildApp(config, { driverOverride: driver, quietLogs: true });
+  await app.ready();
+  open.push({ app, tmp });
+  return { app, driver, ctx };
+}
+
+function claim(
+  app: FastifyInstance,
+  payload: Record<string, unknown>,
+  ip = '203.0.113.1',
+  headers: Record<string, string> = {},
+) {
+  return app.inject({
+    method: 'POST',
+    url: '/v1/claim',
+    payload,
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip, ...headers },
+  });
+}
+
+async function login(app: FastifyInstance): Promise<{ session: string; csrf: string }> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: ADMIN_PASSWORD },
+    headers: { 'content-type': 'application/json' },
+  });
+  return {
+    session: parseCookie(res.headers['set-cookie'], 'faucet_session')!,
+    csrf: parseCookie(res.headers['set-cookie'], 'faucet_csrf')!,
+  };
+}
+
+function patchConfig(app: FastifyInstance, auth: { session: string; csrf: string }, body: Record<string, unknown>) {
+  return app.inject({
+    method: 'PATCH',
+    url: '/admin/config',
+    payload: body,
+    headers: { 'content-type': 'application/json', 'x-faucet-csrf': auth.csrf },
+    cookies: { faucet_session: auth.session, faucet_csrf: auth.csrf },
+  });
+}
+
+afterEach(async () => {
+  for (const { app, tmp } of open.splice(0)) {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+describe('first-time boost', () => {
+  it('boosts a fresh claimant and denies a repeat on the same address or IP', async () => {
+    const { app, driver } = await makeApp({ firstTimeBoostPercent: '50' });
+
+    // Fresh address + IP → boosted.
+    expect((await claim(app, { address: A1 }, '203.0.113.10')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_500_000n);
+
+    // Same address, different IP → not first-time (address match).
+    expect((await claim(app, { address: A1 }, '203.0.113.11')).statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(1_000_000n);
+
+    // Same IP as the first claim, brand-new address → not first-time (IP match).
+    expect((await claim(app, { address: A2 }, '203.0.113.10')).statusCode).toBe(200);
+    expect(driver.sends[2]?.amount).toBe(1_000_000n);
+  });
+
+  it('does not boost when the boost is unset (default)', async () => {
+    const { app, driver } = await makeApp();
+    expect((await claim(app, { address: A1 }, '203.0.113.20')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+  });
+
+  it('fingerprint dimension: shared visitorId denies the boost only when enabled', async () => {
+    // Enabled → a returning device (same visitorId) on a new address+IP is denied.
+    const on = await makeApp({ firstTimeBoostPercent: '50', firstTimeBoostUseFingerprint: 'true' });
+    await claim(on.app, { address: A1, fingerprint: { visitorId: 'VID-1' } }, '203.0.113.30');
+    expect(on.driver.sends[0]?.amount).toBe(1_500_000n);
+    await claim(on.app, { address: A2, fingerprint: { visitorId: 'VID-1' } }, '203.0.113.31');
+    expect(on.driver.sends[1]?.amount).toBe(1_000_000n); // denied via fingerprint
+
+    // Disabled → the same scenario still boosts (visitorId ignored).
+    const off = await makeApp({ firstTimeBoostPercent: '50' });
+    await claim(off.app, { address: A1, fingerprint: { visitorId: 'VID-9' } }, '203.0.113.32');
+    await claim(off.app, { address: A2, fingerprint: { visitorId: 'VID-9' } }, '203.0.113.33');
+    expect(off.driver.sends[1]?.amount).toBe(1_500_000n); // still boosted
+  });
+
+  it('security: an UNVERIFIED uid is ignored — it neither records nor denies the boost', async () => {
+    const { app, driver, ctx } = await makeApp({
+      firstTimeBoostPercent: '50',
+      firstTimeBoostUseUid: 'true',
+    });
+    // Two claims share an unverified hostContext.uid but differ on address+IP.
+    const r1 = await claim(app, { address: A1, hostContext: { uid: 'user-x' } }, '203.0.113.40');
+    expect(driver.sends[0]?.amount).toBe(1_500_000n);
+    const r2 = await claim(app, { address: A2, hostContext: { uid: 'user-x' } }, '203.0.113.41');
+    expect(driver.sends[1]?.amount).toBe(1_500_000n); // STILL boosted — unverified uid never matched
+
+    // And the unverified uid was never persisted into host_uid.
+    const id1 = r1.json().id as string;
+    const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id1)).limit(1);
+    expect(row?.hostUid).toBeNull();
+    expect(r2.statusCode).toBe(200);
+  });
+
+  it('records the device fingerprint visitorId on the paid claim row', async () => {
+    const { app, ctx } = await makeApp({ firstTimeBoostPercent: '50' });
+    const res = await claim(app, { address: A1, fingerprint: { visitorId: 'VID-rec' } }, '203.0.113.50');
+    const id = res.json().id as string;
+    const [row] = await ctx.db.select().from(claims).where(eq(claims.id, id)).limit(1);
+    expect(row?.fingerprintVisitorId).toBe('VID-rec');
+  });
+
+  it('applies a dashboard PATCH live and GET /admin/config reports the effective settings', async () => {
+    const { app, driver } = await makeApp(); // boost off at boot
+    expect((await claim(app, { address: A1 }, '203.0.113.60')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n); // no boost yet
+
+    const auth = await login(app);
+    expect(
+      (await patchConfig(app, auth, { firstTimeBoostPercent: 50, firstTimeBoostUseFingerprint: true })).statusCode,
+    ).toBe(200);
+
+    const after = await claim(app, { address: A3 }, '203.0.113.61');
+    expect(after.statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(1_500_000n); // boost applied live
+
+    const cfg = await app.inject({ method: 'GET', url: '/admin/config', cookies: { faucet_session: auth.session } });
+    expect(cfg.json().base.firstTimeBoostPercent).toBe(50);
+    expect(cfg.json().base.firstTimeBoostUseFingerprint).toBe(true);
+    expect(cfg.json().base.firstTimeBoostUseUid).toBe(false);
+  });
+
+  it('/v1/config still reports the unscaled baseline (no boost leak)', async () => {
+    const { app } = await makeApp({ firstTimeBoostPercent: '50' });
+    const res = await app.inject({ method: 'GET', url: '/v1/config' });
+    expect(res.json().claimAmountLuna).toBe('1000000');
+    expect(res.json().claimAmountNim).toBe('10');
+  });
+
+  it('historical-null safety: an old paid row (null new columns) still denies the boost via address', async () => {
+    const { app, driver, ctx } = await makeApp({ firstTimeBoostPercent: '50' });
+    // Simulate a pre-feature paid claim for A1 (new identity columns are null).
+    await ctx.db.insert(claims).values({
+      id: 'legacy-1',
+      address: A1,
+      amountLuna: '1000000',
+      status: 'broadcast',
+      txId: 'tx_legacy',
+      ip: '198.51.100.9',
+      decision: 'allow',
+    });
+    const res = await claim(app, { address: A1 }, '203.0.113.70');
+    expect(res.statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n); // address backstop works retroactively
+  });
+});

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -11,7 +11,7 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 - Runtime overrides via `PATCH /admin/config` (claim amount, rate limit, abuse thresholds, layer toggles) — see [`apps/server/src/routes/admin/config.ts`](../apps/server/src/routes/admin/config.ts) and the `AdminConfigPatch` schema in [`apps/server/src/openapi/schemas.ts`](../apps/server/src/openapi/schemas.ts).
 - The public derivation served at `GET /v1/config` — see [`apps/server/src/configView.ts`](../apps/server/src/configView.ts).
 
-## All variables (78)
+## All variables (81)
 
 | Env var | Type | Default | Constraints | Required | Description |
 |---|---|---|---|---|---|
@@ -34,6 +34,9 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 | `FAUCET_AUTOMATIC_REWARDS_BASELINE_NIM` | number | — | — |  | Baseline automatic-mode payout, in NIM (1 NIM = 100_000 luna). Used for every valid claim when `automaticRewardsEnabled` is true. Intentionally NOT constrained to > 0 here: an invalid value (missing/zero/negative) is handled at request time as an opaque rejection plus a non-fatal boot warning, never a fatal config-parse error — so a misconfigured faucet still boots and does not leak its state to clients. |
 | `FAUCET_LOW_BALANCE_THRESHOLD_NIM` | number | — | min: 0 |  | Low-balance reward scaling threshold, in NIM. When automatic mode is on and the wallet balance drops below this, each reward is reduced by `lowBalanceReductionPercent`. This is the env DEFAULT; an admin can override it live from the dashboard (persisted in `runtime_config`, read per payout). Unset (or ≤ 0) disables low-balance scaling. |
 | `FAUCET_LOW_BALANCE_REDUCTION_PERCENT` | number | — | min: 0, max: 100 |  | Flat percent (0–100) by which rewards are reduced while the wallet balance is below `lowBalanceThresholdNim`. 100 pauses payouts (a reward of zero is refused opaquely). Env DEFAULT; admin-overridable live from the dashboard. |
+| `FAUCET_FIRST_TIME_BOOST_PERCENT` | number | — | min: 0, max: 500 |  | First-time reward boost percent (0–500), automatic mode only. A claimant who has never been paid before gets `baseline × (1 + percent/100)`. Suppressed while the wallet is below `lowBalanceThresholdNim`. Env DEFAULT; an admin can override it live from the dashboard. Unset/0 disables the boost. |
+| `FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT` | boolean | `false` | — |  | Include the device fingerprint `visitorId` as a first-time identity signal (a returning device is denied the boost even from a new IP/address). Env DEFAULT; admin-overridable live. Default off. |
+| `FAUCET_FIRST_TIME_BOOST_USE_UID` | boolean | `false` | — |  | Include the integrator `uid` as a first-time identity signal. Only counts for HMAC-verified host contexts — browser-only claims never match. Env DEFAULT; admin-overridable live. Default off. |
 | `FAUCET_RATE_LIMIT_PER_MINUTE` | integer | `30` | min: 1 |  | — |
 | `FAUCET_RATE_LIMIT_PER_IP_PER_DAY` | integer | `5` | min: 1 |  | — |
 | `FAUCET_TURNSTILE_SITE_KEY` | string | — | — |  | — |


### PR DESCRIPTION
## Summary

The second `adjustments[]` rule (after low-balance scaling): a **first-time claimant** gets a configurable **extra percent**. "First-time" = no prior **paid** claim matches on any enabled identity signal. **IP + address are always used; the device fingerprint `visitorId` and the integrator `uid` are admin-opt-in extra dimensions** — more enabled = strictly harder to farm. The boost % and the two toggles are dashboard-editable and applied **live**.

## Changes

**Reward engine** [`rewards/automatic.ts`](apps/server/src/rewards/automatic.ts)
- Refactored `calculateAutomaticReward` to **accumulate** (`amount = baseline + Σ deltas`, floored at 0) — required now that two rules can contribute.
- First-time boost = positive delta, **suppressed while the wallet is low** (or its balance is unknown). The boost and the low-balance reduction are therefore **mutually exclusive by balance state**, so a 100% reduction still fully pauses payouts. Boost capped at **500%** (defensive) + Zod/admin cap.

**Detection** [`rewards/firstTime.ts`](apps/server/src/rewards/firstTime.ts) — one `OR`-across-enabled-dimensions query over paid rows (`decision='allow' AND tx_id IS NOT NULL`); first-time iff no match. Run only when boost > 0, before the reward calc (no self-match).

**DB** — two nullable `claims` columns `fingerprint_visitor_id` / `host_uid` (both dialect schemas + `migrations.ts` CREATE + partial indexes + `db/index.ts` ALTERs). **`host_uid` is recorded only when `hostContextVerified`** — a forgeable/unverified uid never enters the table and is never used for detection (no poisoning / griefing).

**Claim handler** [`routes/claim.ts`](apps/server/src/routes/claim.ts) — records the identity columns on the paid row, runs detection, threads the boosted `finalPayout`. Audit log + `faucet_reward_adjustments_total{kind="first-time-boost"}` flow for free.

**Config + admin + dashboard** — 3 env defaults (+ regenerated config reference); `AdminConfigPatch`/`AdminConfigResponse` + `deriveAdminConfigBase` + OpenAPI note; `ConfigView` boost % input + 2 signal checkboxes + a "uid needs a verified integrator" hint. `/v1/config` unchanged (no leak).

## Decisions (confirmed with reviewer)
- **Suppress the boost while the wallet is low** (preserve the low-balance pause). **Cap at 500%.** uid counts **only when HMAC-verified**; visitorId is a deny-only signal.

## Test plan
- [x] `pnpm build` / `pnpm typecheck` (incl. dashboard `vue-tsc`)
- [x] `pnpm test` — **247 server tests**: detection unit (all dimensions + paid-only filter), boost math + suppress-when-low + settings merge, e2e (boost/deny by ip/address/fingerprint, **unverified-uid-ignored** security, live PATCH, GET effective, recording columns, `/v1/config` unscaled, historical-null safety)
- [x] `pnpm pre-merge` green; `schema-parity` / `openapi-parity` / `sdk-contract` untouched
- [ ] `pnpm test:e2e` — n/a (no public route-shape change)

## Security checklist
- [x] No secrets in diff
- [x] Inputs validated at boundary (Zod: boost 0–500; defensive clamp in the pure fn)
- [x] No stack traces in user-facing errors (boost is success-path; reward refusals stay opaque)
- [x] Admin mutations via `/admin/*` (CSRF + session)
- [x] New env vars in `.env.example`
- [x] uid trust boundary enforced (verified-only recording + detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)