### PR TITLE
feat(server): repeat-user reward reduction (identity-gated, live config)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,28 @@ FAUCET_RATE_LIMIT_PER_IP_PER_DAY=5
 # FAUCET_FIRST_TIME_BOOST_PERCENT=50
 # FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT=false
 # FAUCET_FIRST_TIME_BOOST_USE_UID=false
+#
+# Repeat-user reduction (automatic mode only): reduce the reward for a claimant
+# who has already been paid many times in a rolling window. Three tiers — daily
+# (24h), weekly (7d), monthly (30d) — each a paid-claim count threshold + a
+# reduction percent (0–100). When several tiers trigger, the LARGEST percent wins.
+# Stacks additively with low-balance scaling and applies regardless of balance;
+# it suppresses the first-time boost. A threshold/percent of 0 disables a tier.
+# FAUCET_REPEAT_REDUCTION_DAILY_THRESHOLD=3
+# FAUCET_REPEAT_REDUCTION_DAILY_PERCENT=50
+# FAUCET_REPEAT_REDUCTION_WEEKLY_THRESHOLD=0
+# FAUCET_REPEAT_REDUCTION_WEEKLY_PERCENT=0
+# FAUCET_REPEAT_REDUCTION_MONTHLY_THRESHOLD=0
+# FAUCET_REPEAT_REDUCTION_MONTHLY_PERCENT=0
+# Identity multi-select: a prior paid claim counts toward the total if it matches
+# on ANY enabled dimension (OR/union). More dimensions = stricter; none = rule off.
+# Env defaults; admin-overridable live. Address on by default; IP + fingerprint off.
+# NOTE: these env booleans can only WIDEN to true (any non-empty value coerces to
+# true). To turn the default-on address dimension OFF, use the admin dashboard /
+# a JSON override — setting USE_ADDRESS=false here is a no-op.
+# FAUCET_REPEAT_REDUCTION_USE_ADDRESS=true
+# FAUCET_REPEAT_REDUCTION_USE_IP=false
+# FAUCET_REPEAT_REDUCTION_USE_FINGERPRINT=false
 
 # Minimum delay (ms) before any public claim-reject response is delivered.
 # Defends against pipeline-position timing attribution — without padding,

--- a/apps/dashboard/src/views/ConfigView.vue
+++ b/apps/dashboard/src/views/ConfigView.vue
@@ -24,6 +24,15 @@ interface ConfigResponse {
     firstTimeBoostPercent: number | null;
     firstTimeBoostUseFingerprint: boolean;
     firstTimeBoostUseUid: boolean;
+    repeatReductionDailyThreshold: number | null;
+    repeatReductionDailyPercent: number | null;
+    repeatReductionWeeklyThreshold: number | null;
+    repeatReductionWeeklyPercent: number | null;
+    repeatReductionMonthlyThreshold: number | null;
+    repeatReductionMonthlyPercent: number | null;
+    repeatReductionUseAddress: boolean;
+    repeatReductionUseIp: boolean;
+    repeatReductionUseFingerprint: boolean;
     layers: LayerFlags;
   };
   overrides: Record<string, unknown>;
@@ -39,6 +48,15 @@ type PatchBody = {
   firstTimeBoostPercent?: number;
   firstTimeBoostUseFingerprint?: boolean;
   firstTimeBoostUseUid?: boolean;
+  repeatReductionDailyThreshold?: number;
+  repeatReductionDailyPercent?: number;
+  repeatReductionWeeklyThreshold?: number;
+  repeatReductionWeeklyPercent?: number;
+  repeatReductionMonthlyThreshold?: number;
+  repeatReductionMonthlyPercent?: number;
+  repeatReductionUseAddress?: boolean;
+  repeatReductionUseIp?: boolean;
+  repeatReductionUseFingerprint?: boolean;
   layers?: Partial<LayerFlags>;
 };
 
@@ -58,6 +76,15 @@ const form = reactive({
   firstTimeBoostPercent: 0,
   firstTimeBoostUseFingerprint: false,
   firstTimeBoostUseUid: false,
+  repeatReductionDailyThreshold: 0,
+  repeatReductionDailyPercent: 0,
+  repeatReductionWeeklyThreshold: 0,
+  repeatReductionWeeklyPercent: 0,
+  repeatReductionMonthlyThreshold: 0,
+  repeatReductionMonthlyPercent: 0,
+  repeatReductionUseAddress: true,
+  repeatReductionUseIp: false,
+  repeatReductionUseFingerprint: false,
   layers: {
     turnstile: false,
     hcaptcha: false,
@@ -83,6 +110,15 @@ async function load(): Promise<void> {
     form.firstTimeBoostPercent = res.base.firstTimeBoostPercent ?? 0;
     form.firstTimeBoostUseFingerprint = res.base.firstTimeBoostUseFingerprint;
     form.firstTimeBoostUseUid = res.base.firstTimeBoostUseUid;
+    form.repeatReductionDailyThreshold = res.base.repeatReductionDailyThreshold ?? 0;
+    form.repeatReductionDailyPercent = res.base.repeatReductionDailyPercent ?? 0;
+    form.repeatReductionWeeklyThreshold = res.base.repeatReductionWeeklyThreshold ?? 0;
+    form.repeatReductionWeeklyPercent = res.base.repeatReductionWeeklyPercent ?? 0;
+    form.repeatReductionMonthlyThreshold = res.base.repeatReductionMonthlyThreshold ?? 0;
+    form.repeatReductionMonthlyPercent = res.base.repeatReductionMonthlyPercent ?? 0;
+    form.repeatReductionUseAddress = res.base.repeatReductionUseAddress;
+    form.repeatReductionUseIp = res.base.repeatReductionUseIp;
+    form.repeatReductionUseFingerprint = res.base.repeatReductionUseFingerprint;
     form.layers = { ...res.base.layers };
     overrides.value = res.overrides;
     error.value = null;
@@ -109,10 +145,19 @@ async function onSave(): Promise<void> {
       firstTimeBoostPercent: Number(form.firstTimeBoostPercent),
       firstTimeBoostUseFingerprint: form.firstTimeBoostUseFingerprint,
       firstTimeBoostUseUid: form.firstTimeBoostUseUid,
+      repeatReductionDailyThreshold: Number(form.repeatReductionDailyThreshold),
+      repeatReductionDailyPercent: Number(form.repeatReductionDailyPercent),
+      repeatReductionWeeklyThreshold: Number(form.repeatReductionWeeklyThreshold),
+      repeatReductionWeeklyPercent: Number(form.repeatReductionWeeklyPercent),
+      repeatReductionMonthlyThreshold: Number(form.repeatReductionMonthlyThreshold),
+      repeatReductionMonthlyPercent: Number(form.repeatReductionMonthlyPercent),
+      repeatReductionUseAddress: form.repeatReductionUseAddress,
+      repeatReductionUseIp: form.repeatReductionUseIp,
+      repeatReductionUseFingerprint: form.repeatReductionUseFingerprint,
       layers: { ...form.layers },
     };
     const res = await api.patch<{ ok: true; persistedKeys: string[] }>('/admin/config', body);
-    status.value = `Saved: ${res.persistedKeys.join(', ')}. Layer toggles and low-balance reward settings take effect immediately; other settings need a restart.`;
+    status.value = `Saved: ${res.persistedKeys.join(', ')}. Layer toggles and reward settings (low-balance, first-time boost, repeat-user reduction) take effect immediately; other settings need a restart.`;
     await load();
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'failed';
@@ -136,9 +181,9 @@ onMounted(load);
       role="note"
     >
       <strong>Abuse-layer toggles</strong> (fingerprint, on-chain, AI) and the
-      <strong>low-balance reward settings</strong> take effect immediately on Save. Other settings
-      (claim amount, rate limits, abuse thresholds) are persisted but require a container restart to
-      apply.
+      <strong>reward settings</strong> (low-balance scaling, first-time boost, repeat-user reduction)
+      take effect immediately on Save. Other settings (claim amount, rate limits, abuse thresholds)
+      are persisted but require a container restart to apply.
     </div>
 
     <p
@@ -254,6 +299,102 @@ onMounted(load);
           The user-id signal only counts for verified-integrator (HMAC-signed) claims; browser-only
           claims never match it.
         </span>
+      </fieldset>
+
+      <fieldset class="flex flex-col gap-2">
+        <legend class="text-xs font-semibold">Repeat-user reduction</legend>
+        <p class="muted text-xs">
+          Reduce the reward for claimants who have already been paid many times in a rolling window.
+          When several tiers trigger, the largest reduction wins. A threshold or percent of 0 disables
+          that tier. Applies immediately on Save.
+        </p>
+        <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Daily: paid claims in last 24h to trigger</span>
+            <input
+              v-model.number="form.repeatReductionDailyThreshold"
+              class="input font-mono"
+              type="number"
+              min="0"
+              step="1"
+              required
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Daily reduction (%)</span>
+            <input
+              v-model.number="form.repeatReductionDailyPercent"
+              class="input font-mono"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              required
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Weekly: paid claims in last 7d to trigger</span>
+            <input
+              v-model.number="form.repeatReductionWeeklyThreshold"
+              class="input font-mono"
+              type="number"
+              min="0"
+              step="1"
+              required
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Weekly reduction (%)</span>
+            <input
+              v-model.number="form.repeatReductionWeeklyPercent"
+              class="input font-mono"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              required
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Monthly: paid claims in last 30d to trigger</span>
+            <input
+              v-model.number="form.repeatReductionMonthlyThreshold"
+              class="input font-mono"
+              type="number"
+              min="0"
+              step="1"
+              required
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            <span>Monthly reduction (%)</span>
+            <input
+              v-model.number="form.repeatReductionMonthlyPercent"
+              class="input font-mono"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              required
+            />
+          </label>
+        </div>
+        <p class="muted text-xs">
+          Identity signals (multi-select): a prior paid claim counts toward the total if it matches on
+          any enabled signal. More signals = stricter. No signal selected disables the rule.
+        </p>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="form.repeatReductionUseAddress" type="checkbox" />
+          <span>Use NIM address</span>
+        </label>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="form.repeatReductionUseIp" type="checkbox" />
+          <span>Use IP</span>
+        </label>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="form.repeatReductionUseFingerprint" type="checkbox" />
+          <span>Use device fingerprint (visitorId)</span>
+        </label>
       </fieldset>
 
       <fieldset class="flex flex-wrap gap-3">

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -83,6 +83,35 @@ export const ServerConfigSchema = z.object({
    * admin-overridable live. Default off.
    */
   firstTimeBoostUseUid: z.coerce.boolean().default(false),
+
+  /**
+   * Repeat-user reduction (§ Phase 4), automatic mode only. A claimant whose
+   * recent **paid** claim count meets a tier's threshold has the reward reduced
+   * by that tier's percent; when several tiers trigger, the largest percent wins.
+   * Three rolling windows — daily (24h), weekly (7d), monthly (30d) — each a
+   * count threshold + a reduction percent. Stacks additively with low-balance
+   * scaling and applies regardless of balance state; suppresses the first-time
+   * boost. Env DEFAULTS; an admin can override every value live from the
+   * dashboard. A threshold of 0 (or percent of 0) disables that tier.
+   */
+  repeatReductionDailyThreshold: z.coerce.number().int().min(0).optional(),
+  repeatReductionDailyPercent: z.coerce.number().min(0).max(100).optional(),
+  repeatReductionWeeklyThreshold: z.coerce.number().int().min(0).optional(),
+  repeatReductionWeeklyPercent: z.coerce.number().min(0).max(100).optional(),
+  repeatReductionMonthlyThreshold: z.coerce.number().int().min(0).optional(),
+  repeatReductionMonthlyPercent: z.coerce.number().min(0).max(100).optional(),
+  /**
+   * Repeat-user identity dimensions (multi-select). A prior paid claim counts
+   * toward the total if it matches on ANY enabled dimension (OR/union). More
+   * dimensions = stricter. No dimension enabled disables the rule entirely.
+   * Env DEFAULTS; admin-overridable live. Address on by default; IP + fingerprint off.
+   * NOTE: like every `z.coerce.boolean()` env flag, any non-empty value coerces to
+   * true, so the env can only WIDEN the default-on address dimension to true —
+   * disabling it requires an admin override (dashboard / JSON), not `=false` here.
+   */
+  repeatReductionUseAddress: z.coerce.boolean().default(true),
+  repeatReductionUseIp: z.coerce.boolean().default(false),
+  repeatReductionUseFingerprint: z.coerce.boolean().default(false),
   rateLimitPerMinute: z.coerce.number().int().min(1).default(30),
   rateLimitPerIpPerDay: z.coerce.number().int().min(1).default(5),
 
@@ -318,6 +347,15 @@ export const ENV_KEYS: Record<string, string> = {
   firstTimeBoostPercent: 'FAUCET_FIRST_TIME_BOOST_PERCENT',
   firstTimeBoostUseFingerprint: 'FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT',
   firstTimeBoostUseUid: 'FAUCET_FIRST_TIME_BOOST_USE_UID',
+  repeatReductionDailyThreshold: 'FAUCET_REPEAT_REDUCTION_DAILY_THRESHOLD',
+  repeatReductionDailyPercent: 'FAUCET_REPEAT_REDUCTION_DAILY_PERCENT',
+  repeatReductionWeeklyThreshold: 'FAUCET_REPEAT_REDUCTION_WEEKLY_THRESHOLD',
+  repeatReductionWeeklyPercent: 'FAUCET_REPEAT_REDUCTION_WEEKLY_PERCENT',
+  repeatReductionMonthlyThreshold: 'FAUCET_REPEAT_REDUCTION_MONTHLY_THRESHOLD',
+  repeatReductionMonthlyPercent: 'FAUCET_REPEAT_REDUCTION_MONTHLY_PERCENT',
+  repeatReductionUseAddress: 'FAUCET_REPEAT_REDUCTION_USE_ADDRESS',
+  repeatReductionUseIp: 'FAUCET_REPEAT_REDUCTION_USE_IP',
+  repeatReductionUseFingerprint: 'FAUCET_REPEAT_REDUCTION_USE_FINGERPRINT',
   rateLimitPerMinute: 'FAUCET_RATE_LIMIT_PER_MINUTE',
   rateLimitPerIpPerDay: 'FAUCET_RATE_LIMIT_PER_IP_PER_DAY',
   turnstileSiteKey: 'FAUCET_TURNSTILE_SITE_KEY',

--- a/apps/server/src/configView.ts
+++ b/apps/server/src/configView.ts
@@ -121,6 +121,15 @@ export function deriveAdminConfigBase(
     firstTimeBoostPercent: reward.firstTimeBoostPercent ?? null,
     firstTimeBoostUseFingerprint: reward.firstTimeBoostUseFingerprint,
     firstTimeBoostUseUid: reward.firstTimeBoostUseUid,
+    repeatReductionDailyThreshold: reward.repeatReductionDailyThreshold ?? null,
+    repeatReductionDailyPercent: reward.repeatReductionDailyPercent ?? null,
+    repeatReductionWeeklyThreshold: reward.repeatReductionWeeklyThreshold ?? null,
+    repeatReductionWeeklyPercent: reward.repeatReductionWeeklyPercent ?? null,
+    repeatReductionMonthlyThreshold: reward.repeatReductionMonthlyThreshold ?? null,
+    repeatReductionMonthlyPercent: reward.repeatReductionMonthlyPercent ?? null,
+    repeatReductionUseAddress: reward.repeatReductionUseAddress,
+    repeatReductionUseIp: reward.repeatReductionUseIp,
+    repeatReductionUseFingerprint: reward.repeatReductionUseFingerprint,
     layers: deriveAbuseLayers(config),
   };
 }

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -39,6 +39,16 @@ export function migrationStatements(dialect: Dialect): string[] {
     'CREATE INDEX IF NOT EXISTS idx_claims_created_at ON claims(created_at DESC)',
     'CREATE INDEX IF NOT EXISTS idx_claims_address ON claims(address)',
     'CREATE INDEX IF NOT EXISTS idx_claims_ip ON claims(ip)',
+    // Repeat-user reduction: windowed count of paid claims by identity. In the
+    // single-dimension case (the default, address-only) the composite gives an
+    // O(log n + k) seek into `(identity, created_at >= since)` instead of a
+    // per-identity full scan. When two+ dimensions are OR-unioned, the planner
+    // does an OR-by-union — each branch uses its own composite. The fingerprint
+    // dimension (default-off) is intentionally backed only by the partial
+    // single-column idx_claims_fp_visitor (below), so its branch probes by
+    // visitorId then filters created_at per row — no created_at composite there.
+    'CREATE INDEX IF NOT EXISTS idx_claims_address_created_at ON claims(address, created_at)',
+    'CREATE INDEX IF NOT EXISTS idx_claims_ip_created_at ON claims(ip, created_at)',
     // First-time-boost detection dimensions (opt-in). Partial indexes keep them
     // tiny — only claims that actually carried the signal are indexed.
     `CREATE INDEX IF NOT EXISTS idx_claims_fp_visitor

--- a/apps/server/src/openapi/document.ts
+++ b/apps/server/src/openapi/document.ts
@@ -263,7 +263,8 @@ function registerRoutes(): void {
     description:
       'Persists runtime config overrides. Abuse-layer toggles and the reward keys ' +
       '(lowBalanceThresholdNim, lowBalanceReductionPercent, firstTimeBoostPercent, ' +
-      'firstTimeBoostUseFingerprint, firstTimeBoostUseUid) apply live; other keys require a restart.',
+      'firstTimeBoostUseFingerprint, firstTimeBoostUseUid, and the repeatReduction* ' +
+      'tier/identity keys) apply live; other keys require a restart.',
     security: [{ adminSession: [] }],
     request: { body: { content: jsonContent(AdminConfigPatch) } },
     responses: { 200: { description: 'Persisted', content: jsonContent(OkResponse) } },

--- a/apps/server/src/openapi/schemas.ts
+++ b/apps/server/src/openapi/schemas.ts
@@ -299,6 +299,17 @@ export const AdminConfigPatch = registry.register(
       firstTimeBoostPercent: z.number().min(0).max(500).optional(),
       firstTimeBoostUseFingerprint: z.boolean().optional(),
       firstTimeBoostUseUid: z.boolean().optional(),
+      // Repeat-user reduction — applied live. Three tiers (count threshold +
+      // reduction percent); identity is a multi-select over address/IP/fingerprint.
+      repeatReductionDailyThreshold: z.number().int().min(0).optional(),
+      repeatReductionDailyPercent: z.number().min(0).max(100).optional(),
+      repeatReductionWeeklyThreshold: z.number().int().min(0).optional(),
+      repeatReductionWeeklyPercent: z.number().min(0).max(100).optional(),
+      repeatReductionMonthlyThreshold: z.number().int().min(0).optional(),
+      repeatReductionMonthlyPercent: z.number().min(0).max(100).optional(),
+      repeatReductionUseAddress: z.boolean().optional(),
+      repeatReductionUseIp: z.boolean().optional(),
+      repeatReductionUseFingerprint: z.boolean().optional(),
       layers: z
         .object({
           turnstile: z.boolean().optional(),
@@ -331,6 +342,16 @@ export const AdminConfigResponse = registry.register(
       firstTimeBoostPercent: z.number().nullable(),
       firstTimeBoostUseFingerprint: z.boolean(),
       firstTimeBoostUseUid: z.boolean(),
+      // Effective repeat-user reduction settings. Tier numbers null when unset.
+      repeatReductionDailyThreshold: z.number().nullable(),
+      repeatReductionDailyPercent: z.number().nullable(),
+      repeatReductionWeeklyThreshold: z.number().nullable(),
+      repeatReductionWeeklyPercent: z.number().nullable(),
+      repeatReductionMonthlyThreshold: z.number().nullable(),
+      repeatReductionMonthlyPercent: z.number().nullable(),
+      repeatReductionUseAddress: z.boolean(),
+      repeatReductionUseIp: z.boolean(),
+      repeatReductionUseFingerprint: z.boolean(),
       layers: z.record(z.string(), z.boolean()),
     }),
     overrides: z.record(z.string(), z.unknown()),

--- a/apps/server/src/rewards/automatic.test.ts
+++ b/apps/server/src/rewards/automatic.test.ts
@@ -251,6 +251,71 @@ describe('calculateAutomaticReward — first-time boost', () => {
   });
 });
 
+describe('calculateAutomaticReward — repeat-user reduction', () => {
+  // baseline 10 NIM = 1_000_000 luna.
+  it('reduces by the flat percent independent of balance state', () => {
+    const r = calculateAutomaticReward({ baselineNim: 10, repeatReductionPercent: 40 });
+    expect(r.amount).toBe(600_000n);
+    expect(r.adjustments).toEqual([
+      {
+        kind: 'repeat-user-reduction',
+        deltaLuna: -400_000n,
+        reason: 'repeat claimant; reward reduced 40%',
+      },
+    ]);
+  });
+
+  it('applies even when the balance is unknown (unlike low-balance scaling)', () => {
+    expect(
+      calculateAutomaticReward({ baselineNim: 10, repeatReductionPercent: 40, balanceLuna: null }).amount,
+    ).toBe(600_000n);
+  });
+
+  it('stacks additively with low-balance scaling (baseline − low% − repeat%)', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 20,
+      lowBalanceReductionPercent: 25,
+      repeatReductionPercent: 40,
+      balanceLuna: 1_000_000n, // < 20 NIM threshold → low-balance active
+    });
+    // 1_000_000 − 250_000 (low) − 400_000 (repeat) = 350_000
+    expect(r.amount).toBe(350_000n);
+    expect(r.adjustments.map((a) => a.kind)).toEqual([
+      'low-balance-scaling',
+      'repeat-user-reduction',
+    ]);
+  });
+
+  it('a combined reduction ≥ 100% floors to 0n (caller refuses)', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      lowBalanceThresholdNim: 20,
+      lowBalanceReductionPercent: 60,
+      repeatReductionPercent: 60,
+      balanceLuna: 1_000_000n,
+    });
+    expect(r.amount).toBe(0n);
+  });
+
+  it('ignores an out-of-range or zero repeat percent (defensive)', () => {
+    expect(calculateAutomaticReward({ baselineNim: 10, repeatReductionPercent: 0 }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ baselineNim: 10, repeatReductionPercent: 150 }).amount).toBe(1_000_000n);
+    expect(calculateAutomaticReward({ baselineNim: 10, repeatReductionPercent: -5 }).adjustments).toEqual([]);
+  });
+
+  it('suppresses the first-time boost whenever a repeat reduction fires (boost ⊥ repeat)', () => {
+    const r = calculateAutomaticReward({
+      baselineNim: 10,
+      firstTimeBoostPercent: 50,
+      isFirstTime: true,
+      repeatReductionPercent: 40,
+    });
+    expect(r.amount).toBe(600_000n); // reduction only, no boost
+    expect(r.adjustments.map((a) => a.kind)).toEqual(['repeat-user-reduction']);
+  });
+});
+
 describe('resolveRewardSettings', () => {
   const cfg = {
     automaticRewardsEnabled: true,
@@ -302,5 +367,45 @@ describe('resolveRewardSettings', () => {
     expect(s.firstTimeBoostPercent).toBeUndefined();
     expect(s.firstTimeBoostUseFingerprint).toBe(false);
     expect(s.firstTimeBoostUseUid).toBe(false);
+    // Repeat-reduction tiers default undefined; address defaults on, others off.
+    expect(s.repeatReductionDailyThreshold).toBeUndefined();
+    expect(s.repeatReductionDailyPercent).toBeUndefined();
+    expect(s.repeatReductionWeeklyThreshold).toBeUndefined();
+    expect(s.repeatReductionWeeklyPercent).toBeUndefined();
+    expect(s.repeatReductionMonthlyThreshold).toBeUndefined();
+    expect(s.repeatReductionMonthlyPercent).toBeUndefined();
+    expect(s.repeatReductionUseAddress).toBe(true);
+    expect(s.repeatReductionUseIp).toBe(false);
+    expect(s.repeatReductionUseFingerprint).toBe(false);
+  });
+
+  it('resolves the repeat-reduction tiers + toggles (override wins; out-of-range falls back)', () => {
+    const s = resolveRewardSettings(
+      {
+        ...cfg,
+        repeatReductionDailyThreshold: 3,
+        repeatReductionDailyPercent: 30,
+        repeatReductionMonthlyThreshold: 20,
+        repeatReductionMonthlyPercent: 70,
+      },
+      {
+        repeatReductionDailyPercent: 55, // valid override wins
+        repeatReductionWeeklyThreshold: 10, // override (no env default)
+        repeatReductionWeeklyPercent: 200, // out of range → env default (undefined)
+        repeatReductionMonthlyThreshold: 25, // override wins
+        repeatReductionMonthlyPercent: 150, // out of range → env default (70)
+        repeatReductionUseIp: true,
+        repeatReductionUseFingerprint: true,
+      },
+    );
+    expect(s.repeatReductionDailyThreshold).toBe(3); // env default kept (no override)
+    expect(s.repeatReductionDailyPercent).toBe(55); // override wins
+    expect(s.repeatReductionWeeklyThreshold).toBe(10);
+    expect(s.repeatReductionWeeklyPercent).toBeUndefined(); // out of range → fallback
+    expect(s.repeatReductionMonthlyThreshold).toBe(25); // override wins
+    expect(s.repeatReductionMonthlyPercent).toBe(70); // out of range → env default
+    expect(s.repeatReductionUseAddress).toBe(true); // default on
+    expect(s.repeatReductionUseIp).toBe(true); // override
+    expect(s.repeatReductionUseFingerprint).toBe(true); // override
   });
 });

--- a/apps/server/src/rewards/automatic.ts
+++ b/apps/server/src/rewards/automatic.ts
@@ -71,6 +71,13 @@ export interface RewardInput {
   /** First-time boost percent (0–500); applies only when not in a low-balance state. */
   firstTimeBoostPercent?: number | undefined;
   /**
+   * Effective repeat-user reduction percent (0–100), already resolved by the
+   * handler from claim counts + tiers (largest triggered tier wins). A negative
+   * adjustment applied **regardless of balance state**; mutually exclusive with
+   * the first-time boost (a repeat reduction suppresses the boost).
+   */
+  repeatReductionPercent?: number | undefined;
+  /**
    * Current wallet balance in Luna, or `null`/`undefined` when unknown. When
    * unknown, low-balance scaling is skipped (never reduce on a stale/failed
    * balance read — that would silently halve every payout during an RPC blip),
@@ -83,15 +90,21 @@ export interface RewardInput {
  * Compute the automatic reward. Pure and total — never throws. The final amount
  * is the baseline plus the sum of every applied adjustment delta, floored at 0.
  *
- * Two rules, mutually exclusive by balance state:
+ * Three rules:
  *  - **Low-balance scaling** (negative) fires when a positive threshold is set,
  *    the balance is known, and `balance < threshold`. Basis-point bigint math
  *    truncates *down* (never over-pays); a reduction outside `(0, 100]` is
  *    ignored. A 100% reduction yields `amount: 0n` (caller refuses → pause).
+ *  - **Repeat-user reduction** (negative) fires when a valid
+ *    `repeatReductionPercent` in `(0, 100]` is supplied. It is **independent of
+ *    balance state** and **stacks additively** with low-balance scaling — both
+ *    deltas are measured against the baseline and summed (so a combined ≥ 100%
+ *    floors to `0n` → caller refuses).
  *  - **First-time boost** (positive) fires when `isFirstTime`, a boost in
  *    `(0, 500]` is set, and the wallet is known to be at/above the threshold
  *    (or no threshold is configured). It is **suppressed while the wallet is low
- *    or its balance is unknown** — a low faucet must not hand out extra.
+ *    or its balance is unknown** — a low faucet must not hand out extra — and
+ *    **suppressed whenever a repeat reduction fires** (boost ⊥ repeat).
  */
 export function calculateAutomaticReward(input: RewardInput): RewardResult {
   const baseline = nimToLuna(input.baselineNim);
@@ -105,6 +118,15 @@ export function calculateAutomaticReward(input: RewardInput): RewardResult {
   const lowBalanceConfigured = thresholdLuna > 0n;
   const walletIsLow = lowBalanceConfigured && balanceKnown && (input.balanceLuna as bigint) < thresholdLuna;
   const lowBalanceUncertain = lowBalanceConfigured && !balanceKnown;
+
+  // Repeat-user reduction is active when a valid percent is supplied. Computed
+  // up front so it can both push its adjustment and suppress the first-time boost.
+  const repeatReduction = input.repeatReductionPercent;
+  const repeatReductionActive =
+    repeatReduction !== undefined &&
+    Number.isFinite(repeatReduction) &&
+    repeatReduction > 0 &&
+    repeatReduction <= 100;
 
   // Low-balance reduction (negative delta) — only while the wallet is low.
   if (baseline > 0n && walletIsLow) {
@@ -124,9 +146,32 @@ export function calculateAutomaticReward(input: RewardInput): RewardResult {
     }
   }
 
+  // Repeat-user reduction (negative delta) — independent of balance state.
+  // Measured against the baseline (like low-balance scaling), so the two
+  // reductions stack additively in the accumulator below.
+  if (baseline > 0n && repeatReductionActive) {
+    // repeatReductionActive aliases `repeatReduction !== undefined && …`, so TS
+    // narrows repeatReduction to number here — no cast needed.
+    const reductionBp = BigInt(Math.round(repeatReduction * 100));
+    const reduced = (baseline * (BASIS_POINTS - reductionBp)) / BASIS_POINTS;
+    if (reduced !== baseline) {
+      adjustments.push({
+        kind: 'repeat-user-reduction',
+        deltaLuna: reduced - baseline,
+        reason: `repeat claimant; reward reduced ${repeatReduction}%`,
+      });
+    }
+  }
+
   // First-time boost (positive delta) — only when the wallet is confidently NOT
-  // low (mutually exclusive with the reduction above).
-  if (baseline > 0n && input.isFirstTime && !walletIsLow && !lowBalanceUncertain) {
+  // low and no repeat reduction is in effect (boost ⊥ repeat).
+  if (
+    baseline > 0n &&
+    input.isFirstTime &&
+    !walletIsLow &&
+    !lowBalanceUncertain &&
+    !repeatReductionActive
+  ) {
     const boost = input.firstTimeBoostPercent;
     const boostValid =
       boost !== undefined && Number.isFinite(boost) && boost > 0 && boost <= MAX_FIRST_TIME_BOOST_PERCENT;
@@ -159,6 +204,15 @@ export interface PayoutConfig {
   firstTimeBoostPercent?: number | undefined;
   firstTimeBoostUseFingerprint?: boolean | undefined;
   firstTimeBoostUseUid?: boolean | undefined;
+  repeatReductionDailyThreshold?: number | undefined;
+  repeatReductionDailyPercent?: number | undefined;
+  repeatReductionWeeklyThreshold?: number | undefined;
+  repeatReductionWeeklyPercent?: number | undefined;
+  repeatReductionMonthlyThreshold?: number | undefined;
+  repeatReductionMonthlyPercent?: number | undefined;
+  repeatReductionUseAddress?: boolean | undefined;
+  repeatReductionUseIp?: boolean | undefined;
+  repeatReductionUseFingerprint?: boolean | undefined;
   claimAmountLuna: bigint;
 }
 
@@ -192,6 +246,15 @@ export interface EffectiveRewardSettings {
   firstTimeBoostPercent?: number | undefined;
   firstTimeBoostUseFingerprint: boolean;
   firstTimeBoostUseUid: boolean;
+  repeatReductionDailyThreshold?: number | undefined;
+  repeatReductionDailyPercent?: number | undefined;
+  repeatReductionWeeklyThreshold?: number | undefined;
+  repeatReductionWeeklyPercent?: number | undefined;
+  repeatReductionMonthlyThreshold?: number | undefined;
+  repeatReductionMonthlyPercent?: number | undefined;
+  repeatReductionUseAddress: boolean;
+  repeatReductionUseIp: boolean;
+  repeatReductionUseFingerprint: boolean;
 }
 
 function pickInRange(
@@ -213,10 +276,10 @@ function pickBool(override: unknown, envDefault: boolean): boolean {
 
 /**
  * Merge persisted runtime overrides over env-derived config to produce the
- * effective reward settings used at claim time. The low-balance + first-time
- * keys are read live (override-wins); a malformed/out-of-range `runtime_config`
- * row falls back to the env default so it can never widen behaviour unexpectedly.
- * `enabled` and `baselineNim` stay env-only.
+ * effective reward settings used at claim time. The low-balance, first-time, and
+ * repeat-user-reduction keys are read live (override-wins); a malformed/out-of-range
+ * `runtime_config` row falls back to the env default so it can never widen
+ * behaviour unexpectedly. `enabled` and `baselineNim` stay env-only.
  */
 export function resolveRewardSettings(
   config: PayoutConfig,
@@ -250,6 +313,54 @@ export function resolveRewardSettings(
     firstTimeBoostUseUid: pickBool(
       overrides.firstTimeBoostUseUid,
       config.firstTimeBoostUseUid ?? false,
+    ),
+    repeatReductionDailyThreshold: pickInRange(
+      overrides.repeatReductionDailyThreshold,
+      config.repeatReductionDailyThreshold,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    repeatReductionDailyPercent: pickInRange(
+      overrides.repeatReductionDailyPercent,
+      config.repeatReductionDailyPercent,
+      0,
+      100,
+    ),
+    repeatReductionWeeklyThreshold: pickInRange(
+      overrides.repeatReductionWeeklyThreshold,
+      config.repeatReductionWeeklyThreshold,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    repeatReductionWeeklyPercent: pickInRange(
+      overrides.repeatReductionWeeklyPercent,
+      config.repeatReductionWeeklyPercent,
+      0,
+      100,
+    ),
+    repeatReductionMonthlyThreshold: pickInRange(
+      overrides.repeatReductionMonthlyThreshold,
+      config.repeatReductionMonthlyThreshold,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    repeatReductionMonthlyPercent: pickInRange(
+      overrides.repeatReductionMonthlyPercent,
+      config.repeatReductionMonthlyPercent,
+      0,
+      100,
+    ),
+    repeatReductionUseAddress: pickBool(
+      overrides.repeatReductionUseAddress,
+      config.repeatReductionUseAddress ?? true,
+    ),
+    repeatReductionUseIp: pickBool(
+      overrides.repeatReductionUseIp,
+      config.repeatReductionUseIp ?? false,
+    ),
+    repeatReductionUseFingerprint: pickBool(
+      overrides.repeatReductionUseFingerprint,
+      config.repeatReductionUseFingerprint ?? false,
     ),
   };
 }

--- a/apps/server/src/rewards/repeatUser.test.ts
+++ b/apps/server/src/rewards/repeatUser.test.ts
@@ -1,0 +1,221 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { openDb, type Db } from '../db/index.js';
+import { claims } from '../db/schema.js';
+import {
+  countRepeatClaims,
+  effectiveRepeatReductionPercent,
+  isRepeatTierConfigured,
+} from './repeatUser.js';
+
+const NOW = 1_800_000_000_000; // fixed reference time (ms) so windows are deterministic
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+let tmp: string;
+let db: Db;
+let seq = 0;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'faucet-repeat-'));
+  db = openDb({ dataDir: tmp });
+  seq = 0;
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function insertClaim(row: {
+  ip: string;
+  address: string;
+  ageMs: number; // created this long before NOW
+  decision?: string;
+  txId?: string | null;
+  fingerprintVisitorId?: string | null;
+}) {
+  seq += 1;
+  await db.insert(claims).values({
+    id: `c${seq}`,
+    address: row.address,
+    amountLuna: '1000000',
+    status: row.txId === null ? 'rejected' : 'broadcast',
+    // txId defaults to a real id (paid); pass `null` explicitly for unpaid rows.
+    txId: row.txId === undefined ? `tx${seq}` : row.txId,
+    ip: row.ip,
+    decision: row.decision ?? 'allow',
+    createdAt: new Date(NOW - row.ageMs),
+    fingerprintVisitorId: row.fingerprintVisitorId ?? null,
+  });
+}
+
+const allDims = { useAddress: true, useIp: true, useFingerprint: true } as const;
+const allWindows = { needDay: true, needWeek: true, needMonth: true } as const;
+
+describe('countRepeatClaims', () => {
+  it('counts only paid rows (decision=allow AND txId not null)', async () => {
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: HOUR }); // paid
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: HOUR, decision: 'deny', txId: null }); // denied
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: HOUR, decision: 'allow', txId: null }); // no tx
+    const counts = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      ...allDims,
+      ...allWindows,
+    });
+    expect(counts).toEqual({ day: 1, week: 1, month: 1 });
+  });
+
+  it('counts within each rolling window (day/week/month) independently', async () => {
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: 2 * HOUR }); // day + week + month
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: 3 * DAY }); // week + month
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: 10 * DAY }); // month only
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: 40 * DAY }); // outside all windows
+    const counts = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      ...allDims,
+      ...allWindows,
+    });
+    expect(counts).toEqual({ day: 1, week: 2, month: 3 });
+  });
+
+  it('unions the enabled identity dimensions (OR), so a different dimension can match', async () => {
+    // A paid claim sharing only the IP (different address) than the query.
+    await insertClaim({ ip: 'IP1', address: 'A-other', ageMs: HOUR });
+    const ipOnly = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      useAddress: false,
+      useIp: true,
+      useFingerprint: false,
+      ...allWindows,
+    });
+    expect(ipOnly.day).toBe(1);
+    const addrOnly = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      useAddress: true,
+      useIp: false,
+      useFingerprint: false,
+      ...allWindows,
+    });
+    expect(addrOnly.day).toBe(0);
+  });
+
+  it('uses the fingerprint dimension only when enabled and a visitorId is present', async () => {
+    await insertClaim({ ip: 'IP-x', address: 'A-x', ageMs: HOUR, fingerprintVisitorId: 'V1' });
+    const base = { address: 'A1', ip: 'IP1', now: NOW, ...allWindows } as const;
+    expect(
+      (
+        await countRepeatClaims(db, {
+          ...base,
+          fingerprintVisitorId: 'V1',
+          useAddress: false,
+          useIp: false,
+          useFingerprint: true,
+        })
+      ).day,
+    ).toBe(1);
+    // disabled
+    expect(
+      (
+        await countRepeatClaims(db, {
+          ...base,
+          fingerprintVisitorId: 'V1',
+          useAddress: false,
+          useIp: false,
+          useFingerprint: false,
+        })
+      ).day,
+    ).toBe(0);
+    // enabled but no visitorId on this claim → contributes nothing
+    expect(
+      (
+        await countRepeatClaims(db, {
+          ...base,
+          useAddress: false,
+          useIp: false,
+          useFingerprint: true,
+        })
+      ).day,
+    ).toBe(0);
+  });
+
+  it('returns all-zero when no dimension is enabled', async () => {
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: HOUR });
+    const counts = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      useAddress: false,
+      useIp: false,
+      useFingerprint: false,
+      ...allWindows,
+    });
+    expect(counts).toEqual({ day: 0, week: 0, month: 0 });
+  });
+
+  it('queries only the requested windows (others return 0 without a query)', async () => {
+    await insertClaim({ ip: 'IP1', address: 'A1', ageMs: HOUR });
+    const counts = await countRepeatClaims(db, {
+      address: 'A1',
+      ip: 'IP1',
+      now: NOW,
+      ...allDims,
+      needDay: true,
+      needWeek: false,
+      needMonth: false,
+    });
+    expect(counts).toEqual({ day: 1, week: 0, month: 0 });
+  });
+});
+
+describe('effectiveRepeatReductionPercent', () => {
+  const tiers = {
+    repeatReductionDailyThreshold: 3,
+    repeatReductionDailyPercent: 30,
+    repeatReductionWeeklyThreshold: 10,
+    repeatReductionWeeklyPercent: 50,
+    repeatReductionMonthlyThreshold: 20,
+    repeatReductionMonthlyPercent: 70,
+  };
+
+  it('returns 0 when no tier is triggered (sub-threshold)', () => {
+    expect(effectiveRepeatReductionPercent({ day: 2, week: 5, month: 10 }, tiers)).toBe(0);
+  });
+
+  it('returns the triggered tier percent when one triggers', () => {
+    expect(effectiveRepeatReductionPercent({ day: 3, week: 5, month: 10 }, tiers)).toBe(30);
+  });
+
+  it('largest tier wins when several trigger', () => {
+    expect(effectiveRepeatReductionPercent({ day: 5, week: 12, month: 25 }, tiers)).toBe(70);
+    expect(effectiveRepeatReductionPercent({ day: 5, week: 12, month: 10 }, tiers)).toBe(50);
+  });
+
+  it('a disabled tier (threshold 0 or percent 0) never triggers', () => {
+    const disabled = {
+      repeatReductionDailyThreshold: 0,
+      repeatReductionDailyPercent: 90,
+      repeatReductionWeeklyThreshold: 5,
+      repeatReductionWeeklyPercent: 0,
+    };
+    expect(effectiveRepeatReductionPercent({ day: 100, week: 100, month: 0 }, disabled)).toBe(0);
+  });
+});
+
+describe('isRepeatTierConfigured', () => {
+  it('requires a threshold ≥ 1 and a percent > 0', () => {
+    expect(isRepeatTierConfigured(3, 30)).toBe(true);
+    expect(isRepeatTierConfigured(0, 30)).toBe(false);
+    expect(isRepeatTierConfigured(3, 0)).toBe(false);
+    expect(isRepeatTierConfigured(undefined, 30)).toBe(false);
+    expect(isRepeatTierConfigured(3, undefined)).toBe(false);
+  });
+});

--- a/apps/server/src/rewards/repeatUser.ts
+++ b/apps/server/src/rewards/repeatUser.ts
@@ -1,0 +1,131 @@
+/**
+ * Repeat-user reduction: count a claimant's recent **paid** claims and derive a
+ * graduated reward reduction from the configured tiers.
+ *
+ * Three rolling windows — day (24h), week (7d), month (30d) — each with a
+ * claim-count threshold and a reduction percent. A prior **paid** claim
+ * (`decision='allow' AND tx_id IS NOT NULL`) counts toward the total if it
+ * matches on ANY enabled identity dimension (address / IP / device fingerprint
+ * visitorId), OR-ed/unioned exactly like {@link ../rewards/firstTime}. Enabling
+ * more dimensions only makes the counts larger (stricter), never smaller.
+ *
+ * Largest tier wins: when several tiers trigger, the effective reduction is the
+ * single biggest triggered tier's percent — bounded and predictable.
+ *
+ * The window math mirrors the proven, dialect-safe count in
+ * {@link ../abuse/recentClaimsQuery} (`COUNT(*)` + `created_at >= since`). `now`
+ * is supplied by the caller so the function is deterministic and unit-testable.
+ */
+import { and, eq, gte, isNotNull, or, sql, type SQL } from 'drizzle-orm';
+import type { Db } from '../db/index.js';
+import { claims } from '../db/schema.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30 * DAY_MS;
+
+export interface RepeatClaimQuery {
+  address: string;
+  ip: string;
+  /** Device fingerprint visitorId for this claim, if any. */
+  fingerprintVisitorId?: string | null | undefined;
+  useAddress: boolean;
+  useIp: boolean;
+  useFingerprint: boolean;
+  /** Reference time (ms since epoch) the rolling windows are measured back from. */
+  now: number;
+  needDay: boolean;
+  needWeek: boolean;
+  needMonth: boolean;
+}
+
+export interface RepeatClaimCounts {
+  day: number;
+  week: number;
+  month: number;
+}
+
+/** The six tier numbers (a structural subset of `EffectiveRewardSettings`). */
+export interface RepeatReductionTiers {
+  repeatReductionDailyThreshold?: number | undefined;
+  repeatReductionDailyPercent?: number | undefined;
+  repeatReductionWeeklyThreshold?: number | undefined;
+  repeatReductionWeeklyPercent?: number | undefined;
+  repeatReductionMonthlyThreshold?: number | undefined;
+  repeatReductionMonthlyPercent?: number | undefined;
+}
+
+/** A tier is configured (can ever trigger) when it has an integer threshold ≥ 1 and a percent > 0. */
+export function isRepeatTierConfigured(
+  threshold: number | undefined,
+  percent: number | undefined,
+): boolean {
+  return (
+    threshold !== undefined &&
+    Number.isFinite(threshold) &&
+    threshold >= 1 &&
+    percent !== undefined &&
+    Number.isFinite(percent) &&
+    percent > 0
+  );
+}
+
+/**
+ * Count paid claims attributable to this identity within each requested window.
+ * Returns 0 for every window when no dimension is enabled (or a fingerprint-only
+ * setup has no visitorId for this claim) and 0 for any window not requested.
+ */
+export async function countRepeatClaims(db: Db, q: RepeatClaimQuery): Promise<RepeatClaimCounts> {
+  const dims: SQL[] = [];
+  if (q.useAddress) dims.push(eq(claims.address, q.address));
+  if (q.useIp) dims.push(eq(claims.ip, q.ip));
+  if (q.useFingerprint && q.fingerprintVisitorId) {
+    dims.push(eq(claims.fingerprintVisitorId, q.fingerprintVisitorId));
+  }
+
+  if (dims.length === 0) return { day: 0, week: 0, month: 0 };
+
+  const paidOnIdentity = and(eq(claims.decision, 'allow'), isNotNull(claims.txId), or(...dims));
+
+  const countSince = async (windowMs: number): Promise<number> => {
+    const since = new Date(q.now - windowMs);
+    const [row] = await db
+      .select({ n: sql<number>`COUNT(*)` })
+      .from(claims)
+      .where(and(paidOnIdentity, gte(claims.createdAt, since)));
+    return row?.n ?? 0;
+  };
+
+  return {
+    day: q.needDay ? await countSince(DAY_MS) : 0,
+    week: q.needWeek ? await countSince(WEEK_MS) : 0,
+    month: q.needMonth ? await countSince(MONTH_MS) : 0,
+  };
+}
+
+/**
+ * Effective repeat reduction percent: the MAX percent across all *triggered*
+ * tiers (largest tier wins). A tier triggers when it is configured
+ * ({@link isRepeatTierConfigured}) and the matching window count meets its
+ * threshold. Returns 0 when nothing triggers. Pure — unit-testable in isolation.
+ */
+export function effectiveRepeatReductionPercent(
+  counts: RepeatClaimCounts,
+  tiers: RepeatReductionTiers,
+): number {
+  let percent = 0;
+  const consider = (
+    threshold: number | undefined,
+    pct: number | undefined,
+    count: number,
+  ): void => {
+    // Early-return on undefined so both narrow to `number` below (no casts).
+    if (threshold === undefined || pct === undefined) return;
+    if (!isRepeatTierConfigured(threshold, pct) || count < threshold) return;
+    if (pct > percent) percent = pct;
+  };
+  consider(tiers.repeatReductionDailyThreshold, tiers.repeatReductionDailyPercent, counts.day);
+  consider(tiers.repeatReductionWeeklyThreshold, tiers.repeatReductionWeeklyPercent, counts.week);
+  consider(tiers.repeatReductionMonthlyThreshold, tiers.repeatReductionMonthlyPercent, counts.month);
+  return percent;
+}

--- a/apps/server/src/routes/admin/config.ts
+++ b/apps/server/src/routes/admin/config.ts
@@ -2,9 +2,9 @@
  * Admin config GET/PATCH.
  *
  * Layer toggles (fingerprint, onchain, AI) take effect immediately on PATCH —
- * the abuse pipeline is rebuilt in memory. The low-balance reward keys
- * (lowBalanceThresholdNim, lowBalanceReductionPercent) also apply live: the
- * claim handler reads them from `runtime_config` per payout. Other overrides
+ * the abuse pipeline is rebuilt in memory. The reward keys (low-balance scaling,
+ * first-time boost, and repeat-user reduction tiers/identity) also apply live:
+ * the claim handler reads them from `runtime_config` per payout. Other overrides
  * (claim amount, rate-limit thresholds) are persisted but require a restart.
  */
 import type { FastifyInstance } from 'fastify';

--- a/apps/server/src/routes/claim.ts
+++ b/apps/server/src/routes/claim.ts
@@ -22,6 +22,11 @@ import {
   resolveRewardSettings,
 } from '../rewards/automatic.js';
 import { isFirstTimeClaimant } from '../rewards/firstTime.js';
+import {
+  countRepeatClaims,
+  effectiveRepeatReductionPercent,
+  isRepeatTierConfigured,
+} from '../rewards/repeatUser.js';
 import { readRuntimeOverrides } from '../runtimeConfig.js';
 
 // Extend the shared OpenAPI schema with the backwards-compat transform.
@@ -403,12 +408,61 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         });
       }
 
+      // Repeat-user reduction. Only run the windowed count when at least one
+      // tier is configured AND at least one identity dimension is enabled
+      // (zero-cost path otherwise — no DB hit). Only the windows whose tier is
+      // configured are queried.
+      //
+      // Best-effort, not a hard limit: the count is read here but the row that
+      // raises it isn't inserted until after the send below, and `inflightClaims`
+      // serializes only on `address`. So concurrent same-IP / same-fingerprint
+      // claims to *different* addresses can each read a stale (pre-burst) count
+      // and pay full, momentarily defeating the IP/fingerprint tiers under a
+      // burst. That's acceptable for a soft anti-farming measure: the atomic
+      // per-IP daily cap (incrementIpCounter, before the pipeline) and the
+      // per-minute rate limit bound the overpayment per IP per window. (The
+      // address dimension is unaffected — same-address bursts lose the
+      // inflight race and 429.)
+      let repeatReductionPercent = 0;
+      const repeatDimEnabled =
+        settings.repeatReductionUseAddress ||
+        settings.repeatReductionUseIp ||
+        settings.repeatReductionUseFingerprint;
+      const needDay = isRepeatTierConfigured(
+        settings.repeatReductionDailyThreshold,
+        settings.repeatReductionDailyPercent,
+      );
+      const needWeek = isRepeatTierConfigured(
+        settings.repeatReductionWeeklyThreshold,
+        settings.repeatReductionWeeklyPercent,
+      );
+      const needMonth = isRepeatTierConfigured(
+        settings.repeatReductionMonthlyThreshold,
+        settings.repeatReductionMonthlyPercent,
+      );
+      if (repeatDimEnabled && (needDay || needWeek || needMonth)) {
+        const counts = await countRepeatClaims(ctx.db, {
+          address,
+          ip: req.ip,
+          fingerprintVisitorId,
+          useAddress: settings.repeatReductionUseAddress,
+          useIp: settings.repeatReductionUseIp,
+          useFingerprint: settings.repeatReductionUseFingerprint,
+          now,
+          needDay,
+          needWeek,
+          needMonth,
+        });
+        repeatReductionPercent = effectiveRepeatReductionPercent(counts, settings);
+      }
+
       const reward = calculateAutomaticReward({
         baselineNim: settings.baselineNim,
         lowBalanceThresholdNim: settings.lowBalanceThresholdNim,
         lowBalanceReductionPercent: settings.lowBalanceReductionPercent,
         firstTimeBoostPercent: settings.firstTimeBoostPercent,
         isFirstTime,
+        repeatReductionPercent,
         balanceLuna: balance,
       });
       finalPayout = { amountLuna: reward.amount, reward };
@@ -425,9 +479,10 @@ export async function claimRoutes(app: FastifyInstance, ctx: AppContext): Promis
         req.log.error(
           {
             baselineAmountLuna: reward.baselineAmount.toString(),
-            reductionPercent: settings.lowBalanceReductionPercent,
+            lowBalanceReductionPercent: settings.lowBalanceReductionPercent,
+            repeatReductionPercent,
           },
-          'automatic reward scaled to zero by low-balance reduction; refusing payout',
+          'automatic reward scaled to zero by reductions; refusing payout',
         );
       } else if (balance !== null && reward.amount > balance) {
         refusal = 'automatic_reward_exceeds_balance';

--- a/apps/server/test/repeat-user-reduction.e2e.test.ts
+++ b/apps/server/test/repeat-user-reduction.e2e.test.ts
@@ -1,0 +1,302 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+import { ServerConfigSchema } from '../src/config.js';
+import { BaseTestDriver, TEST_FAUCET_ADDRESS, parseCookie } from './helpers/testDriver.js';
+
+const FAUCET_ADDR = TEST_FAUCET_ADDRESS;
+const ADMIN_PASSWORD = 'test-password-123';
+const A1 = 'NQ00 1111 1111 1111 1111 1111 1111 1111 1111';
+const A2 = 'NQ00 2222 2222 2222 2222 2222 2222 2222 2222';
+const A3 = 'NQ00 3333 3333 3333 3333 3333 3333 3333 3333';
+
+class FakeNimiqDriver extends BaseTestDriver {
+  public sends: Array<{ to: string; amount: bigint }> = [];
+  public balance = 100_000_000n;
+  public failBalance = false;
+  override async getBalance() {
+    if (this.failBalance) throw new Error('rpc down');
+    return this.balance;
+  }
+  override async send(to: string, amount: bigint): Promise<string> {
+    this.sends.push({ to, amount });
+    this.balance -= amount;
+    return `tx_${this.sends.length}`;
+  }
+  override async waitForConfirmation(): Promise<void> {}
+}
+
+const open: Array<{ app: FastifyInstance; tmp: string }> = [];
+
+async function makeApp(
+  overrides: Record<string, unknown> = {},
+  driver: FakeNimiqDriver = new FakeNimiqDriver(),
+): Promise<{ app: FastifyInstance; driver: FakeNimiqDriver }> {
+  const tmp = mkdtempSync(join(tmpdir(), 'faucet-repeat-e2e-'));
+  const config = ServerConfigSchema.parse({
+    geoipBackend: 'none',
+    network: 'test',
+    dataDir: tmp,
+    signerDriver: 'rpc',
+    rpcUrl: 'http://unused',
+    walletAddress: FAUCET_ADDR,
+    claimAmountLuna: '100000',
+    rateLimitPerIpPerDay: '100',
+    adminPassword: ADMIN_PASSWORD,
+    automaticRewardsEnabled: 'true',
+    automaticRewardsBaselineNim: '10', // 1_000_000 luna baseline
+    dev: 'true',
+    rejectDelayMsMin: '0',
+    // dev mode trusts loopback XFF, so tests can vary the client IP.
+    ...overrides,
+  });
+  const { app } = await buildApp(config, { driverOverride: driver, quietLogs: true });
+  await app.ready();
+  open.push({ app, tmp });
+  return { app, driver };
+}
+
+function claim(app: FastifyInstance, address: string, ip: string, visitorId?: string) {
+  const payload: Record<string, unknown> = { address };
+  if (visitorId) payload.fingerprint = { visitorId };
+  return app.inject({
+    method: 'POST',
+    url: '/v1/claim',
+    payload,
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+  });
+}
+
+async function login(app: FastifyInstance): Promise<{ session: string; csrf: string }> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/admin/auth/login',
+    payload: { password: ADMIN_PASSWORD },
+    headers: { 'content-type': 'application/json' },
+  });
+  return {
+    session: parseCookie(res.headers['set-cookie'], 'faucet_session')!,
+    csrf: parseCookie(res.headers['set-cookie'], 'faucet_csrf')!,
+  };
+}
+
+function patchConfig(
+  app: FastifyInstance,
+  auth: { session: string; csrf: string },
+  body: Record<string, unknown>,
+) {
+  return app.inject({
+    method: 'PATCH',
+    url: '/admin/config',
+    payload: body,
+    headers: { 'content-type': 'application/json', 'x-faucet-csrf': auth.csrf },
+    cookies: { faucet_session: auth.session, faucet_csrf: auth.csrf },
+  });
+}
+
+afterEach(async () => {
+  for (const { app, tmp } of open.splice(0)) {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+describe('repeat-user reduction', () => {
+  it('reduces once the address claim-count meets the daily tier; other identities unaffected', async () => {
+    // Daily tier: ≥ 2 paid claims in 24h → reduce 30%. Address signal on by default.
+    const { app, driver } = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+    });
+
+    // Same address, varying IP → the address dimension accumulates the count.
+    expect((await claim(app, A1, '198.51.100.1')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n); // 0 prior → full
+    expect((await claim(app, A1, '198.51.100.2')).statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(1_000_000n); // 1 prior (< 2) → full
+    expect((await claim(app, A1, '198.51.100.3')).statusCode).toBe(200);
+    expect(driver.sends[2]?.amount).toBe(700_000n); // 2 prior (≥ 2) → −30%
+
+    // A different address is unaffected (its own count is 0).
+    expect((await claim(app, A2, '198.51.100.9')).statusCode).toBe(200);
+    expect(driver.sends[3]?.amount).toBe(1_000_000n);
+  });
+
+  it('identity multi-select: IP-only counts across addresses; address-only does not', async () => {
+    // IP-only: same IP, different addresses accumulate.
+    const ipOnly = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+      repeatReductionUseAddress: false,
+      repeatReductionUseIp: true,
+    });
+    expect((await claim(ipOnly.app, A1, '198.51.100.20')).statusCode).toBe(200);
+    expect(ipOnly.driver.sends[0]?.amount).toBe(1_000_000n);
+    await claim(ipOnly.app, A2, '198.51.100.20');
+    expect(ipOnly.driver.sends[1]?.amount).toBe(1_000_000n); // 1 prior (< 2)
+    await claim(ipOnly.app, A3, '198.51.100.20');
+    expect(ipOnly.driver.sends[2]?.amount).toBe(700_000n); // 2 prior on the IP → −30%
+
+    // Address-only: same IP, different addresses do NOT accumulate.
+    const addrOnly = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+      repeatReductionUseAddress: true,
+      repeatReductionUseIp: false,
+    });
+    await claim(addrOnly.app, A1, '198.51.100.30');
+    await claim(addrOnly.app, A2, '198.51.100.30');
+    await claim(addrOnly.app, A3, '198.51.100.30');
+    expect(addrOnly.driver.sends.map((s) => s.amount)).toEqual([
+      1_000_000n,
+      1_000_000n,
+      1_000_000n,
+    ]);
+  });
+
+  it('largest tier wins when several tiers trigger', async () => {
+    // Daily 2 → 30%, Weekly 2 → 50%. On the 3rd claim both windows hold 2 → max = 50%.
+    const { app, driver } = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+      repeatReductionWeeklyThreshold: '2',
+      repeatReductionWeeklyPercent: '50',
+    });
+    await claim(app, A1, '198.51.100.40');
+    await claim(app, A1, '198.51.100.41');
+    await claim(app, A1, '198.51.100.42');
+    expect(driver.sends[2]?.amount).toBe(500_000n); // −50%, not −30%
+  });
+
+  it('applies a dashboard PATCH live; GET reports effective values; /v1/config stays unscaled', async () => {
+    const { app, driver } = await makeApp(); // no repeat config at boot
+    await claim(app, A1, '198.51.100.50');
+    await claim(app, A1, '198.51.100.51');
+    expect(driver.sends.map((s) => s.amount)).toEqual([1_000_000n, 1_000_000n]); // no reduction yet
+
+    const auth = await login(app);
+    expect(
+      (
+        await patchConfig(app, auth, {
+          repeatReductionDailyThreshold: 1,
+          repeatReductionDailyPercent: 40,
+          repeatReductionUseIp: true,
+        })
+      ).statusCode,
+    ).toBe(200);
+
+    // 2 prior paid claims on A1 ≥ threshold 1 → reduced 40% live.
+    expect((await claim(app, A1, '198.51.100.52')).statusCode).toBe(200);
+    expect(driver.sends[2]?.amount).toBe(600_000n);
+
+    const cfg = await app.inject({
+      method: 'GET',
+      url: '/admin/config',
+      cookies: { faucet_session: auth.session },
+    });
+    expect(cfg.json().base.repeatReductionDailyThreshold).toBe(1);
+    expect(cfg.json().base.repeatReductionDailyPercent).toBe(40);
+    expect(cfg.json().base.repeatReductionUseAddress).toBe(true); // env default
+    expect(cfg.json().base.repeatReductionUseIp).toBe(true); // override
+
+    // Public config never leaks a per-identity scaled amount.
+    const pub = await app.inject({ method: 'GET', url: '/v1/config' });
+    expect(pub.json().claimAmountLuna).toBe('1000000');
+  });
+
+  it('boost ⊥ repeat: a returning claimant gets the reduction, not the first-time boost', async () => {
+    const { app, driver } = await makeApp({
+      firstTimeBoostPercent: '50',
+      repeatReductionDailyThreshold: '1',
+      repeatReductionDailyPercent: '30',
+    });
+    // First claim: first-time (no prior paid) and repeat count 0 (< 1) → boosted.
+    expect((await claim(app, A1, '198.51.100.60')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_500_000n);
+    // Second claim on the same address: 1 prior paid ≥ 1 → reduction fires, boost suppressed.
+    expect((await claim(app, A1, '198.51.100.61')).statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(700_000n);
+  });
+
+  it('fingerprint dimension: same visitorId across distinct address+IP accumulates only when enabled', async () => {
+    // Fingerprint-only: same visitorId, distinct address+IP → the visitorId accumulates.
+    const on = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+      repeatReductionUseAddress: false,
+      repeatReductionUseFingerprint: true,
+    });
+    await claim(on.app, A1, '198.51.100.90', 'VFP-1');
+    expect(on.driver.sends[0]?.amount).toBe(1_000_000n); // 0 prior on the visitorId
+    await claim(on.app, A2, '198.51.100.91', 'VFP-1');
+    expect(on.driver.sends[1]?.amount).toBe(1_000_000n); // 1 prior (< 2)
+    await claim(on.app, A3, '198.51.100.92', 'VFP-1');
+    expect(on.driver.sends[2]?.amount).toBe(700_000n); // 2 prior on the visitorId → −30%
+
+    // Fingerprint OFF (default): the same visitorId across distinct address+IP does NOT accumulate.
+    const off = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+    });
+    await claim(off.app, A1, '198.51.100.93', 'VFP-2');
+    await claim(off.app, A2, '198.51.100.94', 'VFP-2');
+    await claim(off.app, A3, '198.51.100.95', 'VFP-2');
+    expect(off.driver.sends.map((s) => s.amount)).toEqual([1_000_000n, 1_000_000n, 1_000_000n]);
+  });
+
+  it('a combined ≥100% reduction scales to zero and returns the uniform opaque 403', async () => {
+    const { app, driver } = await makeApp({
+      repeatReductionDailyThreshold: '1',
+      repeatReductionDailyPercent: '100',
+    });
+    // First claim pays full (count 0 < 1).
+    expect((await claim(app, A1, '198.51.100.100')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+    // Second claim: 1 prior ≥ 1 → 100% reduction → amount 0n → opaque refusal, no send.
+    const res = await claim(app, A1, '198.51.100.101');
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ id: expect.any(String), status: 'rejected' });
+    // Exactly two keys — guards against a future tier/percent/reason leak in the body.
+    expect(Object.keys(res.json()).sort()).toEqual(['id', 'status']);
+    expect(driver.sends).toHaveLength(1); // nothing sent on the refusal
+  });
+
+  it('over-balance guard compares the post-reduction amount, not the baseline', async () => {
+    const { app, driver } = await makeApp({
+      repeatReductionDailyThreshold: '1',
+      repeatReductionDailyPercent: '30',
+    });
+    // Build one paid claim on A1 while the wallet is flush.
+    expect((await claim(app, A1, '198.51.100.110')).statusCode).toBe(200);
+    expect(driver.sends[0]?.amount).toBe(1_000_000n);
+    // Wallet now sits between the reduced amount (700k) and the baseline (1M).
+    driver.balance = 800_000n;
+    // Returning claimant: the reduction pulls the payout under balance → PAID 700k.
+    expect((await claim(app, A1, '198.51.100.111')).statusCode).toBe(200);
+    expect(driver.sends[1]?.amount).toBe(700_000n);
+    // A fresh (non-reduced) claimant at the same balance: baseline 1M > 800k → uniform 403.
+    driver.balance = 800_000n;
+    const res = await claim(app, A2, '198.51.100.112');
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ id: expect.any(String), status: 'rejected' });
+    expect(driver.sends).toHaveLength(2); // no new send
+  });
+
+  it('applies the repeat reduction even when the balance read fails (over-balance guard skipped)', async () => {
+    const { app, driver } = await makeApp({
+      repeatReductionDailyThreshold: '2',
+      repeatReductionDailyPercent: '30',
+    });
+    expect((await claim(app, A1, '198.51.100.120')).statusCode).toBe(200);
+    expect((await claim(app, A1, '198.51.100.121')).statusCode).toBe(200);
+    expect(driver.sends.map((s) => s.amount)).toEqual([1_000_000n, 1_000_000n]);
+    // getBalance() now throws → balance unknown. Low-balance scaling would skip and the
+    // first-time boost would suppress, but the repeat reduction must still apply.
+    driver.failBalance = true;
+    expect((await claim(app, A1, '198.51.100.122')).statusCode).toBe(200);
+    expect(driver.sends[2]?.amount).toBe(700_000n);
+  });
+});

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -11,7 +11,7 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 - Runtime overrides via `PATCH /admin/config` (claim amount, rate limit, abuse thresholds, layer toggles) — see [`apps/server/src/routes/admin/config.ts`](../apps/server/src/routes/admin/config.ts) and the `AdminConfigPatch` schema in [`apps/server/src/openapi/schemas.ts`](../apps/server/src/openapi/schemas.ts).
 - The public derivation served at `GET /v1/config` — see [`apps/server/src/configView.ts`](../apps/server/src/configView.ts).
 
-## All variables (81)
+## All variables (90)
 
 | Env var | Type | Default | Constraints | Required | Description |
 |---|---|---|---|---|---|
@@ -37,6 +37,15 @@ Every `FAUCET_*` environment variable accepted by the server, with type, default
 | `FAUCET_FIRST_TIME_BOOST_PERCENT` | number | — | min: 0, max: 500 |  | First-time reward boost percent (0–500), automatic mode only. A claimant who has never been paid before gets `baseline × (1 + percent/100)`. Suppressed while the wallet is below `lowBalanceThresholdNim`. Env DEFAULT; an admin can override it live from the dashboard. Unset/0 disables the boost. |
 | `FAUCET_FIRST_TIME_BOOST_USE_FINGERPRINT` | boolean | `false` | — |  | Include the device fingerprint `visitorId` as a first-time identity signal (a returning device is denied the boost even from a new IP/address). Env DEFAULT; admin-overridable live. Default off. |
 | `FAUCET_FIRST_TIME_BOOST_USE_UID` | boolean | `false` | — |  | Include the integrator `uid` as a first-time identity signal. Only counts for HMAC-verified host contexts — browser-only claims never match. Env DEFAULT; admin-overridable live. Default off. |
+| `FAUCET_REPEAT_REDUCTION_DAILY_THRESHOLD` | integer | — | min: 0 |  | Repeat-user reduction (§ Phase 4), automatic mode only. A claimant whose recent **paid** claim count meets a tier's threshold has the reward reduced by that tier's percent; when several tiers trigger, the largest percent wins. Three rolling windows — daily (24h), weekly (7d), monthly (30d) — each a count threshold + a reduction percent. Stacks additively with low-balance scaling and applies regardless of balance state; suppresses the first-time boost. Env DEFAULTS; an admin can override every value live from the dashboard. A threshold of 0 (or percent of 0) disables that tier. |
+| `FAUCET_REPEAT_REDUCTION_DAILY_PERCENT` | number | — | min: 0, max: 100 |  | — |
+| `FAUCET_REPEAT_REDUCTION_WEEKLY_THRESHOLD` | integer | — | min: 0 |  | — |
+| `FAUCET_REPEAT_REDUCTION_WEEKLY_PERCENT` | number | — | min: 0, max: 100 |  | — |
+| `FAUCET_REPEAT_REDUCTION_MONTHLY_THRESHOLD` | integer | — | min: 0 |  | — |
+| `FAUCET_REPEAT_REDUCTION_MONTHLY_PERCENT` | number | — | min: 0, max: 100 |  | — |
+| `FAUCET_REPEAT_REDUCTION_USE_ADDRESS` | boolean | `true` | — |  | Repeat-user identity dimensions (multi-select). A prior paid claim counts toward the total if it matches on ANY enabled dimension (OR/union). More dimensions = stricter. No dimension enabled disables the rule entirely. Env DEFAULTS; admin-overridable live. Address on by default; IP + fingerprint off. NOTE: like every `z.coerce.boolean()` env flag, any non-empty value coerces to true, so the env can only WIDEN the default-on address dimension to true — disabling it requires an admin override (dashboard / JSON), not `=false` here. |
+| `FAUCET_REPEAT_REDUCTION_USE_IP` | boolean | `false` | — |  | — |
+| `FAUCET_REPEAT_REDUCTION_USE_FINGERPRINT` | boolean | `false` | — |  | — |
 | `FAUCET_RATE_LIMIT_PER_MINUTE` | integer | `30` | min: 1 |  | — |
 | `FAUCET_RATE_LIMIT_PER_IP_PER_DAY` | integer | `5` | min: 1 |  | — |
 | `FAUCET_TURNSTILE_SITE_KEY` | string | — | — |  | — |


### PR DESCRIPTION
## Summary

Phase 4 of automatic rewards (follows #249 baseline → #252 low-balance → #253 first-time boost). A claimant whose recent **paid** claim count meets a configured tier's threshold has the reward reduced by that tier's percent; when several tiers trigger, the **largest percent wins**.

- **Three rolling windows** — daily (24h) / weekly (7d) / monthly (30d) — each a paid-claim count threshold + reduction percent (0–100).
- **Identity multi-select** over address / IP / device fingerprint `visitorId` (OR-union, like first-time detection). More dimensions enabled = stricter; none = rule off. Default: address on, IP + fingerprint off.
- **Interaction with the other reward rules:** stacks *additively* with low-balance scaling, applies *regardless* of balance state, and *suppresses* the first-time boost (boost ⊥ repeat).
- A combined ≥100% reduction floors the payout to `0n` → **uniform opaque 403** (`{id, status:'rejected'}` only — no abuse attribution leaked to the client).
- All tier/identity keys are read **live from `runtime_config`** (admin-overridable from the dashboard); env values are defaults only.
- **Zero-cost claim path** when no tier is configured (no DB hit). New composite `(address,created_at)` / `(ip,created_at)` indexes back the windowed counts; the default-off fingerprint dimension reuses the existing partial visitorId index.

## Surface wired through

config + `.env.example`, OpenAPI schemas + PATCH doc, admin GET/PATCH allowlist, the dashboard `ConfigView`, and the generated config reference (81 → 90 entries).

## Tests

- **Unit** ([repeatUser.test.ts](apps/server/src/rewards/repeatUser.test.ts)): paid-only counting, per-window math, identity OR-union, fingerprint gating, largest-tier-wins, disabled tiers.
- **Integration** ([repeat-user-reduction.e2e.test.ts](apps/server/test/repeat-user-reduction.e2e.test.ts)): daily-tier reduction, IP-only vs address-only accumulation, largest-tier-wins, live dashboard PATCH (with `/v1/config` staying unscaled), boost suppression, the ≥100% opaque refusal, the over-balance guard comparing the *post-reduction* amount, and applying the reduction even when the balance read fails.
- `pnpm pre-merge` green across all 61 tasks (typecheck + build + test for server, dashboard, SDK, and every example app) + config-reference check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)